### PR TITLE
Adding option to disable Tika

### DIFF
--- a/external_roles/fits/defaults/main.yml
+++ b/external_roles/fits/defaults/main.yml
@@ -3,3 +3,4 @@
 
 fits_version: 1.0.2
 fits_install: /opt
+disable_tika: true

--- a/external_roles/fits/tasks/main.yml
+++ b/external_roles/fits/tasks/main.yml
@@ -24,3 +24,12 @@
     state: link
   become: true
   ignore_errors: '{{ ansible_check_mode }}'
+
+- name: Disable Tika
+  lineinfile:
+    dest='{{ fits_install }}/fits-{{ fits_version }}/xml/fits.xml'
+    regexp='.*(<.*edu.harvard.hul.ois.fits.tools.tika.TikaTool.*>).*'
+    backrefs=yes
+    line='<!-- \1 -->'
+    state=present
+  when: disable_tika == true


### PR DESCRIPTION
Disable Tika to dramatically reduce the FITS execution time (from 90+ seconds to 20 seconds).
