### PR TITLE
allow passing of a generic variable user name

### DIFF
--- a/roles/pulibrary.deploy-user/defaults/main.yml
+++ b/roles/pulibrary.deploy-user/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
-# defaults file for pulibrary.deploy-user
-deploy_user: "deploy"
+deploy_user: '{{ generic_app_user | default("deploy") }}'
 deploy_ssh_users: []
 deploy_user_uid: 1001
 deploy_user_shell: /bin/bash


### PR DESCRIPTION
This allows us in non-vagrant settings to pass the -e flag with `generic_app_user` variable to create a user not named deploy but we otherwise use deploy user as the default