### PR TITLE
get rid of the deprecation annoying warning

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,7 +7,7 @@ host_key_checking = False
 # vendorize external roles
 roles_path = external_roles
 inventory = hosts
-ask_sudo_pass = true
+ask_become_pass = true
 ask_vault_pass = true
 ask_pass = true
 pipelining = true


### PR DESCRIPTION
ansible has deprecated sudo for become. 