### PR TITLE
Schedules cron jobs for maintaining Blacklight Apps

### DIFF
--- a/Vagrant/laeVagrantfile
+++ b/Vagrant/laeVagrantfile
@@ -13,6 +13,10 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 8182, host: 8182 # Cantaloupe
   config.vm.network "forwarded_port", guest: 15672, host: 15672 # Cantaloupe
 
+  # By default, the directory from which you launch vagrant will be shared inside your VM as /vagrant
+  # To share an additional folder to the guest VM, state the path on the host
+  # to the actual folder, then the path on the guest to mount the folder.
+  # config.vm.synced_folder "../data", "/vagrant_data"
 
   # Provider-specific configuration for VirtualBox:
   config.vm.provider "virtualbox" do |vb|
@@ -28,8 +32,6 @@ Vagrant.configure(2) do |config|
 
   # Enable provisioning ansible project
   config.vm.provision "ansible" do |ansible|
-    # ansible.verbose = 'vvv'
-
     ansible.groups = {
       "lae_production" => ["default"]
     }
@@ -51,6 +53,7 @@ Vagrant.configure(2) do |config|
     }
 
     ansible.playbook = "lae.yml"
+    ansible.ask_vault_pass = true
 
     # update start_at_task and re-run `vagrant provison` if your configuration scripts fail on a particular task
     # and you want to restart the provisioning at the step where the failure occurred

--- a/group_vars/lae_production.yml
+++ b/group_vars/lae_production.yml
@@ -1,5 +1,5 @@
 passenger_server_name: "lae1.princeton.edu"
-passenger_app_root: "/opt/lae-blacklight/current/public" 
+passenger_app_root: "/opt/lae-blacklight/current/public"
 passenger_app_env: "production"
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"

--- a/install_external_roles.yml
+++ b/install_external_roles.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: all
-  tasks: 
+  tasks:
   - name: Install external roles
-    local_action: command ansible-galaxy install -r external_roles.yml 
-
+  - local_action: command ansible-galaxy install -r external_roles.yml

--- a/lae.yml
+++ b/lae.yml
@@ -12,5 +12,5 @@
     - role: pulibrary.postgresql
     - role: pulibrary.nodejs
     - role: pulibrary.extra_path
-    - role: pulibrary.rails-app
+    - role: pulibrary.blacklight-app
     - role: pulibrary.sneakers_worker

--- a/roles/pulibrary.blacklight-app/defaults/main.yml
+++ b/roles/pulibrary.blacklight-app/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for pulibrary.blacklight-app

--- a/roles/pulibrary.blacklight-app/meta/main.yml
+++ b/roles/pulibrary.blacklight-app/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: 'pulibrary.rails-app' }

--- a/roles/pulibrary.blacklight-app/tasks/main.yml
+++ b/roles/pulibrary.blacklight-app/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Create the cron job
+  cron:
+    name: Clean old Blacklight searches and Devise guest user accounts nightly
+    hour: 22
+    job: "/bin/bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && cd /opt/{{rails_app_directory}}/current && bundle exec rake blacklight:delete_old_searches >> /tmp/guests_searches.log 2>&1 && bundle exec rake devise_guests:delete_old_guest_users >> /tmp/guests_searches.log 2>&1'"
+    minute: 0
+    user: '{{deploy_user}}'

--- a/roles/pulibrary.figgy/tasks/main.yml
+++ b/roles/pulibrary.figgy/tasks/main.yml
@@ -4,7 +4,7 @@
     path: '{{solr_home}}/data'
   register: solr_installed
 - name: Configure Solr Core
-  template: 
+  template:
     src: '{{item.src}}'
     dest: '{{item.dest}}'
   with_items:


### PR DESCRIPTION
Advances #92 by addressing the following:
- Generalizing a new Role for Blacklight Apps
- Introducing a cron job for clearing old Blacklight searches and Devise guest accounts