### PR TITLE
install mariadb repositories

### DIFF
--- a/roles/pulibrary.dss/tasks/main.yml
+++ b/roles/pulibrary.dss/tasks/main.yml
@@ -1,9 +1,18 @@
 ---
+- name: add mariadb repo keys
+  apt_key:
+    keyserver: 'keyserver.ubuntu.com'
+    id: '0xF1656F24C74CD1D8'
+
+- name: add maria db repository
+  apt_repository:
+    repo: 'deb [arch=amd64,i386,ppc64el] https://mirrors.evowise.com/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main'
+
 - name: install maridb client dev headers
   apt:
     name: '{{ item }}'
     state: present
-    update_cache: yes
+    update_cache: 'yes'
   with_items:
     - libmariadbclient-dev
 


### PR DESCRIPTION
in the event where mariadb is remote the repository addition is skipped
by the playbook. this add the repo to install the client dev headers