### PR TITLE
Adds the Orangelight cron task for Sitemap generation and sets both APPLICATION_HOST and APPLICATION_HOST_PROTOCOL

### DIFF
--- a/group_vars/orangelight.yml
+++ b/group_vars/orangelight.yml
@@ -1,8 +1,8 @@
 passenger_server_name: "puls.* pulsearch.* catalog.*"
-passenger_app_root: "/opt/rails_app/current/public"
+passenger_app_root: "/opt/orangelight/current/public"
 passenger_app_env: "production"
 rails_app_name: "orangelight"
-rails_app_directory: "rails_app"
+rails_app_directory: "orangelight"
 rails_app_symlinks: []
 rails_app_dependencies:
   - libpq-dev
@@ -29,6 +29,8 @@ application_db_name: '{{ol_db_name}}'
 application_dbuser_name: '{{ol_db_user}}'
 application_dbuser_password: '{{ol_db_password}}'
 application_dbuser_role_attr_flags: 'SUPERUSER'
+ol_host_name: 'pulsearch.princeton.edu'
+application_host_protocol: 'https'
 rails_app_vars:
   - name: OL_SECRET_KEY_BASE
     value: '{{ol_secret_key}}'
@@ -64,3 +66,7 @@ rails_app_vars:
     value: '{{scsb_auth_key}}'
   - name: HONEYBADGER_API_KEY
     value: '{{ol_honeybadger_key}}'
+  - name: APPLICATION_HOST
+    value: '{{ol_host_name}}'
+  - name: APPLICATION_HOST_PROTOCOL
+    value: '{{application_host_protocol}}'

--- a/group_vars/orangelight.yml
+++ b/group_vars/orangelight.yml
@@ -1,8 +1,8 @@
 passenger_server_name: "puls.* pulsearch.* catalog.*"
-passenger_app_root: "/opt/orangelight/current/public"
+passenger_app_root: "/opt/rails_app/current/public"
 passenger_app_env: "production"
 rails_app_name: "orangelight"
-rails_app_directory: "orangelight"
+rails_app_directory: "rails_app"
 rails_app_symlinks: []
 rails_app_dependencies:
   - libpq-dev

--- a/orangelight.yml
+++ b/orangelight.yml
@@ -11,4 +11,4 @@
     - role: pulibrary.redis
     - role: pulibrary.nodejs
     - role: pulibrary.extra_path
-    - role: pulibrary.rails-app
+    - role: pulibrary.orangelight

--- a/roles/pulibrary.orangelight/meta/main.yml
+++ b/roles/pulibrary.orangelight/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
-  - { role: pulibrary.passenger }
-
+  - { role: 'pulibrary.blacklight-app' }

--- a/roles/pulibrary.orangelight/tasks/main.yml
+++ b/roles/pulibrary.orangelight/tasks/main.yml
@@ -1,18 +1,8 @@
 ---
-- name: remove default nginx
-  file:
-    path: /etc/nginx/sites-enabled/default
-    state: absent
-
-- name: copy template file
-  template:
-    src: default.j2
-    dest: /etc/nginx/sites-available/{{ ansible_hostname }}
-
-- name: symlink to enable
-  file:
-    src: /etc/nginx/sites-available/{{ ansible_hostname }}
-    dest: /etc/nginx/sites-enabled/{{ ansible_hostname }}
-    state: link
-
-  notify: restart nginx
+- name: Create the cron job
+  cron:
+    name: Regenerate the Sitemap nightly
+    hour: 2
+    job: "/bin/bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && cd /opt/{{rails_app_directory}}/current && bundle exec rake sitemap:refresh >> /tmp/ol_sitemap.log 2>&1'"
+    minute: 0
+    user: '{{deploy_user}}'


### PR DESCRIPTION
- Updates the Orangelight Role to use the pulibrary.blacklight-app as a dependency
- Resolves #113 by adding an Orangelight cron task for generating the Sitemap
- Resolves #114 by ensuring that the APPLICATION_HOST and APPLICATION_HOST_PROTOCOL Rails env. variables are exposed to the OL environment