### PR TITLE
Uses the Brightbox PPA (https://www.brightbox.com/docs/ruby/ubuntu/) in order to update Ruby to the latest 2.4.x release

### DIFF
--- a/roles/pulibrary.ruby/tasks/main.yml
+++ b/roles/pulibrary.ruby/tasks/main.yml
@@ -1,13 +1,30 @@
 ---
-- name: install Ruby package
+- name: install the dependencies
+  apt:
+    name: software-properties-common
+    state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
+    update_cache: 'yes'
+
+- name: add the Brightbox repository
+  apt_repository:
+    repo: 'ppa:brightbox/ruby-ng'
+    state: present
+    update_cache: 'yes'
+
+- name: install Ruby 2.4.x
   apt:
     name: '{{ item }}'
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: 'yes'
   with_items:
-    - ruby
-    - ruby-dev
+    - ruby2.4
+    - ruby2.4-dev
+    - ruby-switch
+
+- name: switch to Ruby 2.4.x release for the system default
+  shell: ruby-switch --set ruby2.4
 
 - name: install bundler
   gem:


### PR DESCRIPTION
Resolves #134