### PR TITLE
Uses the command (rather than shell) Module for the pulibrary.ruby Role, downgrade Bundler release 1.16.0 for pulibrary.ruby

### DIFF
--- a/figgy.yml
+++ b/figgy.yml
@@ -6,7 +6,6 @@
     - site_vars.yml
   roles:
     - role: pulibrary.ruby
-    - role: pulibrary.downgrade_bundler
     - role: pulibrary.deploy-user
     - role: pulibrary.passenger
     - role: pulibrary.redis

--- a/orangelight.yml
+++ b/orangelight.yml
@@ -6,7 +6,6 @@
     - site_vars.yml
   roles:
     - role: pulibrary.ruby
-    - role: pulibrary.downgrade_bundler
     - role: pulibrary.deploy-user
     - role: pulibrary.passenger
     - role: pulibrary.redis

--- a/orangelight_staging.yml
+++ b/orangelight_staging.yml
@@ -6,7 +6,6 @@
     - site_vars.yml
   roles:
     - role: pulibrary.ruby
-    - role: pulibrary.downgrade_bundler
     - role: pulibrary.deploy-user
     - role: pulibrary.passenger
     - role: pulibrary.redis

--- a/roles/pulibrary.ruby/tasks/main.yml
+++ b/roles/pulibrary.ruby/tasks/main.yml
@@ -29,5 +29,5 @@
 - name: install bundler
   gem:
     name: bundler
-    state: latest
+    version: 1.16.0
     user_install: 'no'

--- a/roles/pulibrary.ruby/tasks/main.yml
+++ b/roles/pulibrary.ruby/tasks/main.yml
@@ -24,7 +24,7 @@
     - ruby-switch
 
 - name: switch to Ruby 2.4.x release for the system default
-  shell: ruby-switch --set ruby2.4
+  command: /usr/bin/ruby-switch --set ruby2.4
 
 - name: install bundler
   gem:

--- a/roles/pulibrary.ruby/tasks/main.yml
+++ b/roles/pulibrary.ruby/tasks/main.yml
@@ -26,6 +26,11 @@
 - name: switch to Ruby 2.4.x release for the system default
   command: /usr/bin/ruby-switch --set ruby2.4
 
+- name: uninstall bundler
+  gem:
+    name: bundler
+    state: absent
+
 - name: install bundler
   gem:
     name: bundler


### PR DESCRIPTION
Resolves #142 by deprecating `pulibrary.downgrade_bundler`