### PR TITLE
Updates the default Solr release to 6.6.2 for pulibrary.solr and Figgy and uses an alternative mirror

### DIFF
--- a/group_vars/figgy.yml
+++ b/group_vars/figgy.yml
@@ -1,5 +1,5 @@
 passenger_server_name: "figgy-staging1.princeton.edu"
-passenger_app_root: "/opt/figgy/current/public" 
+passenger_app_root: "/opt/figgy/current/public"
 passenger_app_env: "staging"
 rails_app_name: "figgy"
 rails_app_directory: "figgy"
@@ -21,7 +21,6 @@ figgy_solr_name: figgy-staging
 figgy_host_name: 'figgy-staging.princeton.edu'
 solr_cores:
   - '{{figgy_solr_name}}'
-solr_version: "6.2.1"
 application_db_name: '{{figgy_db_name}}'
 application_dbuser_name: '{{figgy_db_user}}'
 application_dbuser_password: '{{figgy_db_password}}'

--- a/group_vars/figgy_production.yml
+++ b/group_vars/figgy_production.yml
@@ -1,5 +1,5 @@
 passenger_server_name: "figgy.princeton.edu"
-passenger_app_root: "/opt/figgy/current/public" 
+passenger_app_root: "/opt/figgy/current/public"
 passenger_app_env: "production"
 rails_app_name: "figgy"
 rails_app_directory: "figgy"
@@ -31,7 +31,6 @@ figgy_host_name: 'figgy.princeton.edu'
 figgy_honeybadger_key: '{{vault_figgy_honeybadger_key}}'
 solr_cores:
   - '{{figgy_solr_name}}'
-solr_version: "6.2.1"
 application_db_name: '{{figgy_db_name}}'
 application_dbuser_name: '{{figgy_db_user}}'
 application_dbuser_password: '{{figgy_db_password}}'

--- a/roles/pulibrary.solr/README.md
+++ b/roles/pulibrary.solr/README.md
@@ -23,7 +23,7 @@ Files will be downloaded to this path on the remote server before being moved in
 
 Solr will be run under the `solr_user`. Set `solr_create_user` to `false` if `solr_user` is created before this role runs, or if you're using Solr 5+ and want Solr's own installation script to set up the user.
 
-    solr_version: "6.2.0"
+    solr_version: "6.6.2"
 
 The Apache Solr version to install. For a full list, see [available Apache Solr versions](http://archive.apache.org/dist/lucene/solr/).
 

--- a/roles/pulibrary.solr/defaults/main.yml
+++ b/roles/pulibrary.solr/defaults/main.yml
@@ -4,8 +4,8 @@ solr_workspace: /root
 solr_create_user: true
 solr_user: solr
 
-solr_version: "6.6.0"
-solr_mirror: "https://lib-solr-mirror.princeton.edu/dist"
+solr_version: "6.6.2"
+solr_mirror: "http://mirrors.sonic.net/apache"
 solr_remove_cruft: false
 
 solr_service_manage: true


### PR DESCRIPTION
Resolves #175 