### PR TITLE
Ensures that the backward compatible `include` is used for releases prior to Ansible 2.4

### DIFF
--- a/roles/pulibrary.bibdata/tasks/main.yml
+++ b/roles/pulibrary.bibdata/tasks/main.yml
@@ -6,13 +6,13 @@
     - libmysqlclient-dev
     - python-mysqldb
 
-- include_tasks: samba_server.yml
+- include: samba_server.yml
   when: samba_status == 'server'
 
-- include_tasks: samba_client.yml
+- include: samba_client.yml
   when: samba_status == 'client'
 
-- include_tasks: local_mariadb.yml
+- include: local_mariadb.yml
   when: bibdata_db_host == 'localhost'
 
 - name: Add the cron task for reseeding the ARK cache from the repositories


### PR DESCRIPTION
Resolves #192 