### PR TITLE
Removing all references to the deprecated domain names `puls*.princeton.edu` and `pulsearch*.princeton.edu`

### DIFF
--- a/group_vars/orangelight.yml
+++ b/group_vars/orangelight.yml
@@ -1,4 +1,4 @@
-passenger_server_name: "puls.* pulsearch.* catalog.*"
+passenger_server_name: "catalog.*"
 passenger_app_root: "/opt/rails_app/current/public"
 passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.4"
@@ -33,7 +33,7 @@ application_db_name: '{{ol_db_name}}'
 application_dbuser_name: '{{ol_db_user}}'
 application_dbuser_password: '{{ol_db_password}}'
 application_dbuser_role_attr_flags: 'SUPERUSER'
-ol_host_name: 'pulsearch.princeton.edu'
+ol_host_name: 'catalog.princeton.edu'
 application_host_protocol: 'https'
 rails_app_vars:
   - name: OL_SECRET_KEY_BASE
@@ -95,5 +95,5 @@ datadog_checks:
       - name: Orangelight Solr
         url: '{{ol_solr_url}}/admin/ping'
         skip_event: true
-        tags: 
+        tags:
          - 'http_service:solr'

--- a/group_vars/orangelight_staging.yml
+++ b/group_vars/orangelight_staging.yml
@@ -1,4 +1,4 @@
-passenger_server_name: "puls-staging.* pulsearch-staging.* catalog-staging.*"
+passenger_server_name: "catalog-staging.*"
 passenger_app_root: "/opt/orangelight/current/public"
 passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.4"
@@ -32,7 +32,7 @@ application_db_name: '{{ol_db_name}}'
 application_dbuser_name: '{{ol_db_user}}'
 application_dbuser_password: '{{ol_db_password}}'
 application_dbuser_role_attr_flags: 'SUPERUSER'
-ol_host_name: 'pulsearch-staging.princeton.edu'
+ol_host_name: 'catalog-staging.princeton.edu'
 application_host_protocol: 'https'
 rails_app_vars:
   - name: OL_SECRET_KEY_BASE

--- a/roles/pulibrary.orangelight/templates/default.j2
+++ b/roles/pulibrary.orangelight/templates/default.j2
@@ -14,6 +14,6 @@ server {
     client_max_body_size 4g;
 
 
-	server_name puls.* pulsearch.* catalog.* ;
+	server_name catalog.* ;
 
 }


### PR DESCRIPTION
Resolves #117 