### PR TITLE
Ensuring that the pulibrary.ansible-datadog Role is only included when Vagrant is not used for provisioning

### DIFF
--- a/figgy.yml
+++ b/figgy.yml
@@ -45,6 +45,7 @@
     - role: pulibrary.sidekiq_worker
     - role: pulibrary.figgy
     - role: pulibrary.ansible-datadog
+      when: not postgresql_is_local
 - hosts: figgy_production_workers
   remote_user: pulsys
   become: true
@@ -64,3 +65,4 @@
     - role: pulibrary.sidekiq_worker
     - role: pulibrary.figgy
     - role: pulibrary.ansible-datadog
+      when: not postgresql_is_local

--- a/orangelight.yml
+++ b/orangelight.yml
@@ -14,3 +14,4 @@
     - role: pulibrary.extra_path
     - role: pulibrary.orangelight
     - role: pulibrary.ansible-datadog
+      when: not postgresql_is_local


### PR DESCRIPTION
Resolves #228 