### PR TITLE
add a new mariadb host

### DIFF
--- a/hosts
+++ b/hosts
@@ -16,6 +16,7 @@ maps-staging1.princeton.edu
 [mariadb]
 mariadb1.princeton.edu
 mariadb2.princeton.edu
+mariadb3.princeton.edu
 [postgres]
 lib-postgres1.princeton.edu
 lib-postgres2.princeton.edu


### PR DESCRIPTION
this adds a third mariadb host to prevent the "split-brain" problems
that happen on restart