### PR TITLE
use the libraries dns forwarder

### DIFF
--- a/roles/pulibrary.bind9/tasks/main.yml
+++ b/roles/pulibrary.bind9/tasks/main.yml
@@ -4,8 +4,8 @@
     - bind9
 - name: Remove other nameservers
   lineinfile: dest=/etc/resolv.conf state=absent regexp='.*nameserver.*'
-- name: Use local nameserver
-  lineinfile: dest=/etc/resolv.conf state=present line='nameserver 127.0.0.1'
+- name: Use dns forwarder nameserver
+  lineinfile: dest=/etc/resolv.conf state=present line='nameserver 128.112.200.253'
   notify: restart bind
 
 - name: enable bind to start on boot


### PR DESCRIPTION
this will prevent our machines from flooding OIT's DNS servers

We have a new ticket where `lib-proc5` this time was misbehaving.