### PR TITLE
[Do not merge] Rename plum rabbit exchange

### DIFF
--- a/group_vars/dpul_production.yml
+++ b/group_vars/dpul_production.yml
@@ -50,7 +50,7 @@ rails_app_vars:
   - name: POMEGRANATE_RABBITMQ_URL
     value: '{{dpul_rabbit_server}}'
   - name: POMEGRANATE_RABBITMQ_EXCHANGE
-    value: 'plum_events'
+    value: 'figgy_events'
   - name: APPLICATION_HOST
     value: '{{dpul_host_name}}'
   - name: APPLICATION_HOST_PROTOCOL

--- a/group_vars/dpul_staging.yml
+++ b/group_vars/dpul_staging.yml
@@ -48,7 +48,7 @@ rails_app_vars:
   - name: POMEGRANATE_RABBITMQ_URL
     value: '{{dpul_rabbit_server}}'
   - name: POMEGRANATE_RABBITMQ_EXCHANGE
-    value: 'plum_events'
+    value: 'figgy_events'
   - name: APPLICATION_HOST
     value: '{{dpul_host_name}}'
   - name: APPLICATION_HOST_PROTOCOL

--- a/group_vars/lae_production.yml
+++ b/group_vars/lae_production.yml
@@ -52,7 +52,7 @@ rails_app_vars:
   - name: LAE_RABBITMQ_URL
     value: '{{lae_rabbit_server}}'
   - name: LAE_RABBITMQ_EXCHANGE
-    value: 'plum_events'
+    value: 'figgy_events'
   - name: APPLICATION_HOST
     value: '{{lae_host_name}}'
   - name: APPLICATION_HOST_PROTOCOL

--- a/group_vars/lae_staging.yml
+++ b/group_vars/lae_staging.yml
@@ -53,7 +53,7 @@ rails_app_vars:
   - name: LAE_RABBITMQ_URL
     value: '{{lae_rabbit_server}}'
   - name: LAE_RABBITMQ_EXCHANGE
-    value: 'plum_events'
+    value: 'figgy_events'
   - name: APPLICATION_HOST
     value: '{{lae_host_name}}'
   - name: APPLICATION_HOST_PROTOCOL


### PR DESCRIPTION
Renames `plum_events` to `figgy_events` in Pom and LAE.

Closes #288