### PR TITLE
Update production solr core names to match SolrCloud naming scheme

### DIFF
--- a/group_vars/dpul_production.yml
+++ b/group_vars/dpul_production.yml
@@ -33,7 +33,7 @@ application_dbuser_role_attr_flags: 'SUPERUSER'
 application_host: '{{passenger_server_name}}'
 application_host_protocol: 'https'
 project_db_host: '{{postgres_host}}'
-dpul_solr: 'http://lib-solr3.princeton.edu:8983/solr/dpul-blacklight'
+dpul_solr: 'http://lib-solr.princeton.edu:8983/solr/dpul'
 rails_app_vars:
   - name: POMEGRANATE_SECRET_KEY_BASE
     value: '{{vault_dpul_secret_key}}'

--- a/group_vars/dss_production.yml
+++ b/group_vars/dss_production.yml
@@ -34,4 +34,4 @@ rails_app_vars:
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{application_host_protocol}}'
   - name: SOLR_URL
-    value: 'http://lib-solr3.princeton.edu:8983/solr/dss-blacklight'
+    value: 'http://lib-solr.princeton.edu:8983/solr/dss'

--- a/group_vars/figgy_production.yml
+++ b/group_vars/figgy_production.yml
@@ -53,7 +53,7 @@ application_host: '{{passenger_server_name}}'
 application_host_protocol: 'https'
 project_db_host: '{{postgres_host}}'
 redis_bind_interface: '0.0.0.0'
-figgy_solr_url: 'http://lib-solr3.princeton.edu:8983/solr/figgy'
+figgy_solr_url: 'http://lib-solr.princeton.edu:8983/solr/figgy'
 rails_app_vars:
   - name: SECRET_KEY_BASE
     value: '{{vault_figgy_secret_key}}'

--- a/group_vars/lae_production.yml
+++ b/group_vars/lae_production.yml
@@ -58,7 +58,7 @@ rails_app_vars:
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{application_host_protocol}}'
   - name: SOLR_URL
-    value: 'http://lib-solr3.princeton.edu:8983/solr/lae-blacklight'
+    value: 'http://lib-solr.princeton.edu:8983/solr/lae'
   - name: HONEYBADGER_API_KEY
     value: '{{lae_honeybadger_key}}'
 sneakers_workers: PlumEventHandler

--- a/group_vars/pulmap.yml
+++ b/group_vars/pulmap.yml
@@ -5,7 +5,7 @@ pulmap_rabbit_user: '{{vault_dpul_rabbit_user}}'
 pulmap_rabbit_password: '{{vault_dpul_rabbit_password}}'
 pulmap_rabbit_host: 'figgy1.princeton.edu'
 pulmap_rabbit_server:  'amqp://{{pulmap_rabbit_user}}:{{pulmap_rabbit_password}}@{{pulmap_rabbit_host}}:5672'
-pulmap_solr_url: http://lib-solr3.princeton.edu:8983/solr/pulmap
+pulmap_solr_url: http://lib-solr.princeton.edu:8983/solr/pulmap
 rails_app_name: "pulmap"
 rails_app_directory: "pulmap"
 rails_app_env: "production"


### PR DESCRIPTION
Closes #326. Updates all production solr urls with the exception of Orangelight.