### PR TITLE
Updates PHP in the pulibrary.php Role to release 7.2

### DIFF
--- a/group_vars/figgy.yml
+++ b/group_vars/figgy.yml
@@ -16,8 +16,6 @@ rails_app_dependencies:
   - pkg-config
   - libtool
   - autoconf
-  - gdal-bin
-  - libgdal-dev
   - libpango1.0-dev
   - zip
   - tesseract-ocr

--- a/group_vars/figgy_production.yml
+++ b/group_vars/figgy_production.yml
@@ -17,8 +17,6 @@ rails_app_dependencies:
   - openjdk-8-jre
   - libtool
   - autoconf
-  - gdal-bin
-  - libgdal-dev
   - libpango1.0-dev
   - zip
   - tesseract-ocr

--- a/roles/pulibrary.figgy/tasks/main.yml
+++ b/roles/pulibrary.figgy/tasks/main.yml
@@ -129,20 +129,20 @@
       link: '/opt/repository/derivatives'
     - src: '{{figgy_geo_derivatives_mount}}'
       link: '/opt/repository/geo_derivatives'
-## Simple tiles dependency
-- name: Compile simple-tiles from source
-  shell: curl -L {{ simple_tiles_url }} | tar -xz && cd simple-tiles-{{simple_tiles_version}} && ./configure && make && make install
-  args:
-    creates: /usr/local/lib/libsimple-tiles.so
 ## Necessary for gdal version >= 2.2.
 ## Can remove once we're using Ubuntu Bionic or above. 
 - name: Add ubuntugis repository
   become: yes
   apt_repository: repo='ppa:ubuntugis/ubuntugis-unstable'
-- name: Check for latest GDAL
+- name: Install GDAL
   apt:
     name: '{{ item }}'
-    state: latest
+    state: present
   with_items:
     - libgdal-dev
     - gdal-bin
+## Simple tiles dependency
+- name: Compile simple-tiles from source
+  shell: curl -L {{ simple_tiles_url }} | tar -xz && cd simple-tiles-{{simple_tiles_version}} && ./configure && make && make install
+  args:
+    creates: /usr/local/lib/libsimple-tiles.so

--- a/roles/pulibrary.php/tasks/main.yml
+++ b/roles/pulibrary.php/tasks/main.yml
@@ -5,10 +5,10 @@
     state: present
     update_cache: 'yes'
   with_items:
-    - php7.0
-    - php7.0-fpm
-    - php7.0-dev
-    - php7.0-mbstring
-    - php7.0-curl
+    - php7.2
+    - php7.2-fpm
+    - php7.2-dev
+    - php7.2-mbstring
+    - php7.2-curl
 
 - include: configure.yml


### PR DESCRIPTION
Ensures that the following error does not occur:
```
TASK [../roles/pulibrary.php : install php7] ***********************************
failed: [training1] (item=[u'php7.0', u'php7.0-fpm', u'php7.0-dev', u'php7.0-mbstring', u'php7.0-curl']) => {"changed": false, "item": ["php7.0", "php7.0-fpm", "php7.0-dev", "php7.0-mbstring", "php7.0-curl"], "msg": "No package matching 'php7.0' is available"}
```