### PR TITLE
Set redis-server overcommit_memory to 1 for bibdata-worker2

### DIFF
--- a/roles/pulibrary.bibdata/tasks/redis_overcommit_memory.yml
+++ b/roles/pulibrary.bibdata/tasks/redis_overcommit_memory.yml
@@ -1,0 +1,4 @@
+---
+- name: Set redis overcommit_memory to 1 in bibdata_workers
+  - hosts: bibdata_workers
+      shell: 'echo 1 > /proc/sys/vm/overcommit_memory'


### PR DESCRIPTION
@kayiwa, would it be a better practice to set the overcommit_memory in the pulibray.redis defaults/main.yml file with a default value and then reference it in any other playbook? If yes, would it be ok to let the default value as 0? From what I've seen so far the servers have it set as 0. 