### PR TITLE
allow ajax calls from catalog-staging

### DIFF
--- a/group_vars/orangelight_staging.yml
+++ b/group_vars/orangelight_staging.yml
@@ -2,6 +2,7 @@ passenger_server_name: "catalog-staging.*"
 passenger_app_root: "/opt/orangelight/current/public"
 passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.4"
+passenger_extra_config: "{{ lookup('file', 'roles/pulibrary.orangelight/templates/nginx_extra_config')  }}"
 rails_app_name: "orangelight"
 rails_app_directory: "orangelight"
 rails_app_symlinks: []

--- a/roles/pulibrary.orangelight/templates/nginx_extra_config
+++ b/roles/pulibrary.orangelight/templates/nginx_extra_config
@@ -1,0 +1,7 @@
+location ~ ^.*/catalog {
+  add_header 'Access-Control-Allow-Origin' '*';
+  add_header 'Access-Control-Allow-Credentials' 'true';
+  add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+  add_header 'Access-Control-Allow-Headers'
+'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Origin';
+}


### PR DESCRIPTION
Allows the /catalog route to be accessed via AJAX on catalog-staging environment.