### PR TITLE
Install whenever directly outside of bundler

### DIFF
--- a/roles/pulibrary.ruby/tasks/main.yml
+++ b/roles/pulibrary.ruby/tasks/main.yml
@@ -29,3 +29,7 @@
 - gem:
     name: bundler
     user_install: no
+
+- gem:
+    name: whenever
+    user_install: no


### PR DESCRIPTION
It has to load before bundler has done its business to allow tighter integration with capistrano