### PR TITLE
Revert "Install whenever directly outside of bundler"

### DIFF
--- a/roles/pulibrary.ruby/tasks/main.yml
+++ b/roles/pulibrary.ruby/tasks/main.yml
@@ -29,7 +29,3 @@
 - gem:
     name: bundler
     user_install: no
-
-- gem:
-    name: whenever
-    user_install: no


### PR DESCRIPTION
This reverts commit bf3b0844f882e019b4cb428b5a397ef244083635.
Turns out we need whenever on the pulbot machine, not the target
machines