### PR TITLE
Increase ZooKeeper timeout, reduce heap size and memory tuning for lib-solr1 only

### DIFF
--- a/host_vars/lib-solr1.princeton.edu.yml
+++ b/host_vars/lib-solr1.princeton.edu.yml
@@ -1,0 +1,4 @@
+---
+solr_gc_tune: -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:-UseGCOverheadLimit
+solr_heap: 40g
+solr_stack_size: 1m

--- a/roles/pulibrary.solrcloud/templates/solr.in.sh.j2
+++ b/roles/pulibrary.solrcloud/templates/solr.in.sh.j2
@@ -38,7 +38,7 @@ GC_TUNE='{{ solr_gc_tune }}'
 ZK_HOST='lib-zk1:2181,lib-zk2:2181,lib-zk3:2181'
 
 # Set the ZooKeeper client timeout (for SolrCloud mode)
-ZK_CLIENT_TIMEOUT='15000'
+ZK_CLIENT_TIMEOUT='60000'
 
 # By default the start script uses "localhost"; override the hostname here
 # for production SolrCloud environments to control the hostname exposed to cluster state


### PR DESCRIPTION
Fixes #374

See 
* https://github.com/pulibrary/pul_solr/blob/master/architecture-decisions/0002-increase-zookeeper-timeout.md
* https://github.com/pulibrary/pul_solr/blob/master/architecture-decisions/0003-remove-memory-tuning.md