### PR TITLE
Ensures that the libnginx-mod-http-passenger package is installed (rather than passenger) for NGINX/Passenger on Ubuntu 18.04 LTS)

### DIFF
--- a/roles/pulibrary.passenger/tasks/main.yml
+++ b/roles/pulibrary.passenger/tasks/main.yml
@@ -25,11 +25,14 @@
     update_cache: true
 
 # Nginx and passenger installation.
+- name: Define nginx_passenger_packages
+  set_fact:
+    nginx_passenger_packages: "{{ __nginx_passenger_packages_16_04 }}"
+  when: ansible_facts['distribution_major_version'] < 18
+
 - name: Install Nginx and Passenger.
   apt: "pkg={{ item }} state=installed"
-  with_items:
-    - nginx-extras
-    - passenger
+  with_items: "{{ nginx_passenger_packages }}"
 
 # Nginx and passenger configuration.
 - name: Copy Nginx configuration into place.

--- a/roles/pulibrary.passenger/vars/main.yml
+++ b/roles/pulibrary.passenger/vars/main.yml
@@ -1,2 +1,8 @@
 ---
 __nginx_user: "www-data"
+nginx_passenger_packages:
+  - nginx-extras
+  - libnginx-mod-http-passenger
+__nginx_passenger_packages_16_04:
+  - nginx-extras
+  - passenger


### PR DESCRIPTION
Resolves #404 