### PR TITLE
Adds Travis CI for testing against multiple releases of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+---
+dist: xenial
+sudo: required
+language: python
+python:
+  - "2.7"
+  - "3.7"
+services: docker
+
+env:
+  matrix:
+    - MOLECULE_DISTRO: ubuntu1604
+    - MOLECULE_DISTRO: ubuntu1804
+
+install:
+  # Install test dependencies
+  - pip install -r requirements.txt
+
+script:
+  # Run tests
+  - molecule test


### PR DESCRIPTION
Given the lack of support for VM-based environments beyond Ubuntu 14.04 releases (which blocks the installation and usage of Python 3.7.x releases in tests), this ensures that Travis CI is the preferred CI solution.