### PR TITLE
mariadb is the client role

### DIFF
--- a/playbooks/dss.yml
+++ b/playbooks/dss.yml
@@ -9,7 +9,7 @@
     - role: roles/pulibrary.deploy-user
     - role: roles/pulibrary.passenger
     - role: roles/pulibrary.redis
-    - {role: roles/pulibrary.mariadb, when: db_host == 'localhost'}
+    - {role: roles/pulibrary.mariadbserver, when: db_host == 'localhost'}
     - role: roles/pulibrary.nodejs
     - role: roles/pulibrary.extra_path
     - role: roles/pulibrary.rails-app


### PR DESCRIPTION
the mariadb role only installs a client whilst the mariadbserver installs the mariadb server