### PR TITLE
Don't password redis by default.

### DIFF
--- a/roles/pulibrary.redis/defaults/main.yml
+++ b/roles/pulibrary.redis/defaults/main.yml
@@ -42,8 +42,6 @@ redis__server_maxmemory_samples: 3
 # feature is disabled.
 # The Redis server configuration parameters set by default by the role.
 redis__server_default_configuration:
-  requirepass: "{{ redis__auth_password }}"
-  masterauth: "{{ redis__auth_password }}"
   syslog-enabled: "{{ redis__server_syslog | bool }}"
   syslog-ident: "{{ redis__server_syslog_ident }}"
   syslog-facility: "{{ redis__server_syslog_facility }}"


### PR DESCRIPTION
We can revert this later, but for now our apps aren't set up with this expectation which got added later - so anything we provision with redis is breaking.