### PR TITLE
update playbooks for apps using solr staging cluster

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -41,8 +41,8 @@ deploy_ssh_users:
     key: https://github.com/pmgreen.keys
 fits_version: 0.8.5
 ol_solr_url: 'http://lib-solr.princeton.edu:8983/solr/catalog-production'
-ol_solr_reindex_url: 'http://lib-solr.princeton.edu:8983/solr/catalog-rebuild'
-ol_staging_solr_url: 'http://lib-solr.princeton.edu:8983/solr/catalog-staging'
+ol_solr_reindex_url: 'http://lib-solr-staging.princeton.edu:8983/solr/catalog-rebuild'
+ol_staging_solr_url: 'http://lib-solr-staging.princeton.edu:8983/solr/catalog-staging'
 pulmap_db: '{{vault_pulmap_db}}'
 pulmap_db_host: '{{vault_pulmap_db_host}}'
 pulmap_db_password: '{{vault_pulmap_db_password}}'

--- a/group_vars/cicognara.yml
+++ b/group_vars/cicognara.yml
@@ -43,7 +43,7 @@ rails_app_vars:
   - name: GOOGLE_CLIENT_ID
     value: '{{ vault_cicognara_staging_google_client_id }}'
   - name: CICOGNARA_SOLR_URL
-    value: 'http://lib-solr.princeton.edu:8983/solr/cicognara-staging'
+    value: 'http://lib-solr-staging.princeton.edu:8983/solr/cicognara-staging'
 sidekiq_worker_name: cicognara-workers
 redis__server_default_configuration:
   syslog-enabled: "{{ redis__server_syslog | bool }}"

--- a/group_vars/dpul_staging.yml
+++ b/group_vars/dpul_staging.yml
@@ -55,7 +55,7 @@ rails_app_vars:
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{application_host_protocol}}'
   - name: POMEGRANATE_SOLR_URL
-    value: 'http://lib-solr.princeton.edu:8983/solr/dpul-staging'
+    value: 'http://lib-solr-staging.princeton.edu:8983/solr/dpul-staging'
   - name: HONEYBADGER_API_KEY
     value: '{{dpul_honeybadger_key}}'
   - name: POMEGRANATE_COLLECTIONS_URL

--- a/group_vars/dss_staging.yml
+++ b/group_vars/dss_staging.yml
@@ -34,4 +34,4 @@ rails_app_vars:
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{application_host_protocol}}'
   - name: SOLR_URL
-    value: 'http://lib-solr.princeton.edu:8983/solr/dss-staging'
+    value: 'http://lib-solr-staging.princeton.edu:8983/solr/dss-staging'

--- a/group_vars/lae_staging.yml
+++ b/group_vars/lae_staging.yml
@@ -24,7 +24,7 @@ lae_rabbit_user: '{{vault_lae_rabbit_user}}'
 lae_rabbit_password: '{{vault_lae_rabbit_password}}'
 lae_rabbit_host: 'figgy1.princeton.edu'
 lae_rabbit_server: 'amqp://{{lae_rabbit_user}}:{{lae_rabbit_password}}@{{lae_rabbit_host}}:5672'
-lae_solr_url: 'http://lib-solr.princeton.edu:8983/solr/lae-staging'
+lae_solr_url: 'http://lib-solr-staging.princeton.edu:8983/solr/lae-staging'
 rabbitmq_user: '{{lae_rabbit_user}}'
 rabbitmq_password: '{{lae_rabbit_password}}'
 rails_app_env: "staging"

--- a/group_vars/pulmap_staging.yml
+++ b/group_vars/pulmap_staging.yml
@@ -16,7 +16,7 @@ rails_app_dependencies:
   - autoconf
 rails_app_vars:
   - name: PULMAP_SOLR_URL
-    value: 'http://lib-solr.princeton.edu:8983/solr/pulmap-staging'
+    value: 'http://lib-solr-staging.princeton.edu:8983/solr/pulmap-staging'
   - name: PULMAP_DB
     value: 'pulmap_staging'
   - name: MAP_FEEDBACK_TO

--- a/group_vars/solrcloud_staging.yml
+++ b/group_vars/solrcloud_staging.yml
@@ -1,5 +1,5 @@
 ---
-solr_heap: '10g'
+solr_heap: '18g'
 lib_solr1_host: '{{ vault_lib_solr_staging1_host }}'
 lib_solr2_host: '{{ vault_lib_solr_staging2_host }}'
 lib_solr3_host: '{{ vault_lib_solr_staging3_host }}'

--- a/playbooks/dss_staging.yml
+++ b/playbooks/dss_staging.yml
@@ -1,0 +1,16 @@
+---
+- hosts: dss_staging
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../site_vars.yml
+  roles:
+    - role: roles/pulibrary.ruby
+    - role: roles/pulibrary.deploy-user
+    - role: roles/pulibrary.passenger
+    - role: roles/pulibrary.redis
+    - {role: roles/pulibrary.mariadb, when: db_host == 'localhost'}
+    - role: roles/pulibrary.nodejs
+    - role: roles/pulibrary.extra_path
+    - role: roles/pulibrary.rails-app
+    - role: roles/pulibrary.dss


### PR DESCRIPTION
 - Updated environment variables to reflect SolrCloud collections for dpul-staging, dss-staging, cicognara-staging, lae-staging, catalog-staging, catalog-rebuild on the Solr staging cluster.
 - Increased solr staging cluster heap setting to 18gb out of total 50gb RAM.
 - Created dss-staging playbook which is identical to [dss playbook](https://github.com/pulibrary/princeton_ansible/blob/master/playbooks/dss.yml) except for hosts setting.