### PR TITLE
Implements a separate Playbook for provisioning ArchivesSpace installations into a staging environment

### DIFF
--- a/group_vars/archivesspace_staging.yml
+++ b/group_vars/archivesspace_staging.yml
@@ -1,0 +1,7 @@
+---
+url_jdbc_base: 'jdbc:mysql://{{ db_server }}:{{ db_port }}/'
+url_jdbc_suffix: '&useUnicode=true&characterEncoding=UTF-8'
+archivesspace_version: 'v2.5.2'
+db_host: '{{ maria_db_cluster_host | default("localhost") }}'
+archivesspace_db_password: '{{ vault_archivesspace_db_password }}'
+ldap_server_hostname: 'ldap.princeton.edu'

--- a/hosts
+++ b/hosts
@@ -42,7 +42,9 @@ lib-proc6.princeton.edu
 lib-proc7.princeton.edu
 lib-proc8.princeton.edu
 [archivesspace]
-lib-aspace-prod1.Princeton.EDU
+lib-aspace-prod1.princeton.edu
+[archivesspace_staging]
+lib-aspace-test1.princeton.edu
 [lae_production]
 lae1.princeton.edu
 lae2.princeton.edu

--- a/playbooks/archivesspace_staging.yml
+++ b/playbooks/archivesspace_staging.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: archivesspace
+- hosts: archivesspace_staging
   remote_user: pulsys
   become: true
   vars_files:

--- a/roles/pulibrary.archivesspace/tasks/main.yml
+++ b/roles/pulibrary.archivesspace/tasks/main.yml
@@ -2,6 +2,11 @@
 - include: setup_mysql.yml
 - include: generate_secrets.yml
 
+- name: install the OpenJDK release of Java 8
+  apt:
+    name: openjdk-8-jre-headless
+    state: present
+
 - set_fact:
     url_jdbc_archivesspace: '{{ url_jdbc_base }}{{ archivesspace_db_name }}?user={{ archivesspace_db_user }}&password={{ archivesspace_db_password }}{{ url_jdbc_suffix }}'
 
@@ -23,7 +28,7 @@
   get_url:
     url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.44/mysql-connector-java-5.1.44.jar
     dest: '/opt/archivesspace/lib/'
-    checksum: md5:803783e5c40c911c92d4b6b5ea324912
+    checksum: md5:5278a3a02fbf9266450612860ba2f41d
     force: 'no'
 
 - name: config db access


### PR DESCRIPTION
Also addresses the following:
- Deprecates unsupported Oracle releases of Java 8 in favor of OpenJDK releases
- Ensures that MariaDB server is installed when provisioning for DBs accessed on localhost