### PR TITLE
Fixing mariadb role

### DIFF
--- a/roles/pulibrary.mariadbserver/tasks/main.yml
+++ b/roles/pulibrary.mariadbserver/tasks/main.yml
@@ -3,7 +3,11 @@
 - name: Check if database server is installed
   environment:
     LC_MESSAGES: 'C'
-  command: dpkg-query -W -f='${Version}\n' 'mariadb-server' | grep -v '^$'
+  shell: |
+    set -o pipefail
+    dpkg-query -W -f='${Version}\n' 'mariadb-server' | grep -v '^$'
+  args:
+    executable: /bin/bash
   register: mariadb_server__register_version
   check_mode: false
   changed_when: false


### PR DESCRIPTION
We made this change during linting, but did not realize it broke 'molecule test'

This PR just reverts the change so that `molecule test` is green


## Error without the fix
![Screen Shot 2019-04-30 at 8 13 41 AM](https://user-images.githubusercontent.com/1599081/56961601-24aeb400-6b22-11e9-85b8-63cf6048a1be.png)

## Passing `molecule test` with the fix
![Screen Shot 2019-04-30 at 8 27 24 AM](https://user-images.githubusercontent.com/1599081/56961622-355f2a00-6b22-11e9-8aea-f3eb954f8901.png)
