### PR TITLE
adds role to set eastern timezone

### DIFF
--- a/playbooks/orangelight_workers.yml
+++ b/playbooks/orangelight_workers.yml
@@ -10,3 +10,4 @@
     - role: roles/pulibrary.nodejs
     - role: roles/pulibrary.extra_path
     - role: roles/pulibrary.rails-app
+    - role: roles/pulibrary.timezone-eastern

--- a/roles/pulibrary.timezone-eastern/tasks/main.yml
+++ b/roles/pulibrary.timezone-eastern/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Sets eastern timezone for cron jobs
+  command: timedatectl set-timezone America/New_York
+
+- name: Restarts cron service
+  service:
+    name: cron
+    state: restarted


### PR DESCRIPTION
Using the local timezone will make it easier to anticipate daylight savings for cron jobs.