### PR TITLE
exclude distrib=false queries from the datadog logs

### DIFF
--- a/group_vars/solrcloud.yml
+++ b/group_vars/solrcloud.yml
@@ -29,6 +29,9 @@ datadog_checks:
           - type: multi_line
             name: new_log_start_with_date
             pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+          - type: exclude_at_match
+            name: exclude_solrcloud_distrib_queries
+            pattern: distrib=false
       - type: file
         path: /solr/logs/solr_gc.log.0.current
         service: solr


### PR DESCRIPTION
Closes #555.
Can someone run the solrcloud playbook for this?