### PR TITLE
Changing the mode to allow user directory access

### DIFF
--- a/roles/pulibrary.deploy-user/tasks/main.yml
+++ b/roles/pulibrary.deploy-user/tasks/main.yml
@@ -55,7 +55,8 @@
     state: directory
     owner: deploy
     group: deploy
-    mode: 0600
+    mode: 0700
+  when: not run_not_in_container
 
 - name: Install deploy github key
   copy:


### PR DESCRIPTION
This is causing issues with deploy being able to ssh into the box.
The directory should already be created,  but the tests do not have any deploy users

Changing the task to only run when we are testing along with setting the mode correctly.

fixes #562 