### PR TITLE
Don't use recurse to create figgy derivatives mount directory

### DIFF
--- a/roles/pulibrary.figgy/tasks/main.yml
+++ b/roles/pulibrary.figgy/tasks/main.yml
@@ -92,7 +92,6 @@
   file:
     path: '{{figgy_derivatives_mount}}'
     state: directory
-    recurse: yes
 
 - name: Create diglibdata mounts (hydra sources)
   mount:
@@ -166,6 +165,7 @@
       link: '/opt/repository/geo_derivatives'
     - src: '{{figgy_stream_derivatives_mount}}'
       link: '/opt/repository/stream_derivatives'
+
 ## Necessary for gdal version >= 2.2.
 ## Can remove once we're using Ubuntu Bionic or above.
 - name: Add ubuntugis repository


### PR DESCRIPTION
Recurse sets properties of all files within the directory, which is not
what we want. `state: directory` already creates required subdirectories
recursively, so we should be fine.