### PR TITLE
Changing how we pass default mariadb vars

### DIFF
--- a/group_vars/libwww/libwww-prod.yml
+++ b/group_vars/libwww/libwww-prod.yml
@@ -37,13 +37,3 @@ db_host: '{{ maria_db_cluster_host }}'
 db_password: '{{ vault_maria_mysql_root_password }}'
 mariadb__server: "{{ db_host }}"
 
-mariadb__users:
-  - name: "{{ drupal_db_user }}"
-    host: "%"
-    password: "{{ drupal_db_password }}"
-    priv: "{{ drupal_db_name }}.*:ALL"
-
-mariadb__databases:
-  - name: "{{ drupal_db_name }}"
-    encoding: utf8mb4
-    collation: utf8mb4_general_ci

--- a/group_vars/libwww/libwww.yml
+++ b/group_vars/libwww/libwww.yml
@@ -35,14 +35,3 @@ search_api_solr_path: '20:"/solr/libwww-staging"'
 db_host: '{{ maria_db_cluster_host }}'
 db_password: '{{ vault_maria_mysql_root_password }}'
 mariadb__server: "{{ db_host }}"
-
-mariadb__users:
-  - name: "{{ drupal_db_user }}"
-    host: "%"
-    password: "{{ drupal_db_password }}"
-    priv: "{{ drupal_db_name }}.*:ALL"
-
-mariadb__databases:
-  - name: "{{ drupal_db_name }}"
-    encoding: utf8mb4
-    collation: utf8mb4_general_ci

--- a/playbooks/libwww-prod.yml
+++ b/playbooks/libwww-prod.yml
@@ -9,6 +9,7 @@
   vars_files:
     - ../group_vars/libwww/libwww-prod.yml
     - ../group_vars/libwww/vault.yml
+    - ../roles/pulibrary.libwww/defaults/mariadb.yml
     # need information to connect to solr staging cluster
   roles:
     - role: pulibrary.libwww

--- a/playbooks/libwww.yml
+++ b/playbooks/libwww.yml
@@ -9,6 +9,7 @@
   vars_files:
     - ../group_vars/libwww/libwww.yml
     - ../group_vars/libwww/vault.yml
+    - ../roles/pulibrary.libwww/defaults/mariadb.yml
     # need information to connect to solr staging cluster
   roles:
     - role: pulibrary.libwww

--- a/roles/pulibrary.libwww/defaults/main.yml
+++ b/roles/pulibrary.libwww/defaults/main.yml
@@ -34,14 +34,3 @@ cas_cert: 's:36:"/etc/ssl/certs/ssl-cert-snakeoil.pem";'
 
 drupal_base_path: 'http://localhost'
 drupal_ssl_base_path: 'https://localhost'
-
-mariadb__users:
-  - name: "{{ maria_db_user }}"
-    host: "%"
-    password: "{{ drupal_db_password }}"
-    priv: "{{ maria_db_name }}.*:ALL"
-
-mariadb__databases:
-  - name: "{{ maria_db_name }}"
-    encoding: utf8mb4
-    collation: utf8mb4_general_ci

--- a/roles/pulibrary.libwww/defaults/mariadb.yml
+++ b/roles/pulibrary.libwww/defaults/mariadb.yml
@@ -1,0 +1,10 @@
+mariadb__users:
+  - name: "{{ maria_db_user }}"
+    host: "%"
+    password: "{{ drupal_db_password }}"
+    priv: "{{ maria_db_name }}.*:ALL"
+
+mariadb__databases:
+  - name: "{{ maria_db_name }}"
+    encoding: utf8mb4
+    collation: utf8mb4_general_ci

--- a/roles/pulibrary.libwww/molecule/default/playbook.yml
+++ b/roles/pulibrary.libwww/molecule/default/playbook.yml
@@ -10,7 +10,7 @@
     # - mariadb__server: 'maria-staging.princeton.edu'
   vars_files:
     - ../../../../site_vars.yml
-    - ../../defaults/main.yml
+    - ../../defaults/mariadb.yml
   roles:
     - role: pulibrary.mariadbserver
     - role: pulibrary.libwww


### PR DESCRIPTION
Default file in a role will not override defaults in another role.  We want to override defaults from mariadb
in libwww, but we want them the same for all servers.  To make sure out variables get precedence we are
including them as a separate variable file in all the playbooks.