### PR TITLE
Changing the base url now that we are named recap

### DIFF
--- a/group_vars/recap/recap-prod.yml
+++ b/group_vars/recap/recap-prod.yml
@@ -1,5 +1,5 @@
 ---
-recap_base_url: 'recap-prod.princeton.edu'
+recap_base_url: 'recap.princeton.edu'
 drupal_ssl_base_path: 'https://{{ recap_base_url }}'
 
 drupal_db_user: 'recap-prod'
@@ -10,6 +10,9 @@ apache_app_path: '{{ drupal_docroot }}/current'
 
 ### Uncomment this to force a dump file to be imported
 # drupal_dbimport_file: 'dump.sql'
+
+### Uncomment to for the settings file to be updated
+# force_settings: true
 
 db_host: '{{ maria_db_cluster_host }}'
 db_password: '{{ vault_maria_mysql_root_password }}'


### PR DESCRIPTION
During the change from `recap-prod` to `recap` we needed to update the base url.