### PR TITLE
[Draft] Introduces a GitLab CI/CD configuration file which uses `invoke` for running tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+---
+image: "quay.io/ansible/molecule:2.22"
+
+services:
+  - docker:dind
+
+before_script:
+  - apk update
+  - apk add --no-cache linux-headers musl-dev gcc libffi-dev libressl-dev make
+  - docker -v
+  - python -V
+  - pip install pipenv
+  - pipenv install
+  - ansible --version
+  - molecule --version
+
+pulibrary-roles:
+  stage: test
+  variables:
+    DOCKER_HOST: "tcp://docker:2375"
+  script: pipenv run invoke test
+  parallel: 4


### PR DESCRIPTION
Advances #627 by introducing an `invoke` task for running subsets of Role
test suites in parallel and using this for executing tests in parallel on GitLab CI/CD