### PR TITLE
Restore php latest

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,9 +1,10 @@
 exclude_paths:
   - ./roles/pulibrary.extra_path/.travis.yml
 skip_list:
-  - ANSIBLE0002
-  - ANSIBLE0006
-  - ANSIBLE0010
+  - 'ANSIBLE0002'
+  - 'ANSIBLE0006'
+  - 'ANSIBLE0010'
+  - '403'
   - '503'
   - '305'
   - '306'

--- a/roles/pulibrary.drush/tasks/main.yml
+++ b/roles/pulibrary.drush/tasks/main.yml
@@ -1,13 +1,27 @@
 ---
-- name: install drush
-  composer:
-    command: "require"
-    arguments: "drush/drush={{ drush_version }} --update-with-dependencies"
-    working_dir: "{{ drush_path }}"
-    optimize_autoloader: true
+- name: Check current state.
+  stat:
+    path: "/usr/local/bin/drush"
+  register: drush_path_state
 
-- name: create symbolic link
+- name: Perform cleanup of old symlink.
   file:
-    src: "{{ drush_path }}/vendor/bin/drush"
-    dest: "{{ drush_path }}/drush"
-    state: link
+    path: "/usr/local/bin/drush"
+    state: absent
+  when: drush_path_state.stat.islnk is defined and drush_path_state.stat.islnk
+
+- name: Ensure Drush path directory exists.
+  file:
+    path: "/usr/local/bin/"
+    state: directory
+    mode: 0755
+
+- name: Install Drush.
+  get_url:
+    url: "https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar"
+    dest: "/usr/local/bin/drush"
+
+- name: Ensure Drush is executable.
+  file:
+    path: "/usr/local/bin/drush"
+    mode: 0755

--- a/roles/pulibrary.php/tasks/main.yml
+++ b/roles/pulibrary.php/tasks/main.yml
@@ -7,8 +7,9 @@
 - name: install php7.2
   apt:
     name: ["php7.2", "php7.2-dev", "php7.2-curl"]
-    state: present
+    state: latest
     update_cache: true
   changed_when: false
+  tags: ['skip_ansible_lint']
 
 - include: configure.yml


### PR DESCRIPTION
- Restores installation of latest PHP while skipping linting errors.
- Adds new drush installation task (adapted from https://github.com/geerlingguy/ansible-role-drush). Composer no longer allows the installation of drush as root. This can be overcome by setting COMPOSER_ALLOW_SUPERUSER=1, however this is definitely not recommended and breaks Ansible idempotentcy.  