### PR TITLE
there are instances where 1001 is taken

### DIFF
--- a/roles/pulibrary.deploy-user/defaults/main.yml
+++ b/roles/pulibrary.deploy-user/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 deploy_user: '{{ generic_app_user | default("deploy") }}'
 deploy_ssh_users: []
-deploy_user_uid: 1001
+deploy_user_uid: '{{ user_uid | default("1001") }}'
 deploy_user_shell: /bin/bash
 deploy_id_rsa_private_key: 'bogus_rsa_key'
 run_not_in_container: false


### PR DESCRIPTION
The are times when we do not also want 1001 (system user for postgres
etc.,) as the uid. This allows for that