### PR TITLE
Remove access to servers for administrators

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -13,8 +13,6 @@ deploy_ssh_users:
     key: https://github.com/eliotjordan.keys
   - name: escowles
     key: https://github.com/escowles.keys
-  - name: jpstroop
-    key: https://github.com/jpstroop.keys
   - name: heaven
     key: "{{ lookup('file', '../keys/heaven.pub') }}"
   - name: mzelesky


### PR DESCRIPTION
Today may not be the day, but some day in the near future, I believe my SSH keys should be removed from our production servers.