### PR TITLE
Needed to allow loading of large database dump

### DIFF
--- a/roles/pulibrary.perconaxdb/files/permissive.sql
+++ b/roles/pulibrary.perconaxdb/files/permissive.sql
@@ -1,2 +1,3 @@
 SET GLOBAL pxc_strict_mode=PERMISSIVE;
 SET GLOBAL log_bin_trust_function_creators = 1;
+SET GLOBAL max_allowed_packet=128*1024*1024;


### PR DESCRIPTION
The main library site could not load the database without this additonal persmission