### PR TITLE
Removing duplicate njmaps proxy

### DIFF
--- a/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -134,10 +134,6 @@
         proxy_pass http://libphp-prod.princeton.edu/jameslyon/;
     }
 
-    location /njmaps {
-        proxy_pass http://libphp-prod.princeton.edu/njmaps/;
-    }
-
     location /hogarth {
         proxy_pass http://libphp-prod.princeton.edu/hogarth/;
     }


### PR DESCRIPTION
NJMaps was in there previously, so the duplicate cause the configuration to be invalid.