### PR TITLE
Adding rules for special-collections

### DIFF
--- a/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -125,34 +125,42 @@
 
     # special collections to libphp-prod
 
+    rewrite ^/special_collections/jameslyon/(.*)$ /jameslyon/$1 redirect;
     location /jameslyon {
         proxy_pass http://libphp-prod.princeton.edu/jameslyon/;
     }
 
+    rewrite ^/special_collections/hogarth/(.*)$ /hogarth/$1 redirect;
     location /hogarth {
         proxy_pass http://libphp-prod.princeton.edu/hogarth/;
     }
 
+    rewrite ^/special_collections/thankful-nation/(.*)$ /thankful-nation/$1 redirect;
     location /thankful-nation {
         proxy_pass http://libphp-prod.princeton.edu/thankful-nation/;
     }
 
+    rewrite ^/special_collections/capping-liberty/(.*)$ /capping-liberty/$1 redirect;
     location /capping-liberty {
         proxy_pass http://libphp-prod.princeton.edu/capping-liberty/;
     }
 
+    rewrite ^/special_collections/pathebaby/(.*)$ /pathebaby/$1 redirect;
     location /pathebaby {
         proxy_pass http://libphp-prod.princeton.edu/pathebaby/;
     }
 
+    rewrite ^/special_collections/republic/(.*)$ /republic/$1 redirect;
     location /republic {
         proxy_pass http://libblogs.princeton.edu/republic/;
     }
 
+    rewrite ^/special_collections/versailles/(.*)$ /versailles/$1 redirect;
     location /versailles {
         proxy_pass http://libphp-prod.princeton.edu/versailles/;
     }
 
+    rewrite ^/special_collections/mudd-dbs/(.*)$ /mudd-dbs/$1 redirect;
     location /mudd-dbs {
         proxy_pass http://libruby-prod.princeton.edu/mudd-dbs/;
     }


### PR DESCRIPTION
Any exhitbit that used to be housed at rbsc will get forwarded to library/specialcollections/<exhibit>
To get them to work out of the box we put them at the base level library/<exhibit>
The apps work when access through the rbsc site, but if anyone still has an old rbsc/<exhibit> url they will get forwarded to library/special_collections/<exhibit> which does not exists.