### PR TITLE
Renaming run_not_in_containter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ In all the steps below substitue your role name for `example`
       1. Add:
          ```
          vars:
-           - run_not_in_container: false
+           - runnning_on_server: false
          ```
       1. remove `role\` from `- role: role\pulibrary.example`
 

--- a/group_vars/consul/consul-staging.yml
+++ b/group_vars/consul/consul-staging.yml
@@ -8,7 +8,7 @@ consul_server_nodes:
 consul_ui: true
 consul_server: true
 consul_syslog: true
-run_not_in_container: true
+runnning_on_server: true
 # consul_agent_services: true
 consul_acl: true
 consul_acl_datacenter: "{{ consul_datacenter }}"

--- a/group_vars/lib-svn/staging.yml
+++ b/group_vars/lib-svn/staging.yml
@@ -1,5 +1,5 @@
 ---
-run_not_in_container: true
+runnning_on_server: true
 svn_users:
   kayiwa: "{{ vault_kayiwa_secret }}"
   escowles: "{{ vault_escowles_secret }}"

--- a/group_vars/patroni/postgres-staging.yml
+++ b/group_vars/patroni/postgres-staging.yml
@@ -3,7 +3,7 @@ patroni_replication_username: replicator
 patroni_replication_password: "{{ vault_repuserpasswd }}"
 patroni_superuser_username: postgres
 patroni_superuser_password: "{{ vault_patroni_postgrespasswd }}"
-run_not_in_container: true
+runnning_on_server: true
 patroni_consul_host: "lib-consul-staging1.princeton.edu:{{ patroni_consul_port | default(8500) }}"
 patroni_consul_dc: "diglib-staging"
 patroni_dcs_exists: true

--- a/molecule/default/playbooks.yml
+++ b/molecule/default/playbooks.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - passenger_listen_port: '8080'
     - apache_listen_port: '8081'
     - directory_options: '+Multiviews'

--- a/playbooks/libwww-prod.yml
+++ b/playbooks/libwww-prod.yml
@@ -3,7 +3,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
     - force_settings: true
     - drupal_git_repo: ''
   vars_files:

--- a/playbooks/libwww-staging.yml
+++ b/playbooks/libwww-staging.yml
@@ -3,7 +3,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
     - force_settings: true
     - drupal_git_repo: ''
   vars_files:

--- a/playbooks/locator-prod.yml
+++ b/playbooks/locator-prod.yml
@@ -3,7 +3,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
   vars_files:
     - ../group_vars/locator/locator-prod.yml
     - ../group_vars/locator/vault.yml

--- a/playbooks/locator-staging.yml
+++ b/playbooks/locator-staging.yml
@@ -3,7 +3,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
   vars_files:
     - ../group_vars/locator/locator-staging.yml
     - ../group_vars/locator/vault.yml

--- a/playbooks/pas-production-code.yml
+++ b/playbooks/pas-production-code.yml
@@ -9,7 +9,7 @@
   vars:
     pas_upload_path: 'pas/pas-production'
     force_pas_deploy: true
-    run_not_in_container: true
+    runnning_on_server: true
     # Change this to true to force an mysql import
     force_pas_sql_import: false
   roles:

--- a/playbooks/pas-production.yml
+++ b/playbooks/pas-production.yml
@@ -7,7 +7,7 @@
     - ../group_vars/pas/vault.yml
   vars:
     - pas_upload_path: 'pas/pas-production'
-    - run_not_in_container: true
+    - runnning_on_server: true
   pre_tasks:
     - set_fact:
         deploy_id_rsa_private_key: "{{  lookup('file', '../roles/pulibrary.pas_code/files/id_rsa')  }}\n"

--- a/playbooks/pas-staging-code.yml
+++ b/playbooks/pas-staging-code.yml
@@ -10,7 +10,7 @@
     force_pas_deploy: true
     # Change this to true to force an mysql import
     force_pas_sql_import: false
-    run_not_in_container: true
+    runnning_on_server: true
   roles:
     - role: roles/pulibrary.pas_code
   pre_tasks:

--- a/playbooks/pas-staging.yml
+++ b/playbooks/pas-staging.yml
@@ -6,7 +6,7 @@
     - ../group_vars/pas/pas-staging.yml
     - ../group_vars/pas/vault.yml
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
   pre_tasks:
     - set_fact:
         deploy_id_rsa_private_key: "{{  lookup('file', '../roles/pulibrary.pas_code/files/id_rsa')  }}\n"

--- a/playbooks/patroni-staging.yml
+++ b/playbooks/patroni-staging.yml
@@ -6,7 +6,7 @@
     - ../group_vars/patroni/postgres-staging.yml
     - ../group_vars/patroni/vault.yml
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
   roles:
     - role: roles/pulibrary.patroni
   post_tasks:

--- a/playbooks/perconadbcluster.yml
+++ b/playbooks/perconadbcluster.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   become: true
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.perconaxdb
       xtradb_cluster_name: "pulibrary-cluster"

--- a/playbooks/recap-production.yml
+++ b/playbooks/recap-production.yml
@@ -3,7 +3,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
     - force_settings: true
     - drupal_git_repo: ''
   vars_files:

--- a/playbooks/recap-staging.yml
+++ b/playbooks/recap-staging.yml
@@ -3,7 +3,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
     - force_settings: true
     - drupal_git_repo: ''
   vars_files:

--- a/roles/pulibrary.approvals/molecule/default/playbook.yml
+++ b/roles/pulibrary.approvals/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - passenger_listen_port: '8080'
     - rails_app_directory: 'approvals'
     - rails_app_name: 'approvals'

--- a/roles/pulibrary.approvals/tasks/main.yml
+++ b/roles/pulibrary.approvals/tasks/main.yml
@@ -10,7 +10,7 @@
   copy:
     src: files/approvals.smb.credentials
     dest: /etc/approvals.smb.credentials
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Create mount for pas shared files
   mount:
@@ -19,7 +19,7 @@
     fstype: cifs
     opts: 'defaults,uid=33,gid={{ deploy_user_uid }},credentials=/etc/approvals.smb.credentials'
     state: mounted
-  when: run_not_in_container
+  when: runnning_on_server
   become: true
 
 - name: Download node apt update script

--- a/roles/pulibrary.archivesspace/molecule/default/playbook.yml
+++ b/roles/pulibrary.archivesspace/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
     - db_host: "localhost"

--- a/roles/pulibrary.bibdata/defaults/main.yml
+++ b/roles/pulibrary.bibdata/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-run_not_in_container: false
+runnning_on_server: false
 bibdata_db_host: '{{ maria_db_cluster_host | default("localhost")}}'

--- a/roles/pulibrary.bibdata/molecule/default/playbook.yml
+++ b/roles/pulibrary.bibdata/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - samba_status: client
     - samba_shares_root: /data
     - xtradb_nodes_group: "all"

--- a/roles/pulibrary.bibdata/tasks/main.yml
+++ b/roles/pulibrary.bibdata/tasks/main.yml
@@ -5,10 +5,10 @@
     state: present
 
 - include: samba_server.yml
-  when: samba_status == 'server' and run_not_in_container
+  when: samba_status == 'server' and runnning_on_server
 
 - include: samba_client.yml
-  when: samba_status == 'client' and run_not_in_container
+  when: samba_status == 'client' and runnning_on_server
 
 - include: local_mariadb.yml
   when: bibdata_db_host == 'localhost'

--- a/roles/pulibrary.bind9/defaults/main.yml
+++ b/roles/pulibrary.bind9/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-run_not_in_container: false
+runnning_on_server: false

--- a/roles/pulibrary.bind9/molecule/default/playbook.yml
+++ b/roles/pulibrary.bind9/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.bind9

--- a/roles/pulibrary.bind9/tasks/main.yml
+++ b/roles/pulibrary.bind9/tasks/main.yml
@@ -18,7 +18,7 @@
     dest: "/etc/resolv.conf"
     state: absent
     regexp: '.*nameserver.*'
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Use dns forwarder nameserver
   lineinfile:
@@ -27,7 +27,7 @@
     line: 'nameserver 128.112.200.253'
   notify:
     - restart bind
-  when: run_not_in_container
+  when: runnning_on_server
 
 #
 # End - untested

--- a/roles/pulibrary.cantaloupe/handlers/main.yml
+++ b/roles/pulibrary.cantaloupe/handlers/main.yml
@@ -3,4 +3,4 @@
   service:
     name: cantaloupe
     state: restarted
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.cantaloupe/molecule/default/playbook.yml
+++ b/roles/pulibrary.cantaloupe/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - cantaloupe_user: deploy
     - cantaloupe_group: deploy
   roles:

--- a/roles/pulibrary.cantaloupe/tasks/install.yml
+++ b/roles/pulibrary.cantaloupe/tasks/install.yml
@@ -54,7 +54,7 @@
   template:
     src: cantaloupe.service.j2
     dest: /etc/systemd/system/cantaloupe.service
-  when: run_not_in_container
+  when: runnning_on_server
   notify: restart cantaloupe
 
 - name: Keep cantaloupe running
@@ -62,4 +62,4 @@
     name: cantaloupe
     enabled: true
     state: started
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.consul/handlers/main.yml
+++ b/roles/pulibrary.consul/handlers/main.yml
@@ -4,4 +4,4 @@
   systemd:
     name: consul
     state: restarted
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.consul/molecule/default/playbook.yml
+++ b/roles/pulibrary.consul/molecule/default/playbook.yml
@@ -12,7 +12,7 @@
         gather_subset:
           - network
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - consul_nodename: inventory
   roles:
     - role: pulibrary.consul

--- a/roles/pulibrary.consul/tasks/config.yml
+++ b/roles/pulibrary.consul/tasks/config.yml
@@ -12,7 +12,7 @@
     src: "{{ consul_logrotate_template_path }}"
     dest: /etc/logrotate.d/consul
     mode: 0644
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: copy consul.service file
   template:

--- a/roles/pulibrary.consul/tasks/service.yml
+++ b/roles/pulibrary.consul/tasks/service.yml
@@ -5,4 +5,4 @@
     enabled: true
     daemon_reload: true
     state: started
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.deploy-user/README.md
+++ b/roles/pulibrary.deploy-user/README.md
@@ -16,7 +16,7 @@ Example Playbook
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: true
+    - runnning_on_server: true
     - generic_app_user: 'aspace'
   roles:
     - role: pulibrary.deploy-user

--- a/roles/pulibrary.deploy-user/defaults/main.yml
+++ b/roles/pulibrary.deploy-user/defaults/main.yml
@@ -4,4 +4,4 @@ deploy_ssh_users: []
 deploy_user_uid: '{{ user_uid | default("1001") }}'
 deploy_user_shell: /bin/bash
 deploy_id_rsa_private_key: 'bogus_rsa_key'
-run_not_in_container: false
+runnning_on_server: false

--- a/roles/pulibrary.deploy-user/molecule/default/playbook.yml
+++ b/roles/pulibrary.deploy-user/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.deploy-user

--- a/roles/pulibrary.deploy-user/tasks/main.yml
+++ b/roles/pulibrary.deploy-user/tasks/main.yml
@@ -56,7 +56,7 @@
     owner: "{{ deploy_user }}"
     group: "{{ deploy_user }}"
     mode: 0700
-  when: not run_not_in_container
+  when: not runnning_on_server
 
 - name: Install deploy github key
   copy:
@@ -65,7 +65,7 @@
     owner: "{{ deploy_user }}"
     group: "{{ deploy_user }}"
     mode: 0600
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Install deploy github ssh config
   copy:

--- a/roles/pulibrary.drupal/molecule/default/playbook.yml
+++ b/roles/pulibrary.drupal/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - drupal_db_user: 'drupal'
     - drupal_db_name: 'drupal'
     - drupal_db_password: 'drupal'

--- a/roles/pulibrary.drupal/tasks/main.yml
+++ b/roles/pulibrary.drupal/tasks/main.yml
@@ -44,7 +44,7 @@
     clone: true
     update: true
   become: true
-  when: run_not_in_container and (drupal_git_repo is defined) and (drupal_git_repo)
+  when: runnning_on_server and (drupal_git_repo is defined) and (drupal_git_repo)
 
 - name: grant permissions on deploy user
   file:
@@ -116,7 +116,7 @@
   copy: src=files/{{ item }} dest=/etc/{{ item }}
   with_items:
     - drupalweb.smb.credentials
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Mount Drupal fileshare
   mount:
@@ -126,7 +126,7 @@
     opts: 'credentials=/etc/drupalweb.smb.credentials,gid={{ deploy_user_uid }},uid=33,file_mode=0777'
     state: mounted
   become: true
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Create directory for drush site alias
   file:
@@ -164,7 +164,7 @@
     state: present
     update_cache: true
   changed_when: false
-  when: not run_not_in_container
+  when: not runnning_on_server
 
 - name: Install php7.2 requirements for libwww
   apt:

--- a/roles/pulibrary.dspace/molecule/default/playbook.yml
+++ b/roles/pulibrary.dspace/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - deploy_user: 'deploy'
   roles:
     - role: pulibrary.dspace

--- a/roles/pulibrary.dspace/tasks/apache_ant_install.yml
+++ b/roles/pulibrary.dspace/tasks/apache_ant_install.yml
@@ -7,7 +7,7 @@
     name: ["ant"]
     state: present
     update_cache: true
-  when: run_not_in_container
+  when: runnning_on_server
 #
 # End - untested
 #####

--- a/roles/pulibrary.dspace/tasks/maven_install.yml
+++ b/roles/pulibrary.dspace/tasks/maven_install.yml
@@ -7,7 +7,7 @@
     name: ["maven"]
     state: present
     update_cache: true
-  when: run_not_in_container
+  when: runnning_on_server
 #
 # End - untested
 #####

--- a/roles/pulibrary.figgy_pubsub_worker/molecule/default/playbook.yml
+++ b/roles/pulibrary.figgy_pubsub_worker/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.figgy_pubsub_worker

--- a/roles/pulibrary.figgy_pubsub_worker/tasks/main.yml
+++ b/roles/pulibrary.figgy_pubsub_worker/tasks/main.yml
@@ -5,14 +5,14 @@
     src: pubsub.service
     dest: /etc/systemd/system/figgy-pubsub-worker.service
   notify: 'restart pubsub worker'
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Keep pubsub worker running
   service:
     name: figgy-pubsub-worker
     enabled: true
     state: started
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Allow deploy user to restart worker
   lineinfile:

--- a/roles/pulibrary.geoserver/defaults/main.yml
+++ b/roles/pulibrary.geoserver/defaults/main.yml
@@ -6,4 +6,4 @@ geoserver_file: "geoserver-{{ geoserver_version }}-war.zip"
 postgresql_apt_key_id: ACCC4CF8
 postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 postgresql_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ansible_distribution_release}}-pgdg main {{postgresql_version}}'
-run_not_in_container: true
+runnning_on_server: true

--- a/roles/pulibrary.geoserver/molecule/default/playbook.yml
+++ b/roles/pulibrary.geoserver/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.geoserver

--- a/roles/pulibrary.geoserver/tasks/main.yml
+++ b/roles/pulibrary.geoserver/tasks/main.yml
@@ -54,5 +54,5 @@
       link: '/var/lib/tomcat8/webapps/geoserver/data/figgy_geo_data'
     - src: '/mnt/libimages2/data/jp2s/plum_prod'
       link: '/var/lib/tomcat8/webapps/geoserver/data/plum_prod'
-  when: run_not_in_container
+  when: runnning_on_server
   changed_when: false

--- a/roles/pulibrary.lib-svn/handlers/main.yml
+++ b/roles/pulibrary.lib-svn/handlers/main.yml
@@ -5,4 +5,4 @@
     name: svnserve
     enabled: true
     state: restarted
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.lib-svn/molecule/default/playbook.yml
+++ b/roles/pulibrary.lib-svn/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - sallysecret: "{{ vault_sally_password | default('change_me') }}"
   vars_files:
     - ../../defaults/main.yml

--- a/roles/pulibrary.lib-svn/tasks/main.yml
+++ b/roles/pulibrary.lib-svn/tasks/main.yml
@@ -43,12 +43,12 @@
     dest: /etc/systemd/system/svnserve.service
     owner: root
     group: root
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: make systemd re-read itself
   systemd:
     daemon_reload: true
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: copy svnserve config file
   copy:

--- a/roles/pulibrary.libwww/molecule/default/playbook.yml
+++ b/roles/pulibrary.libwww/molecule/default/playbook.yml
@@ -11,7 +11,7 @@
       gather_subset:
         - network
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
     - mariadb_server__root_password: "{{ vault_maridb_password | default('change_me') }}"

--- a/roles/pulibrary.locator/molecule/default/playbook.yml
+++ b/roles/pulibrary.locator/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   vars_files:
     - ../../defaults/mariadb.yml
   roles:

--- a/roles/pulibrary.locator/tasks/main.yml
+++ b/roles/pulibrary.locator/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: Copy smb credentials
   copy: src=files/locator.smb.credentials dest=/etc/locator.smb.credentials
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Mount Drupal fileshare
   mount:
@@ -46,4 +46,4 @@
     opts: 'credentials=/etc/locator.smb.credentials,gid={{ deploy_user_uid }},uid=33,file_mode=0777'
     state: mounted
   become: true
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.nginxplus/defaults/main.yml
+++ b/roles/pulibrary.nginxplus/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-run_not_in_container: true
+runnning_on_server: true
 # Install NGINX.
 # Default is true.
 nginx_enable: true

--- a/roles/pulibrary.nginxplus/molecule/default/playbook.yml
+++ b/roles/pulibrary.nginxplus/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.nginxplus

--- a/roles/pulibrary.nginxplus/tasks/localhost.yml
+++ b/roles/pulibrary.nginxplus/tasks/localhost.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: nginx
     group: nginx
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: add template error file
   copy:
@@ -13,4 +13,4 @@
     dest: "/var/local/www/default/error.html"
     owner: nginx
     group: nginx
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.pas/defaults/main.yml
+++ b/roles/pulibrary.pas/defaults/main.yml
@@ -8,7 +8,7 @@ pas_db_password: '{{ pas_password | default("change_this") }}'
 pas_server_name: '{{ application_server | default("localhost") }}'
 pas_site_url: '{{ application_site_url | default("http://localhost:8484") }}'
 pas_base_url: '{{ application_base_url | default("http://localhost:8484") }}'
-run_not_in_container: true
+runnning_on_server: true
 db_port: 3306
 apache:
     docroot: '{{ apache_app_path }}'

--- a/roles/pulibrary.pas/molecule/default/playbook.yml
+++ b/roles/pulibrary.pas/molecule/default/playbook.yml
@@ -11,7 +11,7 @@
       gather_subset:
         - network
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
   roles:

--- a/roles/pulibrary.pas/tasks/main.yml
+++ b/roles/pulibrary.pas/tasks/main.yml
@@ -43,7 +43,7 @@
   copy:
     src: files/pas.smb.credentials
     dest: /etc/pas.smb.credentials
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Create mount for pas shared files
   mount:
@@ -52,4 +52,4 @@
     fstype: cifs
     opts: 'defaults,uid=33,gid={{ deploy_user_uid }},credentials=/etc/pas.smb.credentials'
     state: mounted
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.pas_code/README.md
+++ b/roles/pulibrary.pas_code/README.md
@@ -42,7 +42,7 @@ passed in as parameters) is always nice for users too:
 
     - hosts: servers
       vars:
-        - run_not_in_container: true # needed to force the docker samba items to run
+        - runnning_on_server: true # needed to force the docker samba items to run
       roles:
         - role: roles/pulibrary.pas
         - role: roles/pulibrary.pas_code

--- a/roles/pulibrary.pas_code/defaults/main.yml
+++ b/roles/pulibrary.pas_code/defaults/main.yml
@@ -17,7 +17,7 @@ db_port: 3306
 deploy_user: "deploy"
 force_pas_deploy: false
 force_pas_sql_import: false
-run_not_in_container: false
+runnning_on_server: false
 pas_upload_path: 'pas/pas-staging'
 apache:
     docroot: '{{apache_app_path}}'

--- a/roles/pulibrary.pas_code/molecule/default/playbook.yml
+++ b/roles/pulibrary.pas_code/molecule/default/playbook.yml
@@ -11,7 +11,7 @@
       gather_subset:
         - network
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
     - force_pas_deploy: false

--- a/roles/pulibrary.pas_code/tasks/main.yml
+++ b/roles/pulibrary.pas_code/tasks/main.yml
@@ -15,7 +15,7 @@
   become: true
   when:
     - deploy_ssh_config.diff == [] or force_pas_deploy
-    - run_not_in_container
+    - runnning_on_server
 
 - name: Create the pas directory for docker
   file:
@@ -33,13 +33,13 @@
     - '/opt/pas/web/cpresources'
   when:
     - deploy_ssh_config.diff == []
-    - not run_not_in_container
+    - not runnning_on_server
 
 - name: Install the license key
   copy:
     src: files/license.key
     dest: /opt/pas/config/license.key
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: change permissions of all files recursively
   file:
@@ -111,7 +111,7 @@
   with_items:
     - src: '/mnt/diglibdata1/{{ pas_upload_path }}'
       link: '/opt/pas/web/uploads'
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Migrate craft
   become: true
@@ -122,4 +122,4 @@
   with_items:
     - 'migrate/all'
     - 'project-config/sync'
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.patroni/defaults/main.yml
+++ b/roles/pulibrary.patroni/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for roles/pulibrary.patroni
-run_not_in_container: true
+runnning_on_server: true
 patroni_postgresql_version: 12
 patroni_postgresql_exists: false
 

--- a/roles/pulibrary.patroni/handlers/main.yml
+++ b/roles/pulibrary.patroni/handlers/main.yml
@@ -8,14 +8,14 @@
     enabled: yes
   notify:
     - restart watchdog
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: restart watchdog
   systemd:
     name: watchdog
     state: restarted
     enabled: yes
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: restart patroni
   systemd:
@@ -23,4 +23,4 @@
     state: restarted
     daemon_reload: yes
     enabled: yes
-  when: run_not_in_container
+  when: runnning_on_server

--- a/roles/pulibrary.patroni/molecule/default/playbook.yml
+++ b/roles/pulibrary.patroni/molecule/default/playbook.yml
@@ -14,7 +14,7 @@
   vars_files:
     - molecule_vars.yml
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - consul_nodename: inventory
   roles:
     - role: pulibrary.patroni

--- a/roles/pulibrary.patroni/tasks/main.yml
+++ b/roles/pulibrary.patroni/tasks/main.yml
@@ -14,7 +14,7 @@
     state: started
     daemon_reload: true
     enabled: true
-  when: run_not_in_container
+  when: runnning_on_server
   tags: [patroni]
 
 - import_tasks: manage_users.yml

--- a/roles/pulibrary.patroni/tasks/manage_users.yml
+++ b/roles/pulibrary.patroni/tasks/manage_users.yml
@@ -18,7 +18,7 @@
     label: "{{ item.name }}"
   when:
     - postgres_databases is defined
-    - run_not_in_container
+    - runnning_on_server
 
 - name: create postgres users
   postgresql_user:
@@ -30,6 +30,6 @@
     - "{{ postgres_users }}"
   when:
     - postgres_users is defined
-    - run_not_in_container
+    - runnning_on_server
   become_user: postgres
   become: true

--- a/roles/pulibrary.patroni/tasks/watchdog.yml
+++ b/roles/pulibrary.patroni/tasks/watchdog.yml
@@ -13,7 +13,7 @@
     mode: 0644
   notify:
     - restart patroni-watchdog
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Enable watchdog daemon to start on boot
   file:

--- a/roles/pulibrary.perconaxdb/README.md
+++ b/roles/pulibrary.perconaxdb/README.md
@@ -81,7 +81,7 @@ Migrating your role's database from the MariaDB cluster to Percona
           gather_subset:
             - network
       vars:
-        - run_not_in_container: false
+        - runnning_on_server: false
         - xtradb_nodes_group: "all"
         - xtradb_leader_node: "instance"
       roles:

--- a/roles/pulibrary.perconaxdb/defaults/main.yml
+++ b/roles/pulibrary.perconaxdb/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for roles/pulibrary.perconaxdb
 #
-run_not_in_container: false
+runnning_on_server: false
 mysql_port: 3306
 mysql_language: '/usr/share/mysql/'
 mysql_bind_address: "0.0.0.0"

--- a/roles/pulibrary.perconaxdb/molecule/default/playbook.yml
+++ b/roles/pulibrary.perconaxdb/molecule/default/playbook.yml
@@ -11,7 +11,7 @@
       gather_subset:
         - network
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
   roles:

--- a/roles/pulibrary.perconaxdb/tasks/bootstrap.yml
+++ b/roles/pulibrary.perconaxdb/tasks/bootstrap.yml
@@ -11,7 +11,7 @@
     owner: root
     group: root
     mode: 0644
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Configure swappiness
   sysctl:
@@ -38,7 +38,7 @@
     password: "{{ xtradb_sst_password }}"
     priv: "*.*:grant,reload,lock tables,process,replication client"
   when:
-    - run_not_in_container
+    - runnning_on_server
     - xtradb_bind_address == xtradb_leader_node
 
 - name: Start the follower nodes
@@ -46,7 +46,7 @@
     name: "{{ xtradb_service }}"
     state: started
   when:
-    - run_not_in_container
+    - runnning_on_server
     - xtradb_bind_address != xtradb_leader_node
 
 - name: Marking as configured

--- a/roles/pulibrary.perconaxdb/tasks/setup_install.yml
+++ b/roles/pulibrary.perconaxdb/tasks/setup_install.yml
@@ -22,9 +22,9 @@
     name: "{{ xtradb_service }}"
     state: started
     enabled: true
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: reload systemd
   command: systemctl daemon-reload
-  when: run_not_in_container
+  when: runnning_on_server
   ignore_errors: true

--- a/roles/pulibrary.rails-app/defaults/main.yml
+++ b/roles/pulibrary.rails-app/defaults/main.yml
@@ -6,4 +6,4 @@ rails_app_symlinks: []
 rails_app_dependencies: []
 rails_app_vars: []
 rails_app_env: "staging"
-run_not_in_container: true
+runnning_on_server: true

--- a/roles/pulibrary.rails-app/molecule/default/playbook.yml
+++ b/roles/pulibrary.rails-app/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - passenger_listen_port: '8080'
   roles:
     - role: pulibrary.rails-app

--- a/roles/pulibrary.recap-www/molecule/default/playbook.yml
+++ b/roles/pulibrary.recap-www/molecule/default/playbook.yml
@@ -11,7 +11,7 @@
       gather_subset:
         - network
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
   roles:

--- a/roles/pulibrary.redis/molecule/default/playbook.yml
+++ b/roles/pulibrary.redis/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.redis

--- a/roles/pulibrary.sidekiq_worker/defaults/main.yml
+++ b/roles/pulibrary.sidekiq_worker/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for pulibrary.sidekiq_worker
-run_not_in_container: false
+runnning_on_server: false
 sidekiq_worker_threads: 5
 sidekiq_worker_queues:
   - default

--- a/roles/pulibrary.sidekiq_worker/molecule/default/playbook.yml
+++ b/roles/pulibrary.sidekiq_worker/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.sidekiq_worker

--- a/roles/pulibrary.sidekiq_worker/tasks/main.yml
+++ b/roles/pulibrary.sidekiq_worker/tasks/main.yml
@@ -10,7 +10,7 @@
     name: "{{ sidekiq_worker_name }}"
     enabled: true
     state: started
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Allow deploy user to restart workers
   lineinfile:

--- a/roles/pulibrary.sneakers_worker/defaults/main.yml
+++ b/roles/pulibrary.sneakers_worker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for pulibrary.sneakers_worker
-run_not_in_container: false
+runnning_on_server: false
 sneakers_worker_name: sneakers
 sneakers_workers:

--- a/roles/pulibrary.sneakers_worker/molecule/default/playbook.yml
+++ b/roles/pulibrary.sneakers_worker/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
   roles:
     - role: pulibrary.sneakers_worker

--- a/roles/pulibrary.sneakers_worker/tasks/main.yml
+++ b/roles/pulibrary.sneakers_worker/tasks/main.yml
@@ -10,7 +10,7 @@
     name: "{{ sneakers_worker_name }}"
     enabled: true
     state: started
-  when: run_not_in_container
+  when: runnning_on_server
 
 - name: Allow deploy user to restart workers
   lineinfile:

--- a/roles/pulibrary.zookeeper/molecule/default/playbook.yml
+++ b/roles/pulibrary.zookeeper/molecule/default/playbook.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    - run_not_in_container: false
+    - runnning_on_server: false
     - zookeeper_hosts: "all"
     - lib_zk1_host_name: "instance"
   roles:

--- a/roles/pulibrary.zookeeper/tasks/service.yml
+++ b/roles/pulibrary.zookeeper/tasks/service.yml
@@ -5,4 +5,4 @@
     state: "{{ zookeeper_service_state }}"
     enabled: "{{ zookeeper_service_enabled }}"
     daemon_reload: true
-  when: run_not_in_container
+  when: runnning_on_server


### PR DESCRIPTION
Renames `run_not_in_containter` to `running_on_server for clarity` on when it should be true and when it should be false.
True if you are running on a server, false if you are running in a container (any molecule playbook).
fixes #643

@hackmastera & @jrgriffiniii I know we discussed `run_on_server_only` but when I read the tasks and vars I though `running_on_server` sounded better.  
For example: `when: run_on_server_only` vs `when: running_on_server`