### PR TITLE
Added host and password variables for the privileges to be created correctly

### DIFF
--- a/roles/pulibrary.mariadb/tasks/manage_contents.yml
+++ b/roles/pulibrary.mariadb/tasks/manage_contents.yml
@@ -85,6 +85,7 @@
     login_user: 'root'
     state: 'present'
     password: "{{ item.password }}"
+    host: '{{ item.host | default(omit) }}'
   with_flattened: "{{ mariadb__users + mariadb__dependent_users + mariadb_userss|d([]) }}"
   register: mariadb__register_create_users
   when: ((item.user|d(False) or item.name|d(False)) and
@@ -97,6 +98,8 @@
     login_host: '{{ db_host | default(omit) }}'
     login_password: '{{ db_password | default(omit) }}'
     login_user: 'root'
+    host: '{{ item.host | default(omit) }}'
+    password: '{{ item.password  | default(omit)}}'
     priv: '{{ item.priv | d((item.database | d(item.name)) + ".*:" + mariadb__default_privileges_grant) }}'
     append_privs: true
   with_flattened: "{{ mariadb__users + mariadb__dependent_users + mariadb_userss|d([]) }}"


### PR DESCRIPTION
@kayiwa I had issues running my mudd production playbook.  It created me some really strange users without the host and password. (Note the host of localhost and the blank password)
```
| localhost                      | mudd-prod                             | *29852FB89EEA52B876EF38AF364A792255EB2F5B |
| %                              | mudd-prod                             |                                           |
```
I'm not entirely certain why the host line was removed, so this may break something else, although I did include the default to omit, which should make it work for a item that does not have a host or a password.
