### PR TITLE
Changing to master as running_version no longer exists

### DIFF
--- a/roles/pulibrary.pas_code/tasks/main.yml
+++ b/roles/pulibrary.pas_code/tasks/main.yml
@@ -11,7 +11,7 @@
     clone: true
     update: true
     force: true
-    version: 'running_version'
+    version: 'master'
   become: true
   when:
     - deploy_ssh_config.diff == [] or force_pas_deploy


### PR DESCRIPTION
In a previous the version was changed to master and then got reset to running_version.  This just sets it back to the right version.

@kayiwa I'm tagging you on this, because the Percona PR changed this, and I want to be certain there was really no reason to.