### PR TITLE
make string declaration explicit

### DIFF
--- a/roles/pulibrary.blacklight-app/tasks/main.yml
+++ b/roles/pulibrary.blacklight-app/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Create the cron job
   cron:
     name: Clean old Blacklight searches and Devise guest user accounts nightly
-    hour: 22
+    hour: "22"
     job: "/bin/bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && cd /opt/{{ rails_app_directory }}/current && bundle exec rake blacklight:delete_old_searches >> /tmp/guests_searches.log 2>&1 && bundle exec rake devise_guests:delete_old_guest_users >> /tmp/guests_searches.log 2>&1'"
-    minute: 0
+    minute: "0"
     user: '{{ deploy_user }}'


### PR DESCRIPTION
master branch was broken for nodejs, but there isn't a way (AFAICT) to re-run a specific failed role once it is cached. So making a change that will force the nodejs to re-run. 