### PR TITLE
Allows redirect of base url also

### DIFF
--- a/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -3,5 +3,7 @@
     rewrite ^/special_collections/mudd-dbs/(.*)$ https://lib-mudd-staging.princeton.edu/$1 redirect;
     rewrite ^/mudd-dbs/(.*)$ https://lib-mudd-staging.princeton.edu/$1 redirect;
 
+    rewrite ^/republic https://republic-staging.princeton.edu redirect;
     rewrite ^/republic/(.*)$ https://republic-staging.princeton.edu/$1 redirect;
     rewrite ^/firestone/renovations/(.*)$ https://firestone-renovations-staging.princeton.edu/$1 redirect;
+    rewrite ^/firestone/renovations https://firestone-renovations-staging.princeton.edu redirect;


### PR DESCRIPTION
Currently https://library-staging.princeton.edu/republic & https://library-staging.princeton.edu/firestone/renovations are missing, but https://library-staging.princeton.edu/firestone/renovations/ and https://library-staging.princeton.edu/republic/ respond.
Adding additional redirect so the base url will redirect.