### PR TITLE
try 2gb of heap memory for solr staging cloud nodes

### DIFF
--- a/group_vars/solrcloud_staging.yml
+++ b/group_vars/solrcloud_staging.yml
@@ -1,5 +1,5 @@
 ---
-solr_heap_setting: '18g'
+solr_heap_setting: '2g'
 solr_cloud_download_version: 7.7.2
 solr_log4j_path: '/solr/log4j2.xml'
 lib_solr1_host: '{{ vault_lib_solr_staging1_host }}'


### PR DESCRIPTION
Currently deployed. Seems pretty good so far