### PR TITLE
turning on proxy_ssl_server_name for proxy pass rules

### DIFF
--- a/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -157,3 +157,5 @@
     location /versailles {
         proxy_pass http://libphp-prod.princeton.edu/versailles/;
     }
+
+    proxy_ssl_server_name on;


### PR DESCRIPTION
Should fix `peer closed connection in SSL handshake (104: Connection reset by peer) while SSL handshaking to upstream`