### PR TITLE
Fixing up the solr role to work with pul_solr repo

### DIFF
--- a/roles/pulibrary.solr/defaults/main.yml
+++ b/roles/pulibrary.solr/defaults/main.yml
@@ -5,11 +5,18 @@ solr_workspace: /root
 solr_filename: "solr-{{ solr_version }}"
 
 solr_create_user: true
-solr_user: solr
+solr_user: deploy
+solr_group: deploy
 
 solr_version: "7.7.2"
 solr_mirror: "http://lib-solr-mirror.princeton.edu/dist"
 solr_remove_cruft: false
+
+# Files & Paths
+solr_log4j: "{{ solr_log4j_path | default('/solr/log4j.properties') }}"
+solr_log_dir: /solr/logs
+solr_home: /solr
+solr_data_dir: '{{ solr_home }}/data'
 
 solr_service_manage: true
 solr_service_name: solr
@@ -17,7 +24,6 @@ solr_service_state: started
 
 solr_install_dir: /opt
 solr_install_path: "/opt/{{ solr_service_name }}"
-solr_home: "/var/{{ solr_service_name }}"
 solr_connect_host: localhost
 solr_port: "8983"
 
@@ -34,6 +40,4 @@ solr_config_file: /etc/default/{{ solr_service_name }}.in.sh
 # Enable restart solr handler
 solr_restart_handler_enabled: true
 
-# Used only for Solr < 5.
-solr_log_file_path: /var/log/solr.log
 solr_host: "0.0.0.0"

--- a/roles/pulibrary.solr/molecule/default/tests/test_default.py
+++ b/roles/pulibrary.solr/molecule/default/tests/test_default.py
@@ -7,12 +7,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts('all')
 
 
-def test_hosts_file(host):
-    f = host.file('/etc/hosts')
+def test_solr_directory_ownership(host):
+    f = host.file('/solr')
 
     assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
+    assert f.user == 'deploy'
+    assert f.group == 'deploy'
 
 
 def test_solr_running(host):

--- a/roles/pulibrary.solr/tasks/user.yml
+++ b/roles/pulibrary.solr/tasks/user.yml
@@ -7,3 +7,13 @@
     name: "{{ solr_user }}"
     state: present
     group: "{{ solr_user }}"
+
+- name: create solr dirs
+  file:
+    path: '{{ item }}'
+    state: directory
+    owner: '{{ solr_user }}'
+    group: '{{ solr_group }}'
+  with_items:
+    - '{{ solr_log_dir }}'
+    - '{{ solr_data_dir }}'


### PR DESCRIPTION
we no longer use solr versions below 5
in addition switch the default user from solr to deploy.
create the solr directory
instead of the /var/solr use for consistency with the solr-cloud role
make sure the deploy user owns
the solr directory.
this closes issue #1119

Co-authored-by: Carolyn Cole <cac9@princeton.edu>