### PR TITLE
Drupal cron needs to run every hour.

### DIFF
--- a/roles/pulibrary.lib-jobs/vars/main.yml
+++ b/roles/pulibrary.lib-jobs/vars/main.yml
@@ -6,7 +6,7 @@ rails_app_vars:
   - name: SFX_PORT
     value: '{{ vault_sfx_port | default("port") }}'
   - name: SFX_USER
-    value: '{{ vault_sfx_user | default("user") }}' 
+    value: '{{ vault_sfx_user | default("user") }}'
   - name: SFX_PASS
     value: '{{ vault_sfx_pass | default("pass") }}'
   - name: SFX_GLOBAL_DATABASE

--- a/roles/pulibrary.libwww/molecule/default/tests/test_libwww.py
+++ b/roles/pulibrary.libwww/molecule/default/tests/test_libwww.py
@@ -46,9 +46,9 @@ def test_for_libwww_sudoer(host, line):
 
 
 @pytest.mark.parametrize("line",
-                         ["0 5 * * * sudo -u www-data drush @prod cron",
+                         ["0 * * * * sudo -u www-data drush @prod cron",
                           "0 7 * * * /usr/bin/get_staff_updates.sh >/tmp/staff_updates.out 2>&1",
-                          "0 6 * * * sudo -u www-data drush -r /var/www/special_collections_cap/current cron"
+                          "10 * * * * sudo -u www-data drush -r /var/www/special_collections_cap/current cron"
                           ])
 def test_for_libwww_crontab(host, line):
     cmd = host.run("crontab -l -u deploy")

--- a/roles/pulibrary.libwww/tasks/main.yml
+++ b/roles/pulibrary.libwww/tasks/main.yml
@@ -80,7 +80,6 @@
   cron:
     name: "run drush cron"
     minute: 0
-    hour: 5
     job: "sudo -u www-data drush @prod cron"
     user: "{{ deploy_user }}"
   when: (inventory_hostname ==  groups[group_names[0]][0])
@@ -160,8 +159,7 @@
 - name: install the cron for running drush cron for special collections
   cron:
     name: "run special collections drush cron"
-    minute: 0
-    hour: 6
+    minute: 10
     job: "sudo -u www-data drush -r {{ special_collections_drupal_docroot }}/current cron"
     user: "{{ deploy_user }}"
   when: inventory_hostname ==  groups[group_names[0]][0]


### PR DESCRIPTION
Drupal's cron should run every hour. On libwww the production site will now run at the top of every hour with special collections following at 10 minutes after. 