### PR TITLE
[WIP] Updating the NodeJS release to 12.x versions

### DIFF
--- a/roles/pulibrary.nodejs/defaults/main.yml
+++ b/roles/pulibrary.nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nodejs__upstream_release: 'node_8.x'
+nodejs__upstream_release: 'node_12.x'
 nodejs__upstream_key_id: '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280'
 
 # URL of the NodeSource APT repository in ``sources.list`` format.


### PR DESCRIPTION
Advances #1154 by setting 12.x as the default release for NodeJS