### PR TITLE
Don't override default heap size for lib-solr1

### DIFF
--- a/host_vars/lib-solr1.princeton.edu.yml
+++ b/host_vars/lib-solr1.princeton.edu.yml
@@ -1,4 +1,3 @@
 ---
 solr_gc_tune: -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:-UseGCOverheadLimit
-solr_heap_setting: 40g
 solr_stack_size: 1m


### PR DESCRIPTION
This was missed when we recently decreased heap size; no reason it
should be different so removing it.