### PR TITLE
improve role documentation

### DIFF
--- a/roles/pulibrary.deploy-user/README.md
+++ b/roles/pulibrary.deploy-user/README.md
@@ -8,7 +8,7 @@ Role Variables
 
 - `generic_app_user` by default the role will install the user `deploy` unless you
 use the `-e` flag to pass a different user see the example below
-- `user_id` there are instances (usually non-virtual machines) where there are other users on a system which makes the `groupid` non-deterministic. When this fails determine what the groupid is an rerun by passing that result  :frowning_face:
+- `user_id` there are instances (usually non-virtual machines) where there are other users on a system which makes the `groupid` non-deterministic. When this fails with "GID already exists" determine what the groupid is and rerun by passing that result  :frowning_face:
 
 Find GroupID
 ------------

--- a/roles/pulibrary.deploy-user/README.md
+++ b/roles/pulibrary.deploy-user/README.md
@@ -7,7 +7,20 @@ Role Variables
 --------------
 
 - `generic_app_user` by default the role will install the user `deploy` unless you
-use the `-e` flag to pass a different user
+use the `-e` flag to pass a different user see the example below
+- `user_id` there are instances (usually non-virtual machines) where there are other users on a system which makes the `groupid` non-deterministic. When this fails determine what the groupid is an rerun by passing that result  :frowning_face:
+
+Find GroupID
+------------
+
+```bash
+user@lib-solr2:~$ cat /etc/passwd | grep deploy
+```
+pass the result of the command above to the role
+
+```bash
+ansible-playbook -e user_id=1234 playbooks/solrcloud.yml
+```
 
 Example Playbook
 ----------------


### PR DESCRIPTION
The groupid role on physical hardware is non-deterministic. Physical
hardware (a legacy problem) is not always built consistently and will on
occasion have the `systems` user in addition to the `pulsys` user and
create this problem.

This closes #1200