### PR TITLE
Add staging solr, zk, and catalog back to datadog

### DIFF
--- a/group_vars/orangelight_staging.yml
+++ b/group_vars/orangelight_staging.yml
@@ -87,3 +87,34 @@ rails_app_vars:
     value: '{{application_host_protocol}}'
 sneakers_workers: EventHandler
 sneakers_worker_name: orangelight-sneakers
+datadog_api_key: "{{vault_datadog_key}}"
+datadog_config:
+  tags: "application:orangelight, environment:staging, type:webserverj"
+  apm_enabled: "true"
+  log_enabled: true
+  process_config:
+    enabled: "true"
+  apm_config:
+    analyzed_spans:
+      orangelight|rack.request: 1
+datadog_checks:
+  ruby:
+    init_config:
+    logs:
+      - type: file
+        path: /opt/rails_app/current/log/staging.log
+        service: orangelight
+        source: ruby
+  nginx:
+    init_config:
+    logs:
+      - type: file
+        path: /var/log/nginx/access.log
+        service: orangelight
+        source: nginx
+        sourcecategory: http_web_access
+      - type: file
+        path: /var/log/nginx/error.log
+        service: orangelight
+        source: nginx
+        sourcecategory: http_web_access

--- a/group_vars/solrcloud_staging.yml
+++ b/group_vars/solrcloud_staging.yml
@@ -11,3 +11,103 @@ lib_zk3_host_name: lib-zk-staging3
 lib_zk1_host: '{{ vault_lib_zk_staging1_host }}'
 lib_zk2_host: '{{ vault_lib_zk_staging2_host }}'
 lib_zk3_host: '{{ vault_lib_zk_staging3_host }}'
+datadog_api_key: "{{vault_datadog_key}}"
+datadog_config:
+  tags: "solrcloud, environment:staging, role:solr"
+  apm_enabled: false
+  log_enabled: true
+  dogstatsd_port: 8135
+  process_config:
+    enabled: "true"
+datadog_checks:
+  solrcloud:
+    init_config:
+    logs:
+      - type: file
+        path: /solr/logs/solr.log
+        service: solr
+        source: solr
+        log_processing_rules:
+          - type: multi_line
+            name: new_log_start_with_date
+            pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+          - type: exclude_at_match
+            name: exclude_solrcloud_distrib_queries
+            pattern: distrib=false
+      - type: file
+        path: /solr/logs/solr_gc.log.0.current
+        service: solr
+        source: solr_gc
+        log_processing_rules:
+          - type: multi_line
+            name: new_log_start_with_date
+            pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+  http_check:
+    init_config:
+    instances:
+      - name: Catalog Staging
+        url: 'http://localhost:8983/solr/catalog-staging/admin/ping?wt=json&distrib=true&indent=true'
+        skip_event: true
+        tags:
+          - 'http_service:solr'
+          - 'application:orangelight'
+          - 'environment:staging'
+      - name: DPUL Staging
+        url: 'http://localhost:8983/solr/dpul-staging/admin/ping?wt=json&distrib=true&indent=true'
+        skip_event: true
+        tags:
+          - 'http_service:solr'
+          - 'application:dpul'
+          - 'environment:staging'
+  solr:
+    instances:
+      # location of tomcat
+      - host: localhost
+        port: 1099
+        conf:
+          - include:
+              category: CACHE
+              name: filterCache
+              scope:
+                - searcher
+              attribute:
+                cumulative_hitratio:
+                  alias: solr.filter_cache.cumulative_hitratio
+                  metric_type: gauge
+                cumulative_evictions:
+                  alias: solr.filter_cache.cumulative_evictions
+                  metric_type: gauge
+                size:
+                  alias: solr.filter_cache.size
+                  metric_type: gauge
+          - include:
+              category: CACHE
+              name: queryResultCache
+              scope:
+                - searcher
+              attribute:
+                cumulative_hitratio:
+                  alias: solr.query_result_cache.cumulative_hitratio
+                  metric_type: gauge
+                cumulative_evictions:
+                  alias: solr.query_result_cache.cumulative_evictions
+                  metric_type: gauge
+                size:
+                  alias: solr.query_result_cache.size
+                  metric_type: gauge
+          - include:
+              category: CACHE
+              name: documentCache
+              scope:
+                - searcher
+              attribute:
+                cumulative_hitratio:
+                  alias: solr.document_cache.cumulative_hitratio
+                  metric_type: gauge
+                cumulative_evictions:
+                  alias: solr.document_cache.cumulative_evictions
+                  metric_type: gauge
+                size:
+                  alias: solr.document_cache.size
+                  metric_type: gauge
+    init_config:

--- a/group_vars/zookeeper_staging.yml
+++ b/group_vars/zookeeper_staging.yml
@@ -1,0 +1,23 @@
+datadog_api_key: "{{vault_datadog_key}}"
+datadog_config:
+  tags: "zookeeper, env:staging, role:zookeeper"
+  apm_enabled: "false"
+  log_enabled: true
+  process_config:
+    enabled: "false"
+datadog_checks:
+  zk:
+    init_config:
+    instances:
+      - host: localhost
+        port: 2181
+    logs:
+      - type: file
+        path: /var/log/zookeeper/zookeeper.log
+        source: zookeeper
+        service: zookeeper
+          #To handle multi line that starts with yyyy-mm-dd use the following pattern
+        log_processing_rules:
+          - type: multi_line
+            name: start_with_date
+            pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])

--- a/playbooks/orangelight_staging.yml
+++ b/playbooks/orangelight_staging.yml
@@ -15,6 +15,7 @@
     - role: roles/pulibrary.extra_path
     - role: roles/pulibrary.sneakers_worker
     - role: roles/pulibrary.orangelight
+    - role: roles/pulibrary.ansible-datadog
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/solrcloud_staging.yml
+++ b/playbooks/solrcloud_staging.yml
@@ -12,3 +12,4 @@
     - role: roles/pulibrary.openjdk
     - role: roles/pulibrary.deploy-user
     - role: roles/pulibrary.solrcloud
+    - role: roles/pulibrary.ansible-datadog

--- a/playbooks/zookeeper_staging.yml
+++ b/playbooks/zookeeper_staging.yml
@@ -6,7 +6,9 @@
     - ../site_vars.yml
     - ../group_vars/solrcloud/vault.yml
     - ../group_vars/solrcloud_staging.yml
+    - ../group_vars/zookeeper_staging.yml
   roles:
     - role: roles/pulibrary.openjdk
     - role: roles/pulibrary.deploy-user
     - role: roles/pulibrary.zookeeper
+    - role: roles/pulibrary.ansible-datadog


### PR DESCRIPTION
Maybe in future we should keep the vars but switch on / off the role inclusion?

Assuming we may want to be able to add / remove these as time goes on, which
seems reasonable.