### PR TITLE
our error page should not be cached

### DIFF
--- a/roles/pulibrary.nginxplus/files/error.html
+++ b/roles/pulibrary.nginxplus/files/error.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+    <meta http-equiv="Pragma" content="no-cache"/>
+    <meta http-equiv="Expires" content="0"/>
     <title>Error | Princeton University Library</title>
     <style>
       body {


### PR DESCRIPTION
right now it waits for the health check of nginx to determine if the upstream is healthy
this change removes that