### PR TITLE
Moving approvals to ruby 2.6

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -1,5 +1,4 @@
 ---
-ruby_version: "{{ ruby_version_default }}"
 ruby_install_from_source: true
 ruby_download_url: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz
 git_packages:

--- a/group_vars/approvals/approvals_staging.yml
+++ b/group_vars/approvals/approvals_staging.yml
@@ -18,3 +18,5 @@ running_on_server: true
 install_mailcatcher: true
 mailcatcher_user: 'pulsys'
 mailcatcher_group: 'pulsys'
+ruby_version_override: "ruby2.6"
+bundler_version: '2.1.4'


### PR DESCRIPTION
I had to remove the entry in all to get the override to process.
Additionally I had to upgrade bundler to get it to point at the new ruby.

I also had to ssh onto the box and restart nginx.