### PR TITLE
psql client required to load ol browse lists

### DIFF
--- a/group_vars/orangelight_workers.yml
+++ b/group_vars/orangelight_workers.yml
@@ -8,6 +8,7 @@ rails_app_dependencies:
   - libtool
   - autoconf
   - zlib1g-dev
+  - postgresql-client
 postgres_host: '{{ vault_postgres_host }}'
 postgres_version: 10
 ol_db_host: '{{ postgres_host }}'


### PR DESCRIPTION
Addresses errors on lib-pulindexer1 that the browse lists can't load due to psql not being installed:
```
# tail cron_log.log 
cp: cannot stat '/tmp/call_number_browse_s.sorted': No such file or directory
sh: 1: psql: not found
sh: 1: psql: not found
sh: 1: psql: not found
sh: 1: psql: not found
sh: 1: psql: not found
```