### PR TITLE
add htop and python-apt

### DIFF
--- a/roles/pulibrary.common/molecule/default/tests/test_common.py
+++ b/roles/pulibrary.common/molecule/default/tests/test_common.py
@@ -9,6 +9,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.parametrize("name", [
     "acl",
+    "htop",
+    "python-apt",
     "build-essential",
     "curl",
     "git",

--- a/roles/pulibrary.common/tasks/main.yml
+++ b/roles/pulibrary.common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install building software and build essentials
   apt:
-    name: ["acl", "build-essential", "curl", "git", "unzip", "zip", "python-pip", "python-setuptools", "libssl-dev", "wget", "tmux"]
+    name: ["htop", "python-apt", "acl", "build-essential", "curl", "git", "unzip", "zip", "python-pip", "python-setuptools", "libssl-dev", "wget", "tmux"]
     state: present
     update_cache: true
   changed_when: false


### PR DESCRIPTION
add htop to common to allow ability to determine what is going on with machines
also get rid of the python-apt warning
this closes issue #1270