### PR TITLE
Solrcloud: Use get_url instead of wget for OL's jars

### DIFF
--- a/roles/pulibrary.solrcloud/tasks/config.yml
+++ b/roles/pulibrary.solrcloud/tasks/config.yml
@@ -64,7 +64,18 @@
     force: true
   notify: restart SolrCloud
 
-- name: Add orangelight jar files
-  shell: "cd {{ jardirectory }} && wget {{ cjkfoldingfilter }} {{ umichsolrfilters }}"
+- name: Add orangelight cjk jar file
+  get_url:
+    url: "{{ cjkfoldingfilter }}"
+    dest: "{{ jardirectory }}"
+    force: yes
+  changed_when: false
+  notify: restart SolrCloud
+
+- name: Add orangelight call number jar file
+  get_url:
+    url: "{{ umichsolrfilters }}"
+    dest: "{{ jardirectory }}"
+    force: yes
   changed_when: false
   notify: restart SolrCloud


### PR DESCRIPTION
wget adds each new file, appending them with a digit. We were still
getting an old jar and it seems perhaps load order isn't guaranteed with
this method. using get_url will replace the file each time. Since these
files are pulled from the pul_solr git repository we can still easily
revert them if needed.

For existing solrcloud servers, we may want to move the latest copy of each jar
to the file location with no digit appended and delete the others to prevent
unintended consequences from this PR.