### PR TITLE
Remove Jetty Configuration causing issues with Solr 8.x

### DIFF
--- a/group_vars/solr8cloud/staging.yml
+++ b/group_vars/solr8cloud/staging.yml
@@ -1,6 +1,7 @@
 ---
 solr_heap_setting: '20g'
-solr_cloud_download_version: 8.2.0
+solr_cloud_download_version: 8.4.1
+solr_cloud_url: "https://archive.apache.org/dist/lucene/solr/{{ solr_cloud_version }}/{{ solr_cloud_package}}"
 solr_log4j_path: '/solr/log4j2.xml'
 lib_zk1_host_name: lib-zk-staging1
 lib_zk2_host_name: lib-zk-staging2

--- a/roles/pulibrary.common/tasks/main.yml
+++ b/roles/pulibrary.common/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: update python's crypto libs
   pip:
     name: ["urllib3", "pyopenssl", "ndg-httpsclient", "pyasn1"]
+    executable: pip3
 
 - name: copy tmux.conf
   template:

--- a/roles/pulibrary.solrcloud/defaults/main.yml
+++ b/roles/pulibrary.solrcloud/defaults/main.yml
@@ -83,3 +83,4 @@ log_max_backup_index: 9
 solr_log_root_level: '{{ log_root_level }}'
 solr_log_file_size: '{{ log_file_size }}'
 solr_log_max_backup_index: '{{ log_max_backup_index }}'
+solr_cloud_url: "http://lib-solr-mirror.princeton.edu/dist/lucene/solr/{{ solr_cloud_version }}/{{ solr_cloud_package }}"

--- a/roles/pulibrary.solrcloud/tasks/config.yml
+++ b/roles/pulibrary.solrcloud/tasks/config.yml
@@ -15,20 +15,6 @@
   ignore_errors: true
   changed_when: false
 
-- name: Configuring jetty server
-  template:
-    src: 'jetty.xml.j2'
-    dest: '/opt/solr/server/etc/jetty.xml'
-    force: true
-  notify: restart SolrCloud
-
-- name: Configure jetty server http
-  template:
-    src: 'jetty-http.xml.j2'
-    dest: '/opt/solr/server/etc/jetty-http.xml'
-    force: true
-  notify: restart SolrCloud
-
 - name: Configure SolrCloud init script
   template:
     src: 'solr.in.sh.j2'

--- a/roles/pulibrary.solrcloud/vars/main.yml
+++ b/roles/pulibrary.solrcloud/vars/main.yml
@@ -1,5 +1,4 @@
 ---
 solr_cloud_build_name: "solr-{{ solr_cloud_version }}"
 solr_cloud_package: "{{ solr_cloud_build_name }}.tgz"
-solr_cloud_url: "http://lib-solr-mirror.princeton.edu/dist/lucene/solr/{{ solr_cloud_version }}/{{ solr_cloud_package }}"
 solr_config_xml: "<str name=\"lucene-spec-version\">{{ solr_cloud_version }}</str>"


### PR DESCRIPTION
These jetty config files were added in during https://github.com/pulibrary/princeton_ansible/pull/314/files#diff-bc10ecbc9a1130f0fc92d984791827b5R43. Unfortunately those config files differ between Solr 7 and Solr 8, resulting in a bug making solr boxes being unable to connect to one another during query. We don't seem to change any of the configuration in our local group_vars, but we may have changed the numbers when they first went in.

@jrgriffiniii do you remember when you first made this role if these were variables brought over from somewhere else, or if we changed any of the numbers initially?