### PR TITLE
[Orangelight] Adding mailcatcher to orangelight-staging

### DIFF
--- a/group_vars/orangelight.yml
+++ b/group_vars/orangelight.yml
@@ -81,6 +81,10 @@ rails_app_vars:
     value: '{{ ol_host_name }}'
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{ application_host_protocol }}'
+  - name: SMTP_HOST
+    value: 'lib-ponyexpr.princeton.edu'
+  - name: SMTP_PORT
+    value: '25'
 sneakers_workers: EventHandler
 sneakers_worker_name: orangelight-sneakers
 datadog_api_key: "{{ vault_datadog_key }}"

--- a/group_vars/orangelight_staging.yml
+++ b/group_vars/orangelight_staging.yml
@@ -85,6 +85,10 @@ rails_app_vars:
     value: '{{ol_host_name}}'
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{application_host_protocol}}'
+  - name: SMTP_HOST
+    value: 'localhost'
+  - name: SMTP_PORT
+    value: '1025'
 sneakers_workers: EventHandler
 sneakers_worker_name: orangelight-sneakers
 datadog_api_key: "{{vault_datadog_key}}"
@@ -118,3 +122,6 @@ datadog_checks:
         service: orangelight
         source: nginx
         sourcecategory: http_web_access
+install_mailcatcher: true
+mailcatcher_user: 'pulsys'
+mailcatcher_group: 'pulsys'

--- a/roles/pulibrary.orangelight/meta/main.yml
+++ b/roles/pulibrary.orangelight/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
-  - { role: 'pulibrary.blacklight-app' }
+  - role: 'pulibrary.blacklight-app'
+  - role: 'pulibrary.mailcatcher'


### PR DESCRIPTION
The plan is to use the new ENV variables in the orangelight config/environments/production.rb on the rails side to use pony express in production and mailcatcher on staging.

These were not needed in Approvals, since the approvals staging server uses the staging environment, but in orangelight both staging and production use the production environment.

refs https://github.com/pulibrary/orangelight/issues/1971