### PR TITLE
[Figgy] Remove PLUM env vars.

### DIFF
--- a/group_vars/figgy_production.yml
+++ b/group_vars/figgy_production.yml
@@ -97,12 +97,6 @@ rails_app_vars:
     value: '{{figgy_solr_url}}'
   - name: CANTALOUPE_URL
     value: 'https://iiif.princeton.edu/loris/figgy_prod/'
-  - name: PLUM_SOLR_URL
-    value: 'http://lib-solr1.princeton.edu:8983/solr/plum'
-  - name: PLUM_BINARY_PATH
-    value: '/mnt/diglibdata/hydra_binaries'
-  - name: PLUM_DERIVATIVE_PATH
-    value: '/mnt/libimages2/data/jp2s/plum_prod'
   - name: HONEYBADGER_API_KEY
     value: '{{figgy_honeybadger_key}}'
   - name: FIGGY_REDIS_URL

--- a/group_vars/figgy_staging.yml
+++ b/group_vars/figgy_staging.yml
@@ -92,12 +92,6 @@ rails_app_vars:
     # allowed by the iiif spec so we encode the slash
   - name: CANTALOUPE_URL
     value: 'https://iiif-staging.princeton.edu/figgy_staging/'
-  - name: PLUM_SOLR_URL
-    value: 'http://lib-solr1.princeton.edu:8983/solr/plum'
-  - name: PLUM_BINARY_PATH
-    value: '/mnt/diglibdata/hydra_binaries'
-  - name: PLUM_DERIVATIVE_PATH
-    value: '/mnt/libimages1/data/jp2s/plum_prod'
   - name: HONEYBADGER_API_KEY
     value: '{{figgy_honeybadger_key}}'
   - name: FIGGY_REDIS_URL


### PR DESCRIPTION
These were removed from figgy in
https://github.com/pulibrary/figgy/pull/1483/files

fixes #333
fixes #239