### PR TITLE
Update solr 7 cloud http checks off migrated collections

### DIFF
--- a/group_vars/solrcloud.yml
+++ b/group_vars/solrcloud.yml
@@ -44,19 +44,19 @@ datadog_checks:
   http_check:
     init_config:
     instances:
-      - name: Catalog Production
-        url: 'http://localhost:8983/solr/catalog-production/admin/ping?wt=json&distrib=true&indent=true'
+      - name: Figgy
+        url: 'http://localhost:8983/solr/figgy/admin/ping?wt=json&distrib=true&indent=true'
         skip_event: true
         tags:
           - 'http_service:solr'
-          - 'application:orangelight'
+          - 'application:figgy'
           - 'environment:production'
-      - name: Catalog Reindex
-        url: 'http://localhost:8983/solr/catalog-rebuild/admin/ping?wt=json&distrib=true&indent=true'
+      - name: DPUL
+        url: 'http://localhost:8983/solr/dpul/admin/ping?wt=json&distrib=true&indent=true'
         skip_event: true
         tags:
           - 'http_service:solr'
-          - 'application:orangelight'
+          - 'application:dpul'
           - 'environment:reindex'
   solr:
     instances:

--- a/group_vars/solrcloud_staging.yml
+++ b/group_vars/solrcloud_staging.yml
@@ -46,19 +46,19 @@ datadog_checks:
   http_check:
     init_config:
     instances:
-      - name: Catalog Staging
-        url: 'http://localhost:8983/solr/catalog-staging/admin/ping?wt=json&distrib=true&indent=true'
-        skip_event: true
-        tags:
-          - 'http_service:solr'
-          - 'application:orangelight'
-          - 'environment:staging'
       - name: DPUL Staging
         url: 'http://localhost:8983/solr/dpul-staging/admin/ping?wt=json&distrib=true&indent=true'
         skip_event: true
         tags:
           - 'http_service:solr'
           - 'application:dpul'
+          - 'environment:staging'
+      - name: Pulmap Staging
+        url: 'http://localhost:8983/solr/pulmap-staging/admin/ping?wt=json&distrib=true&indent=true'
+        skip_event: true
+        tags:
+          - 'http_service:solr'
+          - 'application:pulmap'
           - 'environment:staging'
   solr:
     instances:


### PR DESCRIPTION
Use Figgy / DPUL for prod and DPUL / pulmap for staging
orangelight checks now only run on solr 8 cloud machines