### PR TITLE
add the zlib-dev package is needed by nokogiri

### DIFF
--- a/roles/pulibrary.common/defaults/main.yml
+++ b/roles/pulibrary.common/defaults/main.yml
@@ -13,6 +13,7 @@ common_packages:
   - python3-pip
   - python-setuptools
   - libssl-dev
+  - zlib1g-dev
   - tmux
   - vim
   - wget


### PR DESCRIPTION
without this package nokogiri and libxml fail.

Co-authored-by: Christina Chortaria <actspatial@gmail.com>