### PR TITLE
upstream modified the repo URL which

### DIFF
--- a/roles/pulibrary.passenger/tasks/main.yml
+++ b/roles/pulibrary.passenger/tasks/main.yml
@@ -1,69 +1,77 @@
 ---
 # Variable setup.
-- name: Include OS-specific variables.
+- name: Phusion | Include OS-specific variables.
   include_vars: "main.yml"
 
-- name: Define nginx_user.
+- name: Phusion | Define nginx_user.
   set_fact:
     nginx_user: "{{ __nginx_user }}"
   when: nginx_user is not defined
 
 # Passenger repository setup.
-- name: Add Passenger apt key.
+- name: Phusion | Add Passenger apt key.
   apt_key:
     keyserver: keyserver.ubuntu.com
     id: 561F9B9CAC40B2F7
     state: present
 
-- name: Add apt HTTPS capabilities.
+- name: Phusion | Add apt HTTPS capabilities.
   apt:
     name: apt-transport-https
     state: present
 
-- name: Add Phusion apt repo.
+- name: Phusion | Add Phusion apt repo.
   apt_repository:
     repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
     state: present
+  ignore_errors: true
+
+- name: Phusion | update cache release info
+  command: apt-get update -y --allow-releaseinfo-change
+  changed_when: false
+
+- name: Phusion | update our repos
+  apt:
     update_cache: true
 
 # Nginx and passenger installation.
-- name: Define nginx_passenger_packages
+- name: Phusion | Define nginx_passenger_packages
   set_fact:
     nginx_passenger_packages: "{{ __nginx_passenger_packages_16_04 }}"
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 18
 
-- name: Install Nginx and Passenger.
+- name: Phusion | Install Nginx and Passenger.
   apt:
     name: "{{ nginx_passenger_packages }}"
     state: present
 
 # Nginx and passenger configuration.
-- name: Copy Nginx configuration into place.
+- name: Phusion | Copy Nginx configuration into place.
   template:
     src: nginx.conf.j2
     dest: /etc/nginx/nginx.conf
   notify: restart nginx
 
-- name: Copy Passenger configuration into place.
+- name: Phusion | Copy Passenger configuration into place.
   template:
     src: passenger.conf.j2
     dest: /etc/nginx/passenger.conf
   notify: restart nginx
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 18
 
-- name: Configure passenger virtual host.
+- name: Phusion | Configure passenger virtual host.
   template:
     src: passenger.j2
     dest: /etc/nginx/sites-available/passenger
   notify: restart nginx
 
-- name: Ensure passenger virtual host is enabled.
+- name: Phusion | Ensure passenger virtual host is enabled.
   file:
     src: /etc/nginx/sites-available/passenger
     dest: /etc/nginx/sites-enabled/passenger
     state: link
 
-- name: Ensure default virtual host is removed.
+- name: Phusion | Ensure default virtual host is removed.
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent


### PR DESCRIPTION
this allows up to allow the modification of the repo URL and runs free
standing `apt-get update`

this impacts any project that depends on passenger/nginx

closes #1535
