### PR TITLE
Do not error on slack

### DIFF
--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -43,6 +43,7 @@ ol_smtp_port: "25"
 ol_rails_solr_url: "{{ ol_solr_url }}"
 sneakers_workers: EventHandler
 sneakers_worker_name: orangelight-sneakers
+install_mailcatcher: false
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:
   tags: "application:orangelight, environment:production, type:webserverj"

--- a/playbooks/orangelight_production.yml
+++ b/playbooks/orangelight_production.yml
@@ -6,15 +6,10 @@
     - ../site_vars.yml
     - ../group_vars/orangelight/production.yml
   roles:
-    - role: roles/pulibrary.ruby
-    - role: roles/pulibrary.deploy-user
     - role: roles/pulibrary.passenger
-    - role: roles/pulibrary.redis
     - role: roles/pulibrary.nodejs
-    - role: roles/pulibrary.extra_path
-    - role: roles/pulibrary.rails-app
-    - role: roles/pulibrary.sneakers_worker
     - role: roles/pulibrary.ansible-datadog
+    - role: roles/pulibrary.orangelight
       when: postgresql_is_local is not defined or not postgresql_is_local
 
   post_tasks:
@@ -23,4 +18,3 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
         channel: #server-alerts
-      delegate_to: localhost


### PR DESCRIPTION
Also added orangelight role to playbook
And turned off mailcatcher
Copied working version from approvals playbook.
```
TASK [tell everyone on slack you ran an ansible playbook] ************************************************
fatal: [lib-orange-prod2.princeton.edu -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
fatal: [lib-orange-prod6.princeton.edu -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
fatal: [lib-orange-prod4.princeton.edu -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
fatal: [lib-orange-prod3.princeton.edu -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP ***********************************************************************************************
lib-orange-prod2.princeton.edu : ok=117  changed=16   unreachable=0    failed=1    skipped=38   rescued=0    ignored=0   
lib-orange-prod3.princeton.edu : ok=117  changed=16   unreachable=0    failed=1    skipped=38   rescued=0    ignored=0   
lib-orange-prod4.princeton.edu : ok=117  changed=16   unreachable=0    failed=1    skipped=38   rescued=0    ignored=0   
lib-orange-prod6.princeton.edu : ok=117  changed=16   unreachable=0    failed=1    skipped=38   rescued=0    ignored=0   
```