### PR TITLE
Use inventory_hostname instead of variable for running roles conditionally

### DIFF
--- a/host_vars/figgy1.princeton.edu.yml
+++ b/host_vars/figgy1.princeton.edu.yml
@@ -1,5 +1,4 @@
 ---
-figgy_rabbitmq_host: 'true'
 datadog_checks:
   rabbitmq:
     init_config:

--- a/host_vars/lib-proc9.princeton.edu.yml
+++ b/host_vars/lib-proc9.princeton.edu.yml
@@ -1,2 +1,0 @@
----
-figgy_filewatcher_host: 'true'

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -24,7 +24,7 @@
     - role: roles/pulibrary.extra_path
     - role: roles/pulibrary.imagemagick
     - role: roles/pulibrary.rails-app
-    - {role: roles/pulibrary.rabbitmq, when: figgy_rabbitmq_host == 'true'}
+    - {role: roles/pulibrary.rabbitmq, when: inventory_hostname == 'figgy1.princeton.edu'}
     - role: roles/pulibrary.subversion
     - role: roles/pulibrary.figgy
     - role: roles/pulibrary.ansible-datadog
@@ -61,7 +61,7 @@
     - role: roles/pulibrary.sidekiq_worker
     - role: roles/pulibrary.subversion
     - role: roles/pulibrary.figgy
-    - {role: roles/pulibrary.figgy_filewatcher_worker, when: figgy_filewatcher_host == 'true'}
+    - {role: roles/pulibrary.figgy_filewatcher_worker, when: inventory_hostname == 'lib-proc9.princeton.edu' }
     - role: roles/pulibrary.figgy_pubsub_worker
     - role: roles/pulibrary.ansible-datadog
   post_tasks:


### PR DESCRIPTION
Closes #1601 

The `figgy_rabbitmq_host` and `figgy_filewatcher_host ` variables  need to be set for all hosts for the conditional checks to work. I could not coax Ansible to let me only set them to true for a single server. Since we are only using this flag on a single server per condition, it seems reasonable that we can set the server name in the playbook directly.