### PR TITLE
uninstall mediainfo

### DIFF
--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -3,6 +3,12 @@
   remote_user: pulsys
   become: true
   strategy: free
+  pre_tasks:
+    - name: remove mediainfo installation
+      apt:
+        name: mediainfo
+        state: absent
+        ignore_errors: true
   vars_files:
     - ../site_vars.yml
     - ../group_vars/figgy_production.yml


### PR DESCRIPTION
this uninstalls the latest version of mediainfo so the role can run

this fixes the [figgy] processing machines inability to install figgy

this will close #1600
