### PR TITLE
remove use of master and replace with leader

### DIFF
--- a/group_vars/postgresql/gcp_production.yml
+++ b/group_vars/postgresql/gcp_production.yml
@@ -47,12 +47,12 @@ postgresql_hba_entries:
   - type: host
     database: all
     user: postgres
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: replication
     user: replicant
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: all
@@ -77,7 +77,7 @@ postgresql_hba_entries:
   - type: host
     database: replicant
     user: replicant
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: replicant

--- a/group_vars/postgresql/gcp_staging.yml
+++ b/group_vars/postgresql/gcp_staging.yml
@@ -47,12 +47,12 @@ postgresql_hba_entries:
   - type: host
     database: all
     user: postgres
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: replication
     user: replicant
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: all
@@ -77,7 +77,7 @@ postgresql_hba_entries:
   - type: host
     database: replicant
     user: replicant
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: replicant

--- a/group_vars/postgresql/staging.yml
+++ b/group_vars/postgresql/staging.yml
@@ -47,12 +47,12 @@ postgresql_hba_entries:
   - type: host
     database: all
     user: postgres
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: replication
     user: replicant
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: all
@@ -77,7 +77,7 @@ postgresql_hba_entries:
   - type: host
     database: replicant
     user: replicant
-    address: "{{ master_db_ip }}/32"
+    address: "{{ leader_db_ip }}/32"
     method: md5
   - type: host
     database: replicant

--- a/host_vars/gcp_postgres_prod1.yml
+++ b/host_vars/gcp_postgres_prod1.yml
@@ -4,5 +4,5 @@ node_identifier: 1
 repmgr_master: true
 standby_db_host: gcp-postgres-prod2
 master_db_host: gcp-postgres-prod1
-master_db_ip: 10.240.0.2
+leader_db_ip: 10.240.0.2
 standy_db_ip: 10.240.0.3

--- a/host_vars/gcp_postgres_prod2.yml
+++ b/host_vars/gcp_postgres_prod2.yml
@@ -4,5 +4,5 @@ node_identifier: 2
 repmgr_master: false
 standby_db_host: gcp-postgres-prod2
 master_db_host: gcp-postgres-prod1
-master_db_ip: 10.240.0.2
+leader_db_ip: 10.240.0.2
 standby_db_ip: 10.240.0.3

--- a/host_vars/gcp_postgres_staging1.yml
+++ b/host_vars/gcp_postgres_staging1.yml
@@ -4,5 +4,5 @@ node_identifier: 1
 repmgr_master: true
 standby_db_host: gcp-postgres-staging2
 master_db_host: gcp-postgres-staging1
-master_db_ip: 10.132.0.2
+leader_db_ip: 10.132.0.2
 standy_db_ip: 10.132.0.3

--- a/host_vars/gcp_postgres_staging2.yml
+++ b/host_vars/gcp_postgres_staging2.yml
@@ -4,5 +4,5 @@ node_identifier: 2
 repmgr_master: false
 standby_db_host: gcp-postgres-staging2
 master_db_host: gcp-postgres-staging1
-master_db_ip: 10.132.0.2
+leader_db_ip: 10.132.0.2
 standby_db_ip: 10.132.0.3

--- a/host_vars/lib-postgres-staging1.princeton.edu.yml
+++ b/host_vars/lib-postgres-staging1.princeton.edu.yml
@@ -4,5 +4,5 @@ node_identifier: 1
 repmgr_master: true
 standby_db_host: lib-postgres-staging2.princeton.edu
 master_db_host: lib-postgres-staging1.princeton.edu
-master_db_ip: 128.112.203.12
+leader_db_ip: 128.112.203.12
 standy_db_ip: 128.112.203.45

--- a/host_vars/lib-postgres-staging2.princeton.edu.yml
+++ b/host_vars/lib-postgres-staging2.princeton.edu.yml
@@ -4,5 +4,5 @@ node_identifier: 2
 repmgr_master: false
 standby_db_host: lib-postgres-staging2.princeton.edu
 master_db_host: lib-postgres-staging1.princeton.edu
-master_db_ip: 128.112.203.12
+leader_db_ip: 128.112.203.12
 standby_db_ip: 128.112.203.45


### PR DESCRIPTION
removes the use of master in our [postgresql] staging and google cloud clusters
