### PR TITLE
use python 3 instead of python2

### DIFF
--- a/roles/pulibrary.dataspace/tasks/dataspace_config.yml
+++ b/roles/pulibrary.dataspace/tasks/dataspace_config.yml
@@ -2,6 +2,9 @@
 - name: dataspace | install awscli
   pip:
     name: awscli
+    state: forcereinstall
+    executable: pip3
+  when: running_on_server
 
 - name: dataspace | Install site configuration
   template:


### PR DESCRIPTION
until upstream aws makes awscli available on the "cheeseshop" (pip.org) let's at least use python3
