### PR TITLE
Updating the Node.js releases used for the following apps: bibdata, cicognara, dpul, lae, orangelight, pulfalight, and pulmap

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -4,6 +4,7 @@ postgres_version: 10
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:
   tags: "application:bibdata, environment:production, type:webserver"

--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -4,7 +4,8 @@ postgres_version: 10
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:
   tags: "application:bibdata, environment:production, type:webserver"

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -7,6 +7,7 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 rails_app_name: "marc_liberation"
 rails_app_directory: "marc_liberation"
 rails_app_symlinks: []

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -7,7 +7,8 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 rails_app_name: "marc_liberation"
 rails_app_directory: "marc_liberation"
 rails_app_symlinks: []

--- a/group_vars/cicognara.yml
+++ b/group_vars/cicognara.yml
@@ -13,7 +13,8 @@ cicognara_db_password: '{{vault_cicognara_staging_db_password}}'
 rails_app_env: "staging"
 cicognara_host_name: 'cicognara-staging1.princeton.edu'
 bundler_version: "2.0.1"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 application_db_name: '{{cicognara_db_name}}'
 application_dbuser_name: '{{cicognara_db_user}}'
 application_dbuser_password: '{{cicognara_db_password}}'

--- a/group_vars/cicognara.yml
+++ b/group_vars/cicognara.yml
@@ -13,6 +13,7 @@ cicognara_db_password: '{{vault_cicognara_staging_db_password}}'
 rails_app_env: "staging"
 cicognara_host_name: 'cicognara-staging1.princeton.edu'
 bundler_version: "2.0.1"
+nodejs_version: "12.x"
 application_db_name: '{{cicognara_db_name}}'
 application_dbuser_name: '{{cicognara_db_user}}'
 application_dbuser_password: '{{cicognara_db_password}}'

--- a/group_vars/cicognara_production.yml
+++ b/group_vars/cicognara_production.yml
@@ -12,7 +12,8 @@ cicognara_db_name: 'cicognara'
 cicognara_db_user: '{{ vault_cicognara_db_user }}'
 cicognara_db_password: '{{ vault_cicognara_db_password }}'
 rails_app_env: "production"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 cicognara_host_name: 'cicognara1.princeton.edu'
 application_db_name: '{{ cicognara_db_name }}'
 application_dbuser_name: '{{ cicognara_db_user }}'

--- a/group_vars/cicognara_production.yml
+++ b/group_vars/cicognara_production.yml
@@ -12,6 +12,7 @@ cicognara_db_name: 'cicognara'
 cicognara_db_user: '{{ vault_cicognara_db_user }}'
 cicognara_db_password: '{{ vault_cicognara_db_password }}'
 rails_app_env: "production"
+nodejs_version: "12.x"
 cicognara_host_name: 'cicognara1.princeton.edu'
 application_db_name: '{{ cicognara_db_name }}'
 application_dbuser_name: '{{ cicognara_db_user }}'

--- a/group_vars/lae_production.yml
+++ b/group_vars/lae_production.yml
@@ -7,6 +7,7 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 postgresql_is_local: false
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"

--- a/group_vars/lae_production.yml
+++ b/group_vars/lae_production.yml
@@ -7,7 +7,8 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 postgresql_is_local: false
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"

--- a/group_vars/lae_staging.yml
+++ b/group_vars/lae_staging.yml
@@ -7,7 +7,8 @@ passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 postgresql_is_local: false
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"

--- a/group_vars/lae_staging.yml
+++ b/group_vars/lae_staging.yml
@@ -7,6 +7,7 @@ passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 postgresql_is_local: false
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -7,6 +7,7 @@ rails_app_directory: "rails_app"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 postgresql_is_local: false
 postgres_host: '{{ vault_postgres_host }}'
 postgres_version: 10

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -7,7 +7,8 @@ rails_app_directory: "rails_app"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 postgresql_is_local: false
 postgres_host: '{{ vault_postgres_host }}'
 postgres_version: 10

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -7,6 +7,7 @@ passenger_extra_config: "{{ lookup('file', 'roles/pulibrary.orangelight/template
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 postgresql_is_local: false
 rails_app_directory: "orangelight"
 postgres_host: "lib-postgres3.princeton.edu"

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -7,7 +7,8 @@ passenger_extra_config: "{{ lookup('file', 'roles/pulibrary.orangelight/template
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 postgresql_is_local: false
 rails_app_directory: "orangelight"
 postgres_host: "lib-postgres3.princeton.edu"

--- a/group_vars/orangelight_workers.yml
+++ b/group_vars/orangelight_workers.yml
@@ -12,7 +12,8 @@ rails_app_dependencies:
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 postgresql_is_local: false
 postgres_host: '{{ vault_postgres_host }}'
 postgres_version: 10

--- a/group_vars/orangelight_workers.yml
+++ b/group_vars/orangelight_workers.yml
@@ -12,6 +12,7 @@ rails_app_dependencies:
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 postgresql_is_local: false
 postgres_host: '{{ vault_postgres_host }}'
 postgres_version: 10

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -12,7 +12,8 @@ passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 rails_app_name: "pulfalight"
 rails_app_directory: "pulfalight"
 rails_app_symlinks: []

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -12,7 +12,7 @@ passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "9.x"
+nodejs_version: "12.x"
 rails_app_name: "pulfalight"
 rails_app_directory: "pulfalight"
 rails_app_symlinks: []

--- a/group_vars/pulmap.yml
+++ b/group_vars/pulmap.yml
@@ -5,6 +5,7 @@ passenger_server_name: "pulmap.princeton.edu"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 pulmap_geoserver_user: '{{ vault_pulmap_geoserver_user }}'
 pulmap_geoserver_password: '{{ vault_pulmap_geoserver_password }}'
 pulmap_rabbit_user: '{{ vault_dpul_rabbit_user }}'

--- a/group_vars/pulmap.yml
+++ b/group_vars/pulmap.yml
@@ -5,7 +5,8 @@ passenger_server_name: "pulmap.princeton.edu"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 pulmap_geoserver_user: '{{ vault_pulmap_geoserver_user }}'
 pulmap_geoserver_password: '{{ vault_pulmap_geoserver_password }}'
 pulmap_rabbit_user: '{{ vault_dpul_rabbit_user }}'

--- a/group_vars/pulmap_staging.yml
+++ b/group_vars/pulmap_staging.yml
@@ -5,7 +5,8 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
-nodejs_version: "12.x"
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'
 pulmap_geoserver_user: '{{vault_pulmap_geoserver_user}}'
 pulmap_geoserver_password: '{{vault_pulmap_geoserver_password}}'
 pulmap_rabbit_user: '{{vault_figgy_staging_rabbit_user}}'

--- a/group_vars/pulmap_staging.yml
+++ b/group_vars/pulmap_staging.yml
@@ -5,6 +5,7 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
+nodejs_version: "12.x"
 pulmap_geoserver_user: '{{vault_pulmap_geoserver_user}}'
 pulmap_geoserver_password: '{{vault_pulmap_geoserver_password}}'
 pulmap_rabbit_user: '{{vault_figgy_staging_rabbit_user}}'


### PR DESCRIPTION
This blocks:
- https://github.com/pulibrary/lae-blacklight/issues/293
- https://github.com/pulibrary/cicognara-rails/issues/473
- https://github.com/pulibrary/orangelight/issues/2181
- https://github.com/pulibrary/marc_liberation/issues/752