### PR TITLE
Stop redirecting libimages2 errors to libimages1.

### DIFF
--- a/roles/pulibrary.cantaloupe/templates/production_nginx_config.j2
+++ b/roles/pulibrary.cantaloupe/templates/production_nginx_config.j2
@@ -7,8 +7,6 @@ location ~ ^/loris/(iiif/2/)?figgy_prod/.* {
     proxy_set_header X-Forwarded-Path /loris;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_intercept_errors on;
-    error_page 404 = @errors;
     proxy_redirect http://127.0.0.1:8182/ /loris;
 }
 location ~ ^/loris/.* {
@@ -20,8 +18,6 @@ location ~ ^/loris/.* {
     proxy_set_header X-Forwarded-Path /loris;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_intercept_errors on;
-    error_page 404 = @errors;
     proxy_redirect http://127.0.0.1:8182/ /loris;
 }
 
@@ -41,12 +37,4 @@ location / {
   proxy_set_header X-Forwarded-Path /;
   proxy_set_header X-Forwarded-Port 443;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location @errors {
-  add_header 'Access-Control-Allow-Origin' '*';
-  add_header 'Access-Control-Allow-Credentials' 'true';
-  add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-  add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Origin';
-  rewrite ^ https://libimages1.princeton.edu$request_uri;
 }


### PR DESCRIPTION
There's no reason to redirect anymore - all the files are copied over. This is one step in getting rid of libimages1.