### PR TITLE
[libwww] Adding hr-share role to libwww

### DIFF
--- a/roles/pulibrary.libwww/meta/main.yml
+++ b/roles/pulibrary.libwww/meta/main.yml
@@ -19,3 +19,4 @@ dependencies:
   - role: pulibrary.drupal
   - role: pulibrary.redis
   - role: pulibrary.mariadb
+  - role: pulibrary.hr_share


### PR DESCRIPTION
Gives access to the staff report for building the staff directory

fixes #1780 