### PR TITLE
allow cleaner lumping of grouped applications

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,222 +1,352 @@
-[bibdata_staging]
-bibdata-staging1.princeton.edu
-bibdata-staging2.princeton.edu
-[bibdata]
-bibdata1.princeton.edu
-bibdata2.princeton.edu
-[cicognara_staging]
-cicognara-staging1.princeton.edu
-[cicognara_production]
-cicognara1.princeton.edu
-cicognara2.princeton.edu
-[bibdata_workers]
-bibdata-worker2.princeton.edu
-[pulmap]
-maps1.princeton.edu
-maps2.princeton.edu
-[pulmap_staging]
-maps-staging1.princeton.edu
-[mariadb]
-mariadb1.princeton.edu
-[postgres]
-lib-postgres3.princeton.edu
-lib-postgres4.princeton.edu
-[figgy_staging]
-figgy-staging2.princeton.edu
-[figgy_production]
-figgy1.princeton.edu
-figgy2.princeton.edu
-lib-proc6.princeton.edu
-lib-proc7.princeton.edu
-lib-proc8.princeton.edu
-lib-proc9.princeton.edu
-lib-proc10.princeton.edu
-lib-proc11.princeton.edu
-[figgy_production_webserver]
-figgy1.princeton.edu
-figgy2.princeton.edu
-[figgy_production_workers]
-lib-proc6.princeton.edu
-lib-proc7.princeton.edu
-lib-proc8.princeton.edu
-lib-proc9.princeton.edu
-lib-proc10.princeton.edu
-lib-proc11.princeton.edu
-[archivesspace]
-lib-aspace-prod1.Princeton.EDU
-[archivesspace_staging]
-lib-aspace-dev1.Princeton.EDU
-[lae_production]
-lae1.princeton.edu
-lae2.princeton.edu
-[lae_staging]
-lae-staging1.princeton.edu
-[dss_production]
-dss-prod1.princeton.edu
-dss-prod2.princeton.edu
-[dss_staging]
-dss-staging1.princeton.edu
-[orangelight]
-lib-orange-prod2.princeton.edu
-lib-orange-prod3.princeton.edu
-lib-orange-prod4.princeton.edu
-lib-orange-prod6.princeton.edu
-[orangelight_workers]
-lib-pulindexer1.princeton.edu
-lib-pulindexer2.princeton.edu
-lib-pulindexer3.princeton.edu
-[orangelight_staging]
-lib-orange-staging1.princeton.edu
-lib-orange-staging2.princeton.edu
-[orangelight_qa]
-lib-orange-qa1.princeton.edu
-[orangelight_alma_qa]
-lib-orange-alma-qa1.princeton.edu
-[redis_production]
-lib-redis.princeton.edu
-[dpul_production]
-dpul1.princeton.edu
-dpul2.princeton.edu
-[dpul_staging]
-dpul-staging1.princeton.edu
-[geoserver]
-geoserv1.princeton.edu
-[zookeeper]
-lib-zk1.princeton.edu
-lib-zk2.princeton.edu
-lib-zk3.princeton.edu
-[zookeeper_staging]
-lib-zk-staging1.princeton.edu
-lib-zk-staging2.princeton.edu
-lib-zk-staging3.princeton.edu
-[solrcloud]
-lib-solr1.princeton.edu
-lib-solr2.princeton.edu
-lib-solr3.princeton.edu
-[solrcloud_staging]
-lib-solr-staging1.princeton.edu
-lib-solr-staging2.princeton.edu
-lib-solr-staging3.princeton.edu
-[solr8cloud_staging]
-lib-solr-staging4.princeton.edu
-lib-solr-staging5.princeton.edu
-lib-solr-staging6.princeton.edu
-[solr8cloud_production]
-lib-solr-prod4.princeton.edu
-lib-solr-prod5.princeton.edu
-lib-solr-prod6.princeton.edu
-[ojs]
-ojs-staging1.princeton.edu
-[ezproxy_test]
-ezproxy-test.princeton.edu
-[ezproxy_prod]
-ezproxy-prod1.princeton.edu
-[nginxplus]
-lib-adc1.princeton.edu
-lib-adc2.princeton.edu
-[annotations_staging]
-annotations-staging1.princeton.edu
-[pas_staging]
-slavery-staging1.princeton.edu
-[pas_production]
-slavery-prod1.princeton.edu
-[cantaloupe_staging]
-iiif-staging1.princeton.edu
-[cantaloupe_production]
-libimages2.princeton.edu
-[approvals_staging]
-lib-approvals-staging1.princeton.edu
-[approvals_prod]
-lib-approvals-prod1.princeton.edu
-[perconaxdb_staging_cluster]
-maria-staging1.princeton.edu
-[percona_staging]
-maria-staging2.princeton.edu
-maria-staging3.princeton.edu
-[libwww_stage]
-library-staging1.princeton.edu
-library-staging2.princeton.edu
-[libwww_prod]
-library-prod1.princeton.edu
-library-prod3.princeton.edu
-library-prod4.princeton.edu
-[recap_stage]
-recap-www-staging1.princeton.edu
-[recap_prod]
-recap-www-prod1.princeton.edu
-[pulfalight_staging]
-pulfa3-staging1.princeton.edu
-[locator_staging]
-locator-staging1.princeton.edu
-[locator_production]
-locator-prod1.princeton.edu
-[lib_jobs_staging]
-lib-jobs-staging1.princeton.edu
-[lib_jobs_prod]
-lib-jobs-prod1.princeton.edu
-[lib_svn_staging]
-lib-svn-staging1.princeton.edu
-[libsvn]
-lib-svn-prod1.princeton.edu
-[postgresql_staging]
-lib-postgres-staging1.princeton.edu
-lib-postgres-staging2.princeton.edu
-[pgbouncer_staging]
-lib-pgbouncer-staging1.princeton.edu
-[libruby_dev]
-libruby-dev.princeton.edu
-[libruby_prod]
-libruby-prod.princeton.edu
-[libstatic_staging]
-lib-static-staging1.princeton.edu
-[libstatic_prod]
-lib-static-prod1.princeton.edu
-[mudd_staging]
-lib-mudd-staging1.princeton.edu
-[mudd_prod]
-lib-mudd-prod1.princeton.edu
-[confluence_staging]
-lib-confluence-staging1.princeton.edu
-[perconaxdb_prod_cluster]
-mariadb-prod2.princeton.edu
-[percona_prod]
-mariadb-prod1.princeton.edu
-mariadb-prod3.princeton.edu
-[library_solr_staging]
-library-solr-staging1.princeton.edu
-[library_solr_prod]
-library-solr-prod1.princeton.edu
-[repository_solr_staging]
-repository-solr-staging1.princeton.edu
-[elixir_test]
-lib-elixir-test1.princeton.edu
-[ruby_office]
-ruby-office1.princeton.edu
-[smb_serve]
-lib-smb-serve.princeton.edu
-[kennyloggin]
-kennyloggin1.princeton.edu
-kennyloggin2.princeton.edu
-kennyloggin3.princeton.edu
-[gcp_postgresql_staging]
-gcp_postgres_staging1 ansible_host=10.132.0.2
-gcp_postgres_staging2 ansible_host=10.132.0.3
-[gcp_postgresql_production]
-gcp_postgres_prod1 ansible_host=10.240.0.2
-gcp_postgres_prod2 ansible_host=10.240.0.3
-[researchdata_staging]
-prds-staging1
-[researchdata_prod]
-prds-prod1
-[gcp_oar_staging]
-gcp_oar_staging1 ansible_host=10.132.0.4
-[gcp_oar_production]
-gcp_oar_prod1 ansible_host=10.244.0.3
-[gcp_oar_dev]
-gcp_oar_dev1 ansible_host=10.0.20.3
-[gcp_dataspace_dev]
-gcp_dataspace_dev1 ansible_host=10.0.20.4
-[gcp_dataspace_staging]
-gcp_dataspace_staging1 ansible_host=10.132.0.5
-[gcp_dataspace_production]
-gcp_dataspace_prod1 ansible_host=10.244.0.2
+---
+all:
+  children:
+	bibdata_staging:
+	  hosts:
+		bibdata-staging2.princeton.edu:
+	bibdata:
+	  hosts:
+		bibdata1.princeton.edu:
+		bibdata2.princeton.edu:
+	cicognara_staging:
+	  hosts:
+		cicognara-staging1.princeton.edu:
+	cicognara_production:
+	  hosts:
+		cicognara1.princeton.edu:
+		cicognara2.princeton.edu:
+	bibdata_workers:
+	  hosts:
+		bibdata-worker2.princeton.edu:
+	pulmap:
+	  hosts:
+		maps1.princeton.edu:
+		maps2.princeton.edu:
+	pulmap_staging:
+	  hosts:
+		maps-staging1.princeton.edu:
+	mariadb:
+	  hosts:
+		mariadb1.princeton.edu:
+	postgres:
+	  hosts:
+		lib-postgres3.princeton.edu:
+		lib-postgres4.princeton.edu:
+	figgy_staging:
+	  hosts:
+		figgy-staging2.princeton.edu:
+	figgy_production:
+	  hosts:
+		figgy1.princeton.edu:
+		figgy2.princeton.edu:
+		lib-proc6.princeton.edu:
+		lib-proc7.princeton.edu:
+		lib-proc8.princeton.edu:
+		lib-proc9.princeton.edu:
+		lib-proc10.princeton.edu:
+		lib-proc11.princeton.edu:
+	figgy_production_workers:
+	  hosts:
+		lib-proc6.princeton.edu:
+		lib-proc7.princeton.edu:
+		lib-proc8.princeton.edu:
+		lib-proc9.princeton.edu:
+		lib-proc10.princeton.edu:
+		lib-proc11.princeton.edu:
+	figgy_production_webserver:
+	  hosts:
+		figgy1.princeton.edu:
+		figgy2.princeton.edu:
+	archivesspace_staging:
+	  hosts:
+		lib-aspace-dev1.princeton.edu:
+	lae_production:
+	  hosts:
+		lae1.princeton.edu:
+		lae2.princeton.edu:
+	lae_staging:
+	  hosts:
+		lae-staging1.princeton.edu:
+	dss_production:
+	  hosts:
+		dss-prod1.princeton.edu:
+		dss-prod2.princeton.edu:
+	dss_staging:
+	  hosts:
+		dss-staging1.princeton.edu:
+	orangelight:
+	  hosts:
+		lib-orange-prod2.princeton.edu:
+		lib-orange-prod3.princeton.edu:
+		lib-orange-prod4.princeton.edu:
+		lib-orange-prod6.princeton.edu:
+	orangelight_workers:
+	  hosts:
+		lib-pulindexer1.princeton.edu:
+		lib-pulindexer2.princeton.edu:
+		lib-pulindexer3.princeton.edu:
+	orangelight_staging:
+	  hosts:
+		lib-orange-staging1.princeton.edu:
+	orangelight_qa:
+	  hosts:
+		lib-orange-qa1.princeton.edu:
+	orangelight_alma_qa:
+	  hosts:
+		lib-orange-alma-qa1.princeton.edu:
+	redis_production:
+	  hosts:
+		lib-redis.princeton.edu:
+	dpul_production:
+	  hosts:
+		dpul1.princeton.edu:
+		dpul2.princeton.edu:
+	dpul_staging:
+	  hosts:
+		dpul-staging1.princeton.edu:
+	geoserver:
+	  hosts:
+		geoserv1.princeton.edu:
+	zookeeper:
+	  hosts:
+		lib-zk1.princeton.edu:
+		lib-zk2.princeton.edu:
+		lib-zk3.princeton.edu:
+	zookeeper_staging:
+	  hosts:
+		lib-zk-staging1.princeton.edu:
+		lib-zk-staging2.princeton.edu:
+		lib-zk-staging3.princeton.edu:
+	solrcloud:
+	  hosts:
+		lib-solr1.princeton.edu:
+		lib-solr2.princeton.edu:
+		lib-solr3.princeton.edu:
+	solrcloud_staging:
+	  hosts:
+		lib-solr-staging1.princeton.edu:
+		lib-solr-staging2.princeton.edu:
+		lib-solr-staging3.princeton.edu:
+	solr8cloud_staging:
+	  hosts:
+		lib-solr-staging4.princeton.edu:
+		lib-solr-staging5.princeton.edu:
+		lib-solr-staging6.princeton.edu:
+	solr8cloud_production:
+	  hosts:
+		lib-solr-prod4.princeton.edu:
+		lib-solr-prod5.princeton.edu:
+		lib-solr-prod6.princeton.edu:
+	ojs:
+	  hosts:
+		ojs-staging1.princeton.edu:
+	ezproxy_test:
+	  hosts:
+		ezproxy-test.princeton.edu:
+	nginxplus:
+	  hosts:
+		lib-adc1.princeton.edu:
+		lib-adc2.princeton.edu:
+	annotations_staging:
+	  hosts:
+		annotations-staging1.princeton.edu:
+	pas_staging:
+	  hosts:
+		slavery-staging1.princeton.edu:
+	pas_production:
+	  hosts:
+		slavery-prod1.princeton.edu:
+	cantaloupe_staging:
+	  hosts:
+		iiif-staging1.princeton.edu:
+	cantaloupe_production:
+	  hosts:
+		libimages2.princeton.edu:
+	approvals_staging:
+	  hosts:
+		lib-approvals-staging1.princeton.edu:
+	approvals_prod:
+	  hosts:
+		lib-approvals-prod1.princeton.edu:
+	perconaxdb_staging_cluster:
+	  hosts:
+		maria-staging1.princeton.edu:
+	percona_staging:
+	  hosts:
+		maria-staging2.princeton.edu:
+		maria-staging3.princeton.edu:
+	libwww_stage:
+	  hosts:
+		library-staging1.princeton.edu:
+		library-staging2.princeton.edu:
+	libwww_prod:
+	  hosts:
+		library-prod1.princeton.edu:
+		library-prod3.princeton.edu:
+		library-prod4.princeton.edu:
+	recap_stage:
+	  hosts:
+		recap-www-staging1.princeton.edu:
+	recap_prod:
+	  hosts:
+		recap-www-prod1.princeton.edu:
+	pulfalight_staging:
+	  hosts:
+		pulfa3-staging1.princeton.edu:
+	locator_staging:
+	  hosts:
+		locator-staging1.princeton.edu:
+	locator_production:
+	  hosts:
+		locator-prod1.princeton.edu:
+	lib_jobs_staging:
+	  hosts:
+		lib-jobs-staging1.princeton.edu:
+	lib_jobs_prod:
+	  hosts:
+		lib-jobs-prod1.princeton.edu:
+	lib_svn_staging:
+	  hosts:
+		lib-svn-staging1.princeton.edu:
+	lib_svn:
+	  hosts:
+		lib-svn-prod1.princeton.edu:
+	postgresql_staging:
+	  hosts:
+		lib-postgres-staging1.princeton.edu:
+		lib-postgres-staging2.princeton.edu:
+	pgbouncer_staging:
+	  hosts:
+		lib-pgbouncer-staging1.princeton.edu:
+	libruby_dev:
+	  hosts:
+		libruby-dev.princeton.edu:
+	libruby_prod:
+	  hosts:
+		libruby-prod.princeton.edu:
+	libstatic_staging:
+	  hosts:
+		lib-static-staging1.princeton.edu:
+	libstatic_prod:
+	  hosts:
+		lib-static-prod1.princeton.edu:
+	mudd_staging:
+	  hosts:
+		lib-mudd-staging1.princeton.edu:
+	mudd_prod:
+	  hosts:
+		lib-mudd-prod1.princeton.edu:
+	confluence_staging:
+	  hosts:
+		lib-confluence-staging1.princeton.edu:
+	perconaxdb_prod_cluster:
+	  hosts:
+		mariadb-prod2.princeton.edu:
+	percona_prod:
+	  hosts:
+		mariadb-prod1.princeton.edu:
+		mariadb-prod3.princeton.edu:
+	library_solr_staging:
+	  hosts:
+		library-solr-staging1.princeton.edu:
+	library_solr_prod:
+	  hosts:
+		library-solr-prod1.princeton.edu:
+	elixir_test:
+	  hosts:
+		lib-elixir-test1.princeton.edu:
+	ruby_office:
+	  hosts:
+		ruby-office1.princeton.edu:
+	smb_serve:
+	  hosts:
+		lib-smb-serve.princeton.edu:
+	kennyloggin:
+	  hosts:
+		kennyloggin1.princeton.edu:
+		kennyloggin2.princeton.edu:
+		kennyloggin3.princeton.edu:
+	researchdata_staging:
+	  hosts:
+		prds-staging1.princeton.edu:
+	researchdata_prod:
+	  hosts:
+		prds-prod1.princeton.edu:
+	gcp_postgresql_staging:
+	  hosts:
+		gcp_postgres_staging1 ansible_host=10.132.0.2:
+		gcp_postgres_staging2 ansible_host=10.132.0.3:
+	gcp_postgresql_production:
+	  hosts:
+		gcp_postgres_prod1 ansible_host=10.240.0.2:
+		gcp_postgres_prod2 ansible_host=10.240.0.3:
+	gcp_oar_dev:
+	  hosts:
+		gcp_oar_dev1 ansible_host=10.0.20.3:
+	gcp_oar_staging:
+	  hosts:
+		gcp_oar_staging1 ansible_host=10.132.0.4:
+	gcp_oar_production:
+	  hosts:
+		gcp_oar_prod1 ansible_host=10.244.0.3:
+	gcp_dataspace_dev:
+	  hosts:
+		gcp_dataspace_dev1 ansible_host=10.0.20.4:
+	gcp_dataspace_staging:
+	  hosts:
+		gcp_dataspace_staging1 ansible_host=10.132.0.5:
+	gcp_dataspace_production:
+	  hosts:
+		gcp_dataspace_prod1 ansible_host=10.244.0.2:
+	monitor_backends:
+	  hosts:
+		lib-monitor1.princeton.edu:
+	monitor_agents:
+	  hosts:
+		library-solr-prod1.princeton.edu:
+		lib-solr1.princeton.edu:
+		lib-solr2.princeton.edu:
+		lib-solr3.princeton.edu:
+		lib-pulindexer1.princeton.edu:
+		lib-pulindexer2.princeton.edu:
+		lib-pulindexer3.princeton.edu:
+		figgy1.princeton.edu:
+		figgy2.princeton.edu:
+		lib-proc6.princeton.edu:
+		lib-proc7.princeton.edu:
+		lib-proc8.princeton.edu:
+		lib-proc9.princeton.edu:
+		lib-proc10.princeton.edu:
+		lib-proc11.princeton.edu:
+		lib-orange-prod2.princeton.edu:
+		lib-orange-prod3.princeton.edu:
+		lib-orange-prod4.princeton.edu:
+		lib-orange-prod6.princeton.edu:
+		lib-postgres-staging1.princeton.edu:
+		lib-postgres-staging2.princeton.edu:
+		lib-solr-prod4.princeton.edu:
+		lib-solr-prod5.princeton.edu:
+		lib-solr-prod6.princeton.edu:
+		library-prod1.princeton.edu:
+		library-prod3.princeton.edu:
+		library-prod4.princeton.edu:
+		slavery-prod1.princeton.edu:
+		lae1.princeton.edu:
+		lae2.princeton.edu:
+		geoserv1.princeton.edu:
+		dss-prod1.princeton.edu:
+		dss-prod2.princeton.edu:
+		lib-svn-prod1.princeton.edu:
+		lib-zk1.princeton.edu:
+		lib-zk2.princeton.edu:
+		lib-zk3.princeton.edu:
+		maps1.princeton.edu:
+		maps2.princeton.edu:
+		cicognara1.princeton.edu:
+		cicognara2.princeton.edu:
+		bibdata1.princeton.edu:
+		bibdata2.princeton.edu:
+		lib-postgres3.princeton.edu:
+		lib-postgres4.princeton.edu:
+		prds-prod1.princeton.edu:
+		cdh-pemm1.princeton.edu:


### PR DESCRIPTION
This is in preparation for monitoring (look towards bottom of file)
  where will need to define specific groups and children to run ansible
  against

this will be needed by #1784 but no reason not to take advantage of this now
