### PR TITLE
Update proxy pass to use Drupal site for Pathe Baby

### DIFF
--- a/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/pulibrary.nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -27,7 +27,7 @@
 
     rewrite ^/special-collections/pathebaby(.*)$ /pathebaby/$1 redirect;
     location /pathebaby/ {
-        proxy_pass https://lib-static-prod.princeton.edu/pathebaby/;
+        proxy_pass http://libphp-prod.princeton.edu/pathebaby/;
     }
 
     rewrite ^/special-collections/hogarth(.*)$ /hogarth/$1 redirect;


### PR DESCRIPTION
This will point to the Drupal site to restore search functionality for students.