### PR TITLE
Updating the Node.js release to the 12.x series (LTS Erbium) for the orangelight Role

### DIFF
--- a/roles/orangelight/vars/main.yml
+++ b/roles/orangelight/vars/main.yml
@@ -7,3 +7,5 @@ rails_app_dependencies:
   - pkg-config
   - libtool
   - autoconf
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'


### PR DESCRIPTION
This isolates the updates introduced in https://github.com/pulibrary/princeton_ansible/issues/1315 for just the `orangelight` Role.