### PR TITLE
[Bibdata] Add APPLICATION_URL to group_vars

### DIFF
--- a/group_vars/bibdata/alma_staging.yml
+++ b/group_vars/bibdata/alma_staging.yml
@@ -103,6 +103,8 @@ rails_app_vars:
     value: '{{ scsb_s3_secret_access_key }}'
   - name: SCSB_S3_BUCKET_NAME
     value: '{{ scsb_s3_bucket_name }}'
+  - name: APPLICATION_URL
+    value: 'bibdata-alma-staging.princeton.edu'
 sidekiq_worker_name: bibdata-workers
 samba_users:
   - name: pulsys


### PR DESCRIPTION
Allows for the correct URLs to be generated for reindexing tasks.