### PR TITLE
Adding dom dependency that is no longer there by default in 7.4

### DIFF
--- a/roles/pas/tasks/main.yml
+++ b/roles/pas/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for roles/pas
 - name: pas | Install php7.2 requirements for craft
   apt:
-    name: ["php7.4-gd", "php7.4-json", "php7.4-mbstring", "php7.4-mysql", "php7.4-zip", "php7.4-intl"]
+    name: ["php7.4-gd", "php7.4-json", "php7.4-mbstring", "php7.4-mysql", "php7.4-zip", "php7.4-intl", "php7.4-dom"]
     state: present
     update_cache: true
 


### PR DESCRIPTION
fixes https://github.com/PrincetonUniversityLibrary/pas-craft3/issues/15