### PR TITLE
[Bibdata] Fix Bibdata role for bibdata-alma-staging.

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -66,6 +66,7 @@ project_db_host: http://127.0.0.1
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_admin_user: '{{ vault_postgres_admin_user }}'
 postgres_host: '{{ vault_postgres_host }}'
+postgresql_is_cloud: false
 samba_pulsys_password: '{{ vault_samba_pulsys_password }}'
 mariadb_mysql_root_password: '{{ vault_maria_mysql_root_password }}'
 maria_db_cluster_host: '{{ vault_maria_db_cluster_host }}'

--- a/roles/bibdata/tasks/samba_server.yml
+++ b/roles/bibdata/tasks/samba_server.yml
@@ -1,19 +1,12 @@
 ---
-- name: Adjust samba share permissions
+- name: Create Samba Data Sources
   file:
-    path: '/data/marc_liberation_files'
-    mode: 0777
+    path: '{{ item }}'
+    state: directory
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
-- name: Adjust samba share permissions
-  file:
-    path: '/data/marc_liberation_files/scsb_update_files'
     mode: 0777
-    owner: '{{ deploy_user }}'
-    group: '{{ deploy_user }}'
-- name: Adjust samba share permissions
-  file:
-    path: '/data/marc_liberation_files/campus_access_files'
-    mode: 0777
-    owner: '{{ deploy_user }}'
-    group: '{{ deploy_user }}'
+  with_items:
+    - '/data/marc_liberation_files'
+    - '/data/marc_liberation_files/scsb_update_files'
+    - '/data/marc_liberation_files/campus_access_files'


### PR DESCRIPTION
Closes #2059

Without the `state: directory` it tried to adjust permissions for a directory which may not be there.