### PR TITLE
Removing cron responsibility from ansible for libwww

### DIFF
--- a/group_vars/libwww/libwww-prod.yml
+++ b/group_vars/libwww/libwww-prod.yml
@@ -37,6 +37,7 @@ special_collections_drupal_base_path: 'https://library.princeton.edu/special-col
 special_collections_drupal_ssl_base_path: 'https://library.princeton.edu/special-collections'
 special_collections_drupal_db_name: 'special_collections_prod'
 special_collections_drupal_db_host: 'mariadb-prod3.princeton.edu'
+bundler_version: '2.1.4'
 
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_service_name: library

--- a/group_vars/libwww/libwww-staging.yml
+++ b/group_vars/libwww/libwww-staging.yml
@@ -45,3 +45,4 @@ install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
 mailcatcher_install_location: "/var/lib/gems/2.6.0/gems/mailcatcher-0.7.1/bin/mailcatcher"
+bundler_version: '2.1.4'

--- a/roles/capistrano/defaults/main.yml
+++ b/roles/capistrano/defaults/main.yml
@@ -5,3 +5,4 @@ capistrano_shared_links: []
 capistrano_base_dir: '/opt'
 capistrano_web_owner: 'www-data'
 capistrano_web_service: 'nginx'
+cap_install_whenever: false

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -71,3 +71,11 @@
     state: "present"
     line: "{{ deploy_user }} ALL=(ALL) NOPASSWD: /bin/chown -R deploy {{ capistrano_base_dir }}/{{ capistrano_directory }}*"
     validate: "visudo -cf %s"
+
+- name: Allow deploy user to bundle install as root to allow whenever to run on non rails machines
+  lineinfile:
+    dest: "/etc/sudoers"
+    state: "present"
+    line: "{{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/local/bin/bundle install"
+    validate: "visudo -cf %s"
+  when: cap_install_whenever

--- a/roles/drupal/vars/main.yml
+++ b/roles/drupal/vars/main.yml
@@ -5,3 +5,4 @@ capistrano_shared_links: []
 capistrano_base_dir: '{{ drupal_base_dir }}'
 capistrano_web_owner: '{{ drupal_web_owner }}'
 capistrano_web_service: '{{ drupal_web_service }}'
+cap_install_whenever: true

--- a/roles/libwww/defaults/main.yml
+++ b/roles/libwww/defaults/main.yml
@@ -43,6 +43,7 @@ special_collections_drupal_base_path: 'https://localhost/special-collections'
 special_collections_drupal_ssl_base_path: 'https://localhost/special-collections'
 special_collections_drupal_db_name: 'special_collections'
 
+datadog_trace_environment: ''
 special_collections_datadog_trace_environment: "{{ datadog_trace_environment }}"
 
 discovery_utils_datadog_trace_environment: "{{ datadog_trace_environment }}"

--- a/roles/libwww/molecule/default/verify.yml
+++ b/roles/libwww/molecule/default/verify.yml
@@ -76,6 +76,4 @@
   - name: assert cron jobs exists
     assert:
       that:
-        - "'0 * * * * sudo -u www-data drush @prod cron' in cron_results.stdout"
-        - "'0 7 * * * /usr/bin/get_staff_updates.sh >/tmp/staff_updates.out 2>&1' in cron_results.stdout"
         - "'10 * * * * sudo -u www-data drush -r /var/www/special_collections_cap/current cron' in cron_results.stdout"

--- a/roles/libwww/tasks/main.yml
+++ b/roles/libwww/tasks/main.yml
@@ -64,23 +64,6 @@
     group: '{{ deploy_user }}'
     mode: 0777
 
-- name: libwww | install the cron job for staff
-  cron:
-    name: "staff profile"
-    minute: 0
-    hour: 7
-    job: "/usr/bin/get_staff_updates.sh >/tmp/staff_updates.out 2>&1"
-    user: "{{ deploy_user }}"
-  when: (inventory_hostname ==  groups[group_names[0]][0])
-
-- name: libwww | install the cron for running drush cron
-  cron:
-    name: "run drush cron"
-    minute: 0
-    job: "sudo -u www-data drush @prod cron"
-    user: "{{ deploy_user }}"
-  when: (inventory_hostname ==  groups[group_names[0]][0])
-
 - name: libwww | ensure max file size is set in apache2 php.ini
   lineinfile:
     dest: "/etc/php/7.4/apache2/php.ini"


### PR DESCRIPTION
Allow libwww to run whenever so that we can maintain the cron tab with the code
Left Special Collections cron in, since we have yet to look at whenever for that codebase