### PR TITLE
Fixing host list for library-prod

### DIFF
--- a/hosts
+++ b/hosts
@@ -176,8 +176,8 @@ library-staging1.princeton.edu
 library-staging2.princeton.edu
 [libwww_prod]
 library-prod1.princeton.edu
-library-prod2.princeton.edu
 library-prod3.princeton.edu
+library-prod4.princeton.edu
 [recap_stage]
 recap-www-staging1.princeton.edu
 [recap_prod]


### PR DESCRIPTION
Library-prod2 does not exists, but library-prod4 does.  Updating host list to match actual machines