### PR TITLE
Reorder roles in the pulmap playbook so common runs first

### DIFF
--- a/playbooks/pulmap_production.yml
+++ b/playbooks/pulmap_production.yml
@@ -6,8 +6,8 @@
     - ../group_vars/pulmap/vault.yml
     - ../group_vars/pulmap/pulmap_production.yml
   roles:
-    - role: datadog
     - role: roles/pulmap
+    - role: datadog
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook


### PR DESCRIPTION
We need that apt-cache business and datadog doesn't have common as a
dependency