### PR TITLE
Updating gitattributes to reflect unvaulted files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,6 @@ group_vars/all/vault.yml diff=ansible-vault merge=ansible-vault
 group_vars/bibdata/vault.yml diff=ansible-vault merge=ansible-vault
 group_vars/solrcloud/vault.yml diff=ansible-vault merge=ansible-vault
 group_vars/lib-jobs/vault.yml diff=ansible-vault merge=ansible-vault
-roles/nginxplus/files/conf/http/*.conf diff=ansible-vault merge=ansible-vault
+roles/nginxplus/files/conf/http/templates/restrict.conf diff=ansible-vault merge=ansible-vault
 roles/nginxplus/files/conf/stream/*.conf diff=ansible-vault merge=ansible-vault
 group_vars/**/vault.yml diff=ansible-vault merge=ansible-vault


### PR DESCRIPTION
nginx files are now no longer vaulted.  This causes errors when trying to amend commits or run a git diff.
fixes #2240