### PR TITLE
Update bibdata boxes to node 12

### DIFF
--- a/roles/bibdata/vars/main.yml
+++ b/roles/bibdata/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for bibdata
+nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_key_id: '68576280'


### PR DESCRIPTION
This was run on bibdata, bibdata staging, bibdata worker boxes, and bibdata-alma-staging

closes pulibrary/bibdata#752