### PR TITLE
Move hr share out of bibdata role dependencies and into playbooks

### DIFF
--- a/playbooks/bibdata_alma_staging.yml
+++ b/playbooks/bibdata_alma_staging.yml
@@ -13,6 +13,7 @@
   roles:
     - role: roles/bibdata
     - role: roles/bibdata_sqs_poller
+    - role: 'hr_share'
     - role: roles/datadog
 
   post_tasks:

--- a/playbooks/bibdata_production.yml
+++ b/playbooks/bibdata_production.yml
@@ -11,6 +11,7 @@
   roles:
     - role: 'oracle_client'
     - role: roles/bibdata
+    - role: 'hr_share'
     - role: roles/datadog
 - hosts: bibdata_workers
   remote_user: pulsys

--- a/playbooks/bibdata_staging.yml
+++ b/playbooks/bibdata_staging.yml
@@ -13,6 +13,7 @@
   roles:
     - role: 'oracle_client'
     - role: roles/bibdata
+    - role: 'hr_share'
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/roles/bibdata/meta/main.yml
+++ b/roles/bibdata/meta/main.yml
@@ -21,4 +21,3 @@ dependencies:
   - role: 'nodejs'
   - role: 'rails_app'
   - role: 'sidekiq_worker'
-  - role: 'hr_share'


### PR DESCRIPTION
It's not needed on the worker box
