### PR TITLE
Removing campus access from list

### DIFF
--- a/roles/bibdata/tasks/samba_server.yml
+++ b/roles/bibdata/tasks/samba_server.yml
@@ -9,4 +9,3 @@
   with_items:
     - '/data/marc_liberation_files'
     - '/data/marc_liberation_files/scsb_update_files'
-    - '/data/marc_liberation_files/campus_access_files'


### PR DESCRIPTION
We do not want it owned by deploy as we can not write to it if it is