### PR TITLE
Add galaxy.yml to allow installing as a collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,9 @@
+namespace: "pulibrary"
+name: "princeton_ansible"
+version: "1.0.0"
+readme: "README.md"
+authors:
+    - "Princeton University Library"
+license:
+    - "MIT"
+repository: "https://github.com/pulibrary/princeton_ansible"


### PR DESCRIPTION
With the galaxy.yml file added, I'm able to install this repository as a collection of roles.

Here's what I put in my `requirements.yml` (version set to this branch for testing to confirm):
```
collections:
  - name: https://github.com/pulibrary/princeton_ansible.git
    type: git
    version: galaxy-collection
```

And then I installed with `ansible-galaxy install -r requirements.yml`

I put in what I thought would be reasonable defaults for the galaxy.yml; the only thing I wasn't sure about was version because AFAIK you don't version this repository.  Here is the [documentation on galaxy.yml fields](https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html#collections-galaxy-meta)