### PR TITLE
Update timezome role in orangelight workers

### DIFF
--- a/playbooks/orangelight_workers.yml
+++ b/playbooks/orangelight_workers.yml
@@ -11,4 +11,4 @@
     - role: roles/nodejs
     - role: roles/extra_path
     - role: roles/rails_app
-    - role: roles/timezone-eastern
+    - role: roles/timezone


### PR DESCRIPTION
The role was renamed but hadn't been updated in this playbook
