### PR TITLE
Adjust IP access to CDH geniza sites

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_geniza_prod.conf
+++ b/roles/nginxplus/files/conf/http/cdh_geniza_prod.conf
@@ -48,10 +48,7 @@ server {
         health_check interval=10 fails=3 passes=2;
 
         # allow princeton network
-        allow 128.112.0.0/16;
-        allow 140.180.0.0/16;
-        allow 172.20.95.0/24;
-        allow 172.20.192.0/19;
+        include /etc/nginx/conf.d/templates/restrict.conf;
         # allow access from old PGP site on cPanel
         allow 198.199.71.236;
         # block all

--- a/roles/nginxplus/files/conf/http/cdh_geniza_prod.conf
+++ b/roles/nginxplus/files/conf/http/cdh_geniza_prod.conf
@@ -46,6 +46,16 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache geniza_prodcache;
         health_check interval=10 fails=3 passes=2;
+
+        # allow princeton network
+        allow 128.112.0.0/16;
+        allow 140.180.0.0/16;
+        allow 172.20.95.0/24;
+        allow 172.20.192.0/19;
+        # allow access from old PGP site on cPanel
+        allow 198.199.71.236;
+        # block all
+        deny all;
     }
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;
 }

--- a/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
@@ -47,10 +47,7 @@ server {
         proxy_cache test_genizacache;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
-        allow 128.112.0.0/16;
-        allow 140.180.0.0/16;
-        allow 172.20.95.0/24;
-        allow 172.20.192.0/19;
+        include /etc/nginx/conf.d/templates/restrict.conf;
         # allow access from old PGP site on cPanel
         allow 198.199.71.236;
         # block all

--- a/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
@@ -51,6 +51,8 @@ server {
         allow 140.180.0.0/16;
         allow 172.20.95.0/24;
         allow 172.20.192.0/19;
+        # allow access from old PGP site on cPanel
+        allow 198.199.71.236;
         # block all
         deny all;
     }


### PR DESCRIPTION
- add cPanel ip to test site to give access from old PGP site
- restrict production site to campus/vpn+cPanel while in development

Please confirm I did this right! I just copied the other examples