### PR TITLE
Make test-geniza.cdh and geniza.cdh the canonical hostnames

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_geniza_prod.conf
+++ b/roles/nginxplus/files/conf/http/cdh_geniza_prod.conf
@@ -24,7 +24,22 @@ server {
     server_name cdh-geniza.princeton.edu;
 
     location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://geniza.cdh.princeton.edu$request_uri;
+    }
+}
+
+
+server {
+    listen 443 ssl;
+    server_name cdh-geniza.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/geniza_cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/geniza_cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        return 301 https://geniza.cdh.princeton.edu$request_uri;
     }
 }
 
@@ -53,26 +68,6 @@ server {
         allow 198.199.71.236;
         # block all
         deny all;
-    }
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
-}
-
-server {
-    listen 443 ssl;
-    server_name cdh-geniza.princeton.edu;
-
-    ssl_certificate            /etc/nginx/conf.d/ssl/certs/geniza_cdh_princeton_edu_chained.pem;
-    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/geniza_cdh_princeton_edu_priv.key;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
-
-    location / {
-        proxy_pass http://geniza_prod;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_cache geniza_prodcache;
-        health_check interval=10 fails=3 passes=2;
     }
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;
 }

--- a/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
@@ -24,7 +24,22 @@ server {
     server_name cdh-test-geniza.princeton.edu;
 
     location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://test-geniza.cdh.princeton.edu$request_uri;
+    }
+}
+
+
+server {
+    listen 443 ssl;
+    server_name cdh-test-geniza.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/test-geniza_cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/test-geniza_cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        return 301 https://test-geniza.cdh.princeton.edu$request_uri;
     }
 }
 
@@ -50,30 +65,6 @@ server {
         include /etc/nginx/conf.d/templates/restrict.conf;
         # allow access from old PGP site on cPanel
         allow 198.199.71.236;
-        # block all
-        deny all;
-    }
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
-}
-
-server {
-    listen 443 ssl;
-    server_name cdh-test-geniza.princeton.edu;
-
-    ssl_certificate            /etc/nginx/conf.d/ssl/certs/test-geniza_cdh_princeton_edu_chained.pem;
-    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/test-geniza_cdh_princeton_edu_priv.key;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
-
-    location / {
-        proxy_pass http://test_geniza;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_cache test_genizacache;
-        health_check interval=10 fails=3 passes=2;
-        # allow princeton network
-        include /etc/nginx/conf.d/templates/restrict.conf;
         # block all
         deny all;
     }


### PR DESCRIPTION
configures cdh-test-geniza and cdh-test-geniza as redirect locations so we don't have two different location blocks and two different urls