### PR TITLE
WIP: Work on sorting out bibdata samba clients from servers

### DIFF
--- a/group_vars/bibdata/alma_production.yml
+++ b/group_vars/bibdata/alma_production.yml
@@ -125,29 +125,6 @@ rails_app_vars:
     value: "{{ vault_production_sqs_queue_url }}"
 sidekiq_worker_name: bibdata-workers
 bibdata_samba_source_host: 'bibdata-alma-worker1.princeton.edu'
-samba_shares_root: '/data'
-samba_users:
-  - name: pulsys
-    password: '{{samba_pulsys_password}}'
-samba_shares:
-  - name: marc_liberation_files
-    owner: deploy
-    group: sambashare
-    write_list: +sambashare
-    writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
-  - name: marc_liberation_files/scsb_update_files
-    owner: deploy
-    group: sambashare
-    write_list: +sambashare
-    writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
 
 bibdata_db: "bibdata_alma_production"
 bibdata_db_port: 5432

--- a/group_vars/bibdata/alma_staging.yml
+++ b/group_vars/bibdata/alma_staging.yml
@@ -124,29 +124,6 @@ rails_app_vars:
   - name: SQS_QUEUE_URL
     value: "{{ vault_sqs_queue_url }}"
 sidekiq_worker_name: bibdata-workers
-samba_users:
-  - name: pulsys
-    password: '{{samba_pulsys_password}}'
-samba_shares:
-  - name: marc_liberation_files
-    owner: deploy
-    group: sambashare
-    write_list: "deploy, +sambashare"
-    writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
-  - name: marc_liberation_files/scsb_update_files
-    owner: deploy
-    group: sambashare
-    write_list: "deploy, +sambashare"
-    writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
-
 bibdata_db: "bibdata_alma_staging"
 bibdata_db_port: 5432
 application_dbuser_name: "bibdata"

--- a/playbooks/bibdata_alma_production.yml
+++ b/playbooks/bibdata_alma_production.yml
@@ -9,7 +9,7 @@
     - ../group_vars/bibdata/alma_workers.yml
   vars:
     passenger_server_name: bibdata-alma.*
-    samba_status: "server"
+    samba_status: "server" # This becomes an issue if there's more than one worker
   roles:
     - role: roles/bibdata
     - role: roles/bibdata_sqs_poller
@@ -37,6 +37,7 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
         channel: #server-alerts
+
 - hosts: bibdata_alma_production
   remote_user: pulsys
   become: true

--- a/playbooks/bibdata_alma_staging.yml
+++ b/playbooks/bibdata_alma_staging.yml
@@ -17,22 +17,6 @@
     - role: roles/datadog
 
   post_tasks:
-    - name: Correct file permissions for /data/marc_liberation_files
-      file:
-        path: "/data/marc_liberation_files"
-        owner: "{{ deploy_user }}"
-        group: "sambashare"
-        mode: 0777
-      when: running_on_server
-
-    - name: Correct file permissions for /data/marc_liberation_files/scsb_update_files
-      file:
-        path: "/data/marc_liberation_files/scsb_update_files"
-        owner: "{{ deploy_user }}"
-        group: "sambashare"
-        mode: 0777
-      when: running_on_server
-
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"


### PR DESCRIPTION
We should not provide yml config when we want the box to be a samba
server. That config gets used by the samba role (a prerequisite
for the hr_shares role) to set up the client connection.

refs #2290