### PR TITLE
Add datadog to orangelight alma

### DIFF
--- a/playbooks/orangelight_alma_prod.yml
+++ b/playbooks/orangelight_alma_prod.yml
@@ -6,6 +6,7 @@
     - ../group_vars/orangelight/alma_prod.yml
     - ../group_vars/orangelight/vault.yml
   roles:
+    - role: roles/datadog
     - role: roles/postgresql
     - role: roles/orangelight
 

--- a/playbooks/orangelight_alma_qa.yml
+++ b/playbooks/orangelight_alma_qa.yml
@@ -6,6 +6,7 @@
     - ../group_vars/orangelight/alma_qa.yml
     - ../group_vars/orangelight/vault.yml
   roles:
+    - role: roles/datadog
     - role: roles/postgresql
     - role: roles/orangelight
 


### PR DESCRIPTION
Closes #2318 
Closes https://github.com/pulibrary/orangelight/issues/2492

Playbook changes were run on alma-qa and alma-prod. Logs are showing up in datadog.