### PR TITLE
[Bibdata] fix write errors

### DIFF
--- a/group_vars/bibdata/alma_staging.yml
+++ b/group_vars/bibdata/alma_staging.yml
@@ -139,22 +139,16 @@ samba_shares:
     group: sambashare
     write_list: "deploy, +sambashare"
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777
   - name: marc_liberation_files/scsb_update_files
     owner: deploy
     group: sambashare
     write_list: "deploy, +sambashare"
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777
   - name: marc_liberation_files/campus_access_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
 
 bibdata_db: "bibdata_alma_staging"
 bibdata_db_port: 5432

--- a/group_vars/bibdata/alma_workers.yml
+++ b/group_vars/bibdata/alma_workers.yml
@@ -9,23 +9,13 @@ samba_shares:
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
   - name: marc_liberation_files/scsb_update_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
   - name: marc_liberation_files/campus_access_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777

--- a/group_vars/bibdata/bibdata_workers.yml
+++ b/group_vars/bibdata/bibdata_workers.yml
@@ -141,20 +141,14 @@ samba_shares:
     group: sambashare
     write_list: +sambashare
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777
   - name: marc_liberation_files/scsb_update_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777
   - name: marc_liberation_files/campus_access_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777
 timezone: "America/New_York"

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -123,22 +123,16 @@ samba_shares:
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
   - name: marc_liberation_files/scsb_update_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
   - name: marc_liberation_files/campus_access_files
     owner: deploy
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
 
 bibdata_db: "marc_liberation_staging"
 bibdata_db_port: 5432

--- a/group_vars/cantaloupe/production.yml
+++ b/group_vars/cantaloupe/production.yml
@@ -37,10 +37,6 @@ samba_shares_root: '/'
 samba_shares:
   - name: data
     writable: 'yes'
-    create_mode: '0777'
-    force_create_mode: '0777'
-    directory_mode: '0777'
-    force_directory_mode: '0777'
     valid_users: pudl
 datadog_api_key: "{{vault_datadog_key}}"
 datadog_config:

--- a/group_vars/cantaloupe/staging.yml
+++ b/group_vars/cantaloupe/staging.yml
@@ -38,8 +38,4 @@ samba_shares_root: '/'
 samba_shares:
   - name: data
     writable: 'yes'
-    create_mode: '0777'
-    force_create_mode: '0777'
-    directory_mode: '0777'
-    force_directory_mode: '0777'
     valid_users: pudl

--- a/group_vars/geoserver.yml
+++ b/group_vars/geoserver.yml
@@ -7,15 +7,7 @@ samba_shares:
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777
   - name: figgy_geo_data
     group: sambashare
     write_list: +sambashare
     writable: yes
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777

--- a/group_vars/smb_serve/production.yml
+++ b/group_vars/smb_serve/production.yml
@@ -7,7 +7,3 @@ samba_shares:
     group: deploy
     write_list: +deploy
     writable: true
-    create_mode: 0777
-    force_create_mode: 0777
-    directory_mode: 0777
-    force_directory_mode: 0777

--- a/roles/bibdata/tasks/samba_client.yml
+++ b/roles/bibdata/tasks/samba_client.yml
@@ -20,7 +20,7 @@
     name: '{{ bibdata_data_dir }}'
     src: '//{{ bibdata_samba_source_host }}/marc_liberation_files'
     fstype: cifs
-    opts: 'credentials=/etc/bibdata-worker.smb.credentials,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }}'
+    opts: 'credentials=/etc/bibdata-worker.smb.credentials,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }},file_mode=0775,dir_mode=0775'
     state: mounted
 
 - name: Create marc_liberation data mount {{ scsb_file_dir }}
@@ -28,7 +28,7 @@
     name: '{{ scsb_file_dir }}'
     src: '//{{ bibdata_samba_source_host }}/marc_liberation_files/scsb_update_files'
     fstype: cifs
-    opts: 'credentials=/etc/bibdata-worker.smb.credentials,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }}'
+    opts: 'credentials=/etc/bibdata-worker.smb.credentials,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }},file_mode=0775,dir_mode=0775'
     state: mounted
   ignore_errors: true
 

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,10 +1,18 @@
 ---
+- name: nodejs | Get debsource APT GPG key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+  register: debsource_servers
+  ignore_errors: true
+
 - name: Get upstream APT GPG key
   apt_key:
     id: "{{ nodejs__upstream_key_id }}"
     keyserver: "hkp://pool.sks-keyservers.net"
     state: present
   register: pool_servers
+  when: debsource_servers is failed
   ignore_errors: true
 
 - name: Get upstream APT GPG key from MIT
@@ -26,13 +34,19 @@
 
 - name: Add upstream Yarn APT key from PGP
   apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+  register: yarn_servers
+  ignore_errors: true
+
+- name: Add upstream Yarn APT key from PGP
+  apt_key:
     id: "{{ nodejs__yarn_upstream_key_id }}"
     keyserver: "hkp://pool.sks-keyservers.net"
     state: present
   register: yarnpool_servers
+  when: yarn_servers is failed
   ignore_errors: true
-  changed_when: false
-  # TODO: This changed when should be removed when we upgrade to molecule 3
 
 - name: Add upstream Yarn APT key from MIT
   apt_key:
@@ -50,8 +64,16 @@
     keyserver: "keyserver.pgp.com"
   when: yarnmit_servers is failed
   ignore_errors: true
-  changed_when: false
-  # TODO: This changed when should be removed when we upgrade to molecule 3
+
+- name: Configure upstream APT repository
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_12.x {{ ansible_lsb.codename }} main
+    state: present
+    update_cache: true
+  register: nodejs_repo
+  retries: 3
+  delay: 60
+  until: nodejs_repo is succeeded
 
 - name: Configure upstream APT repository
   apt_repository:
@@ -69,8 +91,6 @@
     state: present
     update_cache: true
   ignore_errors: true
-  changed_when: false
-  # TODO: This changed when should be removed when we upgrade to molecule 3
 
 - name: Gather the apt package facts
   package_facts:
@@ -97,5 +117,3 @@
     name: ["nodejs", "yarn"]
     state: present
     autoremove: true
-  changed_when: false
-  # TODO: This changed when should be removed when we upgrade to molecule 3

--- a/roles/samba/templates/smb.conf.j2
+++ b/roles/samba/templates/smb.conf.j2
@@ -92,11 +92,13 @@
 {% endif %}
 {% if share.writable is defined %}
   writable = {{ share.writable }}
+## We're hard-coding these values because we don't have a use case for anything
+#  other than 777 and somehow they were always coming through as 511
 {% endif %}
-  create mode = {{ share.create_mode|default('0664') }}
-  force create mode = {{ share.force_create_mode|default('0664') }}
-  directory mode = {{ share.directory_mode|default('0775') }}
-  force directory mode = {{ share.force_directory_mode|default('0775') }}
+  create mode = 0777
+  force create mode = 0777
+  directory mode = 0777
+  force directory mode = 0777
 
 {% endfor %}
 {% endif%}


### PR DESCRIPTION
fixes pulibrary/bibdata#1457

The smb.conf file was somehow coming up with 511 file and directory permissions even though we had configuration and a default value asking it to do otherwise. We ended up just hard-coding these values because there isn't a use case for any other value on any of our boxes.

Note this has been run on bibdata-alma production boxes.