### PR TITLE
[Solrcloud] Increase jetty idle timeout

### DIFF
--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -72,8 +72,8 @@ solr_zk_host: '{{ solr_zookeeper_hosts_string }}{{ solr_znode_path if solr_znode
 
 # Orangelight Jars
 jardirectory: /opt/solr/contrib/analysis-extras/lib
-cjkfoldingfilter: https://github.com/pulibrary/pul_solr/raw/master/solr_configs/catalog-production/conf/CJKFoldingFilter.jar
-umichsolrfilters: https://github.com/pulibrary/pul_solr/raw/master/solr_configs/catalog-production/conf/lucene-umich-solr-filters-6.0.0-SNAPSHOT.jar
+cjkfoldingfilter: https://github.com/pulibrary/pul_solr/raw/main/solr_configs/catalog-production-v2/conf/CJKFoldingFilter.jar
+umichsolrfilters: https://github.com/pulibrary/pul_solr/raw/main/solr_configs/catalog-production-v2/conf/lucene-umich-solr-filters-6.0.0-SNAPSHOT.jar
 
 # LOG
 log_root_level: WARN

--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -44,7 +44,7 @@ solr_stack_size: 256k
 solr_heap: "{{ solr_heap_setting | default('72g') }}"
 solr_jetty_threads_min: 10
 solr_jetty_threads_max: 10000
-solr_jetty_threads_idle_timeout: 5000
+solr_jetty_threads_idle_timeout: 30000
 solr_jetty_threads_stop_timeout: 60000
 solr_jetty_secure_port: 8443
 solr_jetty_output_buffer_size: 32768

--- a/roles/solrcloud/templates/solr.in.sh.j2
+++ b/roles/solrcloud/templates/solr.in.sh.j2
@@ -59,7 +59,7 @@ RMI_PORT={{ solr_jmx_port }}
 SOLR_OPTS="$SOLR_OPTS -Xss{{ solr_stack_size }}"
 
 # Set idle timeout
-SOLR_OPTS = "$SOLR_OPTS -Dsolr.jetty.threads.idle.timeout=1800000"
+SOLR_OPTS="$SOLR_OPTS -Dsolr.jetty.threads.idle.timeout=1800000"
 
 # Anything you add to the SOLR_OPTS variable will be included in the java
 # start command line as-is, in ADDITION to other options. If you specify the

--- a/roles/solrcloud/templates/solr.in.sh.j2
+++ b/roles/solrcloud/templates/solr.in.sh.j2
@@ -58,6 +58,9 @@ RMI_PORT={{ solr_jmx_port }}
 # Set the thread stack size
 SOLR_OPTS="$SOLR_OPTS -Xss{{ solr_stack_size }}"
 
+# Set idle timeout
+SOLR_OPTS = "$SOLR_OPTS -Dsolr.jetty.threads.idle.timeout=1800000"
+
 # Anything you add to the SOLR_OPTS variable will be included in the java
 # start command line as-is, in ADDITION to other options. If you specify the
 # -a option on start script, those options will be appended as well. Examples:


### PR DESCRIPTION
A short timeout causes large updates to fail.