### PR TITLE
[Bibdata] Install sidekiq only on alma-worker1-3.

### DIFF
--- a/hosts
+++ b/hosts
@@ -57,7 +57,6 @@ bibdata-alma1.princeton.edu
 bibdata-alma2.princeton.edu
 bibdata-alma-worker2.princeton.edu
 bibdata-alma-worker3.princeton.edu
-bibdata-alma-worker4.princeton.edu
 [cicognara_staging]
 cicognara-staging1.princeton.edu
 [cicognara_production]

--- a/playbooks/bibdata_alma_production.yml
+++ b/playbooks/bibdata_alma_production.yml
@@ -15,6 +15,11 @@
     - role: roles/bibdata_sqs_poller
     - role: 'hr_share'
     - role: roles/datadog
+  tasks:
+    - name: Install sidekiq worker
+      include_role:
+        name: 'sidekiq_worker'
+      when: "'worker' in inventory_hostname"
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       slack:
@@ -37,6 +42,11 @@
     - role: roles/bibdata_sqs_poller
     - role: 'hr_share'
     - role: roles/datadog
+  tasks:
+    - name: Install sidekiq worker
+      include_role:
+        name: 'roles/sidekiq_worker'
+      when: "'worker' in inventory_hostname"
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       slack:

--- a/playbooks/bibdata_alma_staging.yml
+++ b/playbooks/bibdata_alma_staging.yml
@@ -12,6 +12,7 @@
     samba_status: server
   roles:
     - role: roles/bibdata
+    - role: roles/sidekiq_worker
     - role: roles/bibdata_sqs_poller
     - role: 'hr_share'
     - role: roles/datadog
@@ -34,6 +35,7 @@
     samba_status: client
   roles:
     - role: roles/bibdata
+    - role: roles/sidekiq_worker
     - role: roles/bibdata_sqs_poller
     - role: 'hr_share'
     - role: roles/datadog

--- a/roles/bibdata/meta/main.yml
+++ b/roles/bibdata/meta/main.yml
@@ -21,6 +21,5 @@ dependencies:
   - role: 'postgresql'
   - role: 'nodejs'
   - role: 'rails_app'
-  - role: 'sidekiq_worker'
   - role: 'timezone'
   - role: 'samba'


### PR DESCRIPTION
This just installs Sidekiq on any alma-prod hosts with *worker in the
name, in case we want to add more later.