### PR TITLE
Restart sshd after deploy_user reconfigures it

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ In all the steps below substitue your role name for `your_new_role`
       cp roles/example/molecule.yml roles/$your_new_role/molecule/default
       cp roles/example/main.yml roles/$your_new_role/meta/main.yml
       cp roles/example/.ansible-lint roles/$your_new_role/.ansible-lint
+      cp roles/example/yamllint roles/$your_new_role/.yamllint
       ```
 
    1. edit `vi roles/$your_new_role/meta/main.yml` and add a description

--- a/roles/deploy_user/.yamllint
+++ b/roles/deploy_user/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/roles/deploy_user/molecule/default/prepare.yml
+++ b/roles/deploy_user/molecule/default/prepare.yml
@@ -2,7 +2,7 @@
 - name: prepare
   hosts: all
   become: true
-  gather_facts: no
+  gather_facts: false
 
   roles:
     - role: common

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -89,3 +89,9 @@
     - sudo_options is defined
   loop_control:
     label: "{{ deploy_user }}"
+    
+# Note that this should not be necessary, but the `restart sshd` handler does not work
+- name: restart sshd for real
+  become: true
+  command: systemctl restart sshd
+  when: running_on_server

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -89,7 +89,7 @@
     - sudo_options is defined
   loop_control:
     label: "{{ deploy_user }}"
-    
+
 # Note that this should not be necessary, but the `restart sshd` handler does not work
 - name: restart sshd for real
   become: true

--- a/roles/example/yamllint
+++ b/roles/example/yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable


### PR DESCRIPTION
This shouldn't be necessary but the sshd handler does not work as
expected. We currently waste time over and over again tracking down
why the deploy user can't log in on newly built boxes, so let's fix that.