### PR TITLE
[orangelight qa] Update rabbit server to new figgy staging machine

### DIFF
--- a/group_vars/orangelight/alma_qa.yml
+++ b/group_vars/orangelight/alma_qa.yml
@@ -32,7 +32,7 @@ ol_newrelic_app_name: ""
 ol_honeybadger_key: "{{ vault_ol_honeybadger_key }}"
 ol_rabbit_user: "{{ vault_figgy_alma_qa_rabbit_user }}"
 ol_rabbit_password: "{{ vault_figgy_alma_qa_rabbit_password }}"
-ol_rabbit_host: "figgy-staging1.princeton.edu"
+ol_rabbit_host: "figgy-staging2.princeton.edu"
 ol_rabbit_server: "amqp://{{ ol_rabbit_user }}:{{ ol_rabbit_password }}@{{ ol_rabbit_host }}:5672"
 ol_read_only_mode: 'false'
 bd_auth_key: "{{ vault_bd_auth_key }}"


### PR DESCRIPTION
This was updated directly on the box (since lpass login was erroring).