### PR TITLE
Adding the SMTP host and port for the production oawaiver hosts

### DIFF
--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -55,6 +55,9 @@ app_solr_path: "/solr/{{ oawaiver_solr_core }}"
 app_secret_key: "{{ vault_oawaiver_prod_secret_key }}"
 app_host_name: "oawaiver.princeton.edu"
 
+app_smtp_host: "lib-ponyexpr.princeton.edu"
+app_smtp_port: 25
+
 rails_app_vars:
   - name: APP_SECRET_KEY_BASE
     value: "{{ app_secret_key }}"
@@ -78,3 +81,7 @@ rails_app_vars:
     value: "{{ app_host_name }}"
   - name: APPLICATION_HOST_PROTOCOL
     value: "{{ application_host_protocol }}"
+  - name: SMTP_HOST
+    value: "{{ app_smtp_host }}"
+  - name: SMTP_PORT
+    value: "{{ app_smtp_port }}"


### PR DESCRIPTION
This ensures that the environment variables are instead parsed for setting the SMTP host for oawaiver deployments.