### PR TITLE
Ensuring that the /rt4ds endpoint is accessible over the HTTP for OAR deployments

### DIFF
--- a/roles/oar/templates/oar_nginx.conf.j2
+++ b/roles/oar/templates/oar_nginx.conf.j2
@@ -246,7 +246,7 @@
 
         # Let users access REST and DS2 URLs quickly, but turn bots away
 
-        location ~ ^/(ds2|rest)/ {
+        location ~ ^/(ds2|rest|rt4ds)/ {
             if ($per_user_key ~ bot) {
               return 403;
             }


### PR DESCRIPTION
This is necessary in order to advance https://github.com/pulibrary/dspace-development/issues/465