### PR TITLE
Adding a proxy pass to maps on lib static

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -108,6 +108,11 @@
     location /RBVisuals {
         proxy_pass https://lib-dbserver.princeton.edu/RBVisuals;
     }
+
+    location /visual_materials/maps/ {
+        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/maps/;
+    }
+
     location /visual_materials {
         proxy_pass https://lib-dbserver.princeton.edu/visual_materials;
     }


### PR DESCRIPTION
This is the first step in moving visual_materials/maps from lib-dbserver