### PR TITLE
Install missing xml library for OJS

### DIFF
--- a/roles/ojs/tasks/install_prerequisites.yml
+++ b/roles/ojs/tasks/install_prerequisites.yml
@@ -1,7 +1,16 @@
 ---
+- apache2_module:
+    state: present
+    name: ssl
+
 - name: ojs | install apache php modules
   apt:
     name: ["libapache2-mod-php", "php{{ php_version }}-mbstring", "php{{ php_version }}-ldap"]
+    state: present
+
+- name: ojs | install php xml libraries
+  apt:
+    name: ["php7.4-xml"]
     state: present
 
 - name: ojs | install php postgres drivers


### PR DESCRIPTION
* Ensure mod_ssl is enabled for apache2

@kayiwa Seems like there is probably a better place for this enable apache2 ssl module to go. Feedback welcome.