### PR TITLE
Configure stall time to be very high.

### DIFF
--- a/roles/solrcloud/templates/solr.in.sh.j2
+++ b/roles/solrcloud/templates/solr.in.sh.j2
@@ -61,6 +61,11 @@ SOLR_OPTS="$SOLR_OPTS -Xss{{ solr_stack_size }}"
 # Set idle timeout
 SOLR_OPTS="$SOLR_OPTS -Dsolr.jetty.threads.idle.timeout=1800000"
 
+# Set client stall time to prevent large update requests in Figgy from timing
+# out.
+
+SOLR_OPTS="$SOLR_OPTS -Dsolr.cloud.client.stallTime=1800000"
+
 # Anything you add to the SOLR_OPTS variable will be included in the java
 # start command line as-is, in ADDITION to other options. If you specify the
 # -a option on start script, those options will be appended as well. Examples:


### PR DESCRIPTION
Figgy was timing out on large updates.

This has been deployed, as we're unsure if it'll fix our issue.

Refs https://github.com/pulibrary/figgy/issues/4802