### PR TITLE
Load balancer must point to 443 to pick up shib config

### DIFF
--- a/roles/nginxplus/files/conf/http/vireo_staging.conf
+++ b/roles/nginxplus/files/conf/http/vireo_staging.conf
@@ -8,7 +8,7 @@ map $http_upgrade $connection_upgrade {
 
 upstream vireo-staging {
     zone vireo-staging 64k;
-    server vireo-staging1.princeton.edu:8080 resolve;
+    server vireo-staging1.princeton.edu:443 resolve;
     sticky learn
           create=$upstream_cookie_vireostagingcookie
           lookup=$cookie_vireostagingcookie


### PR DESCRIPTION
We are changing the vireo strategy away from pointing the load balancer
directly at tomcat (port 8080). Instead, we'll point it at apache2,
running on port 443.

Connected to https://github.com/pulibrary/princeton_ansible/issues/2585