### PR TITLE
fixes indents on task, removes hosts that don't run apache

### DIFF
--- a/hosts
+++ b/hosts
@@ -354,8 +354,6 @@ library-prod3.princeton.edu
 library-prod4.princeton.edu
 recap-www-staging1.princeton.edu
 recap-www-prod1.princeton.edu
-prds-staging1.princeton.edu
-prds-prod1.princeton.edu
 fpul-staging1.princeton.edu
 fpul-prod1.princeton.edu
 lib-sc-staging1.princeton.edu

--- a/playbooks/upgrade_apache.yml
+++ b/playbooks/upgrade_apache.yml
@@ -5,10 +5,10 @@
 
   tasks:
     - name: update apache versions
-      package:
+      apt:
         name: ['apache2']
         state: latest
-      update_cache: true
+        update_cache: true
       # version 2.4.49 patched CVE-2021-40438, but apparently had troubles of its own
       # see https://ubuntu.com/security/CVE-2021-42013
       # as of Dec 3, 2.4.29 is the latest available on Ubuntu Bionic


### PR DESCRIPTION
Supersedes #2598.

Follows up on #2597 by:
- [x] using `apt` instead of `package`
- [x] correctly indenting the `update_cache` directive
- [x] removing two servers from the inventory group for apache servers, because they do not run apache
