### PR TITLE
remove digitalocean repo

### DIFF
--- a/roles/drupal/tasks/main.yml
+++ b/roles/drupal/tasks/main.yml
@@ -168,7 +168,7 @@
 - name: install npm for git actions
   apt:
     name: ["nodejs-dev", "node-gyp", "npm", "libssl1.0-dev"]
-    state: present
+    state: build-dep
     update_cache: true
   changed_when: false
   when: not running_on_server

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: add maria db repository
   apt_repository:
-    repo: "deb [arch=amd64,i386,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
+    repo: "deb [arch=amd64] https://mirrors.accretive-networks.net/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
 
 - name: Override configuration if local server is detected
   set_fact:

--- a/roles/mariadb/tasks/manage_contents.yml
+++ b/roles/mariadb/tasks/manage_contents.yml
@@ -30,7 +30,7 @@
   loop: "{{ mariadb__databases | d([]) }}"
   when: ((item.database|d(false) or item.name|d(false)) and
          (item.state is undefined or item.state != 'absent'))
-  no_log: false
+  no_log: true
   register: mariadb__register_database_status
 
 - name: Copy database source file to remote host

--- a/roles/mariadbserver/tasks/main.yml
+++ b/roles/mariadbserver/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: add maria db repository
   apt_repository:
-    repo: "deb [arch=amd64,i386,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
+    repo: "deb [arch=amd64] https://mirrors.accretive-networks.net/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
 
 - name: install maria db version
   apt:

--- a/roles/molecule_mariadb/tasks/main.yml
+++ b/roles/molecule_mariadb/tasks/main.yml
@@ -7,18 +7,21 @@
           - python3-pymysql
         state: latest
         update_cache: true
+
     - name: Install MariaDB key
       apt_key:
         url: https://mariadb.org/mariadb_release_signing_key.asc
         state: present
       register: install_app_key
+
     - name: Install MariaDB repository
       apt_repository:
-        repo: deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.4/debian jessie main
+        repo: "deb [arch=amd64] https://mirrors.accretive-networks.net/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
         state: present
         validate_certs: false
       ignore_errors: true
       when: install_app_key.changed
+
     - name: mariadb
       apt:
         name:
@@ -26,21 +29,25 @@
         state: latest
         update_cache: true
       when: install_app_key.changed
+
     - name: Start the service
       service:
         name: mysql
         enabled: true
         state: started
       when: install_app_key.changed
+
     - name: remove unix_plugin
       command: mysql -u root --execute="UPDATE mysql.user SET plugin = '' WHERE user = 'root' AND host = 'localhost'; FLUSH PRIVILEGES;"
       ignore_errors: true
       when: install_app_key.changed
+
     - name: Restart MySQL
       service:
         name: mysql
         state: restarted
       when: install_app_key.changed
+
     - name: mysql_root_password
       mysql_user:
         login_user: root


### PR DESCRIPTION
Supersedes #2562, which got a bunch of merge commits in it by mistake.

Updates the mirrors for mariadb. The old mirror disappeared, which was causing apt commands to fail. 