### PR TITLE
Update the timeout for DSS to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/dss-prod.conf
+++ b/roles/nginxplus/files/conf/http/dss-prod.conf
@@ -33,6 +33,9 @@ server {
         proxy_pass http://dss-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache dss-prodcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
     }
 

--- a/roles/nginxplus/files/conf/http/dss-staging.conf
+++ b/roles/nginxplus/files/conf/http/dss-staging.conf
@@ -32,6 +32,9 @@ server {
         proxy_pass http://dss-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache dss-stagingcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'

Co-authored-by: Christina Chortaria <actspatial@gmail.com>
Co-authored-by: Francis Kayiwa <kayiwa@pobox.com>