### PR TITLE
Update the timeout for maps to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/maps-prod.conf
+++ b/roles/nginxplus/files/conf/http/maps-prod.conf
@@ -37,6 +37,9 @@ server {
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
     }
 

--- a/roles/nginxplus/files/conf/http/maps-staging.conf
+++ b/roles/nginxplus/files/conf/http/maps-staging.conf
@@ -33,6 +33,9 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache maps-stagingcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
    Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'