### PR TITLE
Update the timeout for slavery to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/slavery-prod.conf
+++ b/roles/nginxplus/files/conf/http/slavery-prod.conf
@@ -33,6 +33,9 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache slavery-prodcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
     }
 

--- a/roles/nginxplus/files/conf/http/slavery-staging.conf
+++ b/roles/nginxplus/files/conf/http/slavery-staging.conf
@@ -34,6 +34,9 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache slavery-stagingcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2 uri=/talkback/get-in-touch;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'