### PR TITLE
Update the timeout for catalog to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-alma-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-alma-qa.conf
@@ -1,4 +1,0 @@
-# This is an ansible_managed file. Any changes made will be overwritten
-# when the role is run again
-#
-# File should be empty; see catalog-qa.conf

--- a/roles/nginxplus/files/conf/http/catalog-alma.conf
+++ b/roles/nginxplus/files/conf/http/catalog-alma.conf
@@ -1,3 +1,0 @@
-# Ansible managed
-#
-# File should be empty; see catalog-prod.conf

--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -52,6 +52,9 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache catalog-prodcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=2 passes=1 uri=/catalog/991234563506421;
     }
 

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -33,6 +33,9 @@ server {
         proxy_pass http://catalog-qa;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache catalog-qacache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2 uri=/catalog/1234567;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'

Also removes empty NGINX config files