### PR TITLE
Update the timeout for locator to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/locator-prod.conf
+++ b/roles/nginxplus/files/conf/http/locator-prod.conf
@@ -34,8 +34,11 @@ server {
     location / {
         proxy_pass http://locator-prod;
         proxy_cache locator-prodcache;
-        health_check interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
+        health_check interval=10 fails=3 passes=2;
     }
 
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;

--- a/roles/nginxplus/files/conf/http/locator-staging.conf
+++ b/roles/nginxplus/files/conf/http/locator-staging.conf
@@ -34,8 +34,11 @@ server {
     location / {
         proxy_pass http://locator-staging;
         proxy_cache locator-stagingcache;
-        health_check interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
+        health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'