### PR TITLE
Update the timeout for mudd-dbs to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-mudd-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-mudd-prod.conf
@@ -34,8 +34,11 @@ server {
     location / {
         proxy_pass http://lib-mudd-prod;
         proxy_cache lib-mudd-prodcache;
-        health_check interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
+        health_check interval=10 fails=3 passes=2;
     }
 
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;

--- a/roles/nginxplus/files/conf/http/lib-mudd-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-mudd-staging.conf
@@ -34,8 +34,11 @@ server {
     location / {
         proxy_pass http://lib-mudd-staging;
         proxy_cache lib-mudd-stagingcache;
-        health_check interval=10 fails=3 passes=2;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         proxy_set_header Host $http_host;
+        health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'