### PR TITLE
Update the timeout for confluence to something very large

### DIFF
--- a/roles/nginxplus/files/conf/http/confluence-prod.conf
+++ b/roles/nginxplus/files/conf/http/confluence-prod.conf
@@ -32,6 +32,9 @@ server {
         proxy_pass http://confluence-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache confluence-stagingcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
     }
 

--- a/roles/nginxplus/files/conf/http/confluence-staging.conf
+++ b/roles/nginxplus/files/conf/http/confluence-staging.conf
@@ -32,6 +32,9 @@ server {
         proxy_pass http://confluence-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache confluence-stagingcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
Should fix the 'upstream timed out (110: Connection timed out) while reading response header from upstream'