### PR TITLE
Alphabetize roles for Molecule testing

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -7,95 +7,95 @@ jobs:
     strategy:
       matrix:
         role:
-          - lockers_and_study_spaces
-          - geaccirc
-          # - repec
-          - bibdata_sqs_poller
-          - confluence
-          - lae
-          - ojs
-          - lib_solr
-          # - pas
-          - solr
-          # - percona
-          # - perconaxdb
-          - rubyoffice
-          - oracle_client
-          # - libstatic
-          - timezone
-          - simple_annotation
-          - saxon
-          - geoserver
-          - ezproxy
-          - redis
-          - bibdata
-          - lib_svn
-          - svn
-          # - locator
-          - hr_share
-          - shibboleth
-          - cantaloupe
-          - approvals
-          - capistrano
-          - datadog
-          - pulmap
-          - tomcat8
-          - apache_ant
-          - apache_tomcat
-          - apache_maven
-          - memcached
-          - common
-          - deploy_user
-          - ruby
-          - samba
           - apache2
-          - rvm
+          - apache_ant
+          - apache_maven
+          - apache_tomcat
+          - appdeploy
+          - approvals
+          - bibdata
+          - bibdata_sqs_poller
+          - bind9
+          - blacklight_app
+          - cantaloupe
+          - capistrano
+          - common
+          - composer
+          - confluence
+          - datadog
+          - deploy_user
+          # - drupal
+          - drupal9
+          - drush
+          # - elastic
+          - extra_path
+          - ezproxy
+          - ffmpeg
+          - figgy
+          - figgy_filewatcher_worker
+          - figgy_pubsub_worker
+          - fits
+          - freetds
+          # - friends_of_pul
+          - geaccirc
+          - geoserver
+          - hr_share
+          - imagemagick
+          - kakadu
+          - lae
+          # - libstatic
+          - libwww
+          - lib_jobs
+          - lib_solr
+          # - lib_statistics
+          - lib_svn
+          # - locator
+          - lockers_and_study_spaces
+          - mailcatcher
+          # - mariadb
+          # - mariadb
+          - mediainfo
+          - memcached
           - nginxplus
           - nodejs
+          - oawaiver
+          - ojs
+          - openjdk
+          - oracle_client
+          # - pas
+          # - pas
+          - passenger
+          # - percona
+          # - perconaxdb
           - php
-          - composer
-          - drush
           - postgresql
           - psql
-          - ffmpeg
-          - openjdk
-          - freetds
-          - passenger
-          # - mariadb
-          - imagemagick
-          - bind9
-          - solrcloud
-          - zookeeper
-          # - mariadb
-          - vips
+          - pulmap
           - rails_app
-          - vips
-          # - drupal
-          - fits
-          - kakadu
-          - figgy_filewatcher_worker
-          - drupal9
-          - mediainfo
-          - figgy_pubsub_worker
-          - subversion
-          - blacklight_app
-          - figgy
-          - sidekiq_worker
-          - sneakers_worker
-          - mailcatcher
-          - extra_path
-          - libwww
           # - recap_www
-          - lib_jobs
-          # - elastic
-          - shared_data
+          - redis
+          # - repec
           - researchdata
-          # - pas
-          # - friends_of_pul
-          # - lib_statistics
+          - ruby
+          - rubyoffice
+          - rvm
+          - samba
+          - saxon
+          - shared_data
+          - shibboleth
+          - sidekiq_worker
+          - simple_annotation
+          - sneakers_worker
+          - solr
+          - solrcloud
           - special_collections
-          - appdeploy
-          - oawaiver
+          - subversion
+          - svn
+          - timezone
+          - tomcat8
+          - vips
+          - vips
+          - zookeeper
     steps:
       - name: Checkout branch
         run: |

--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -7,27 +7,33 @@ jobs:
     strategy:
       matrix:
         role:
+          # - abid
           - apache2
           - apache_ant
           - apache_maven
           - apache_tomcat
           - appdeploy
           - approvals
+          # - archivesspace
           - bibdata
           - bibdata_sqs_poller
           - bind9
           - blacklight_app
           - cantaloupe
           - capistrano
+          # - clamav
           - common
           - composer
           - confluence
           - datadog
           - deploy_user
+          # - dpul
           # - drupal
           - drupal9
           - drush
+          # - dss
           # - elastic
+          # - elixir
           - extra_path
           - ezproxy
           - ffmpeg
@@ -43,37 +49,49 @@ jobs:
           - imagemagick
           - kakadu
           - lae
-          # - libstatic
-          - libwww
           - lib_jobs
           - lib_solr
           # - lib_statistics
           - lib_svn
+          # - libstatic
+          - libwww
           # - locator
           - lockers_and_study_spaces
           - mailcatcher
           # - mariadb
+          # - mariadbserver
           - mediainfo
           - memcached
+          # - molecule_mariadb
+          # - mudd
+          # - nginx/templates
           - nginxplus
           - nodejs
           - oawaiver
           - ojs
           - openjdk
           - oracle_client
+          # - orangelight
+          # - ouranos
           # - pas
           - passenger
           # - percona
           # - perconaxdb
+          # - pgbouncer
           - php
+          # - postfix
+          # - postgres
           - postgresql
           - psql
+          # - pulfalight
           - pulmap
+          # - rabbitmq
           - rails_app
           # - recap_www
           - redis
           # - repec
           - researchdata
+          # - resque_worker
           - ruby
           - rubyoffice
           - rvm
@@ -92,6 +110,7 @@ jobs:
           - timezone
           - tomcat8
           - vips
+          # - vireo
           - zookeeper
     steps:
       - name: Checkout branch

--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -53,7 +53,6 @@ jobs:
           - lockers_and_study_spaces
           - mailcatcher
           # - mariadb
-          # - mariadb
           - mediainfo
           - memcached
           - nginxplus
@@ -62,7 +61,6 @@ jobs:
           - ojs
           - openjdk
           - oracle_client
-          # - pas
           # - pas
           - passenger
           # - percona
@@ -93,7 +91,6 @@ jobs:
           - svn
           - timezone
           - tomcat8
-          - vips
           - vips
           - zookeeper
     steps:


### PR DESCRIPTION
To make it easier to maintain the molecule test suite, this branch:
- alphabetizes the existing list of roles in .github/workflows/molecule_tests.yml
- deduplicates the existing list
- adds all other roles in the repo in their alphabetized position

The molecule file now reflects the current state of the repo, though that may not be the ideal state (some roles may be obsolete). 

I wasn't entirely sure why some roles were commented out, so I went with the "countryside rule" of "leave it how you found it." If a role was commented, I left it commented. And I added the missing roles as comments, in case they were left out for a reason.