### PR TITLE
adds note about apache config settings and link to vireo example

### DIFF
--- a/roles/shibboleth/README.md
+++ b/roles/shibboleth/README.md
@@ -10,7 +10,7 @@ This installation attempts to follow the guides here:
 
 This role will install shibd, apache2, and the apache2 modules necessary, which include SSL.
 In order to configure SSL, you will need to generate SSL keys and put them into a vault in 
-the group_vars directory for your project. See group_vars/vireo for an example.
+the group_vars directory for your project. See [group_vars/vireo](https://github.com/pulibrary/princeton_ansible/tree/main/group_vars/vireo) for an example.
 
 After running this role, you should be able to run this on the command line and see 
 your shibboleth metadata.
@@ -19,10 +19,9 @@ your shibboleth metadata.
 curl --insecure https://localhost/Shibboleth.sso/Metadata
 ```
 
-In your playbook, you will also need to set up an SSL enabled virtual host (and remove the default SSL virtual host). Again, see
+In your playbook, you will also need to set up an SSL-enabled virtual host (and remove the default SSL virtual host). Again, see
 the vireo role for an example. After setting that up, you should be able to visit the 
-following url and see the same shibboleth metadata (except it will have your server name
-instead of localhost)
+following url and see the same shibboleth metadata (supply your server's name instead of `YOUR_SERVER_NAME`).
 
 https://YOUR_SERVER_NAME/Shibboleth.sso/Metadata
 
@@ -34,13 +33,15 @@ https://princeton.service-now.com/service?id=sc_cat_item&sys_id=edd831664f2c3340
 Requirements
 ------------
 
-The Apache Webserver
+The Apache Webserver.
+
+Shibboleth requires certain apache config rules to be set - see the [vireo conf template](https://github.com/pulibrary/princeton_ansible/blob/main/roles/vireo/templates/vireo.conf.j2) for an example.
 
 Role Variables
 --------------
 
 * The [defaults/main.yml](defaults/main.yml) lists the ubuntu release
-* shib_hostname: e.g., "vireo-staging.princeton.edu"
+* shib_hostname: FQDN of your server, for example, "vireo-staging.princeton.edu"
   * `shib_hostname` will become your shibboleth `entityID`. Note that shib_hostname must NOT include the https prefix. This is the hostname as it appears to the OIT shibboleth auth service.
 * shib_host: e.g., "vireo-staging"
 


### PR DESCRIPTION
Closes #2634.

Adds a note for future users who need to install Shibboleth about the apache config requirements, with a link to the example in the Vireo role. 
