### PR TITLE
Revise nginxplus playbook and role

### DIFF
--- a/playbooks/nginxplus_production.yml
+++ b/playbooks/nginxplus_production.yml
@@ -2,6 +2,7 @@
 - name: update nginx
   hosts: nginxplus
   remote_user: pulsys
+  strategy: linear
   become: true
 
 # updates existing load balancer

--- a/playbooks/nginxplus_production.yml
+++ b/playbooks/nginxplus_production.yml
@@ -11,6 +11,7 @@
 - name: restart nginx and announce success
   hosts: nginxplus
   remote_user: pulsys
+  strategy: linear
   become: true
 
   tasks:

--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -22,6 +22,7 @@
       service: 
         name: nginx
         state: restarted
+      tag: always
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
@@ -29,3 +30,4 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
         channel: #server-alerts
+      tag: always

--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -1,16 +1,20 @@
 ---
-- name: update nginx
+- name: rebuild nginx with datadog
   hosts: nginxplus
   remote_user: pulsys
+  strategy: free
   become: true
 
-# updates existing load balancer
+# rebuilds the load balancer from scratch
   roles:
+    - role: ../roles/datadog
+    - role: ../roles/deploy_user
     - role: ../roles/nginxplus
 
 - name: restart nginx and announce success
   hosts: nginxplus
   remote_user: pulsys
+  strategy: linear
   become: true
 
   tasks:

--- a/roles/nginxplus/README.md
+++ b/roles/nginxplus/README.md
@@ -1,13 +1,13 @@
 Role Name
 =========
 
-* This role installs NGINX Open Source and NGINX Plus on a target host.
+* This role installs NGINX Open Source and NGINX Plus on a target host. To rebuild NGINX Plus, run the `nginx_production_rebuild.yml` playbook.
 
 * If you just need to add a [New Host](ADDHOSTS.md)
 
-* If you just need to add or update SSL Certs and Keys:
-  - add the new cert and key to the `files/ssl` directory
-  - run the nginx_production.yml playbook with `-t SSL` 
+* If you just need to add or update SSL Certs and Keys, you can use the `SSL` tag to run only the required tasks quickly:
+  - add the new cert and key to the `files/ssl/` directory
+  - run the `nginx_production.yml` playbook with `-t SSL` (this runs tasks with `tags: SSL` and tasks with `tags: always`)
 
 **Note** This role is a stripped down version (to allow us to understand what it
 does for us) of

--- a/roles/nginxplus/README.md
+++ b/roles/nginxplus/README.md
@@ -5,6 +5,10 @@ Role Name
 
 * If you just need to add a [New Host](ADDHOSTS.md)
 
+* If you just need to add or update SSL Certs and Keys:
+  - add the new cert and key to the `files/ssl` directory
+  - run the nginx_production.yml playbook with `-t SSL` 
+
 **Note** This role is a stripped down version (to allow us to understand what it
 does for us) of
 [https://github.com/nginxinc/ansible-role-nginx](https://github.com/nginxinc/ansible-role-nginx)

--- a/roles/nginxplus/tasks/conf/upload-config.yml
+++ b/roles/nginxplus/tasks/conf/upload-config.yml
@@ -89,6 +89,7 @@
     state: directory
     mode: 0755
   when: nginx_ssl_upload_enable
+  tag: SSL
 
 - name: "Setup: Upload NGINX SSL Certificates"
   copy:
@@ -99,6 +100,7 @@
     backup: true
   with_fileglob: "{{ nginx_ssl_crt_upload_src }}"
   when: nginx_ssl_upload_enable
+  tag: SSL
 
 - name: "(Setup: All NGINX) Upload NGINX SSL Keys"
   copy:
@@ -109,3 +111,4 @@
     backup: true
   with_fileglob: "{{ nginx_ssl_key_upload_src }}"
   when: nginx_ssl_upload_enable
+  tag: SSL

--- a/roles/nginxplus/tasks/conf/upload-config.yml
+++ b/roles/nginxplus/tasks/conf/upload-config.yml
@@ -89,7 +89,7 @@
     state: directory
     mode: 0755
   when: nginx_ssl_upload_enable
-  tag: SSL
+  tags: SSL
 
 - name: "Setup: Upload NGINX SSL Certificates"
   copy:
@@ -100,7 +100,7 @@
     backup: true
   with_fileglob: "{{ nginx_ssl_crt_upload_src }}"
   when: nginx_ssl_upload_enable
-  tag: SSL
+  tags: SSL
 
 - name: "(Setup: All NGINX) Upload NGINX SSL Keys"
   copy:
@@ -111,4 +111,4 @@
     backup: true
   with_fileglob: "{{ nginx_ssl_key_upload_src }}"
   when: nginx_ssl_upload_enable
-  tag: SSL
+  tags: SSL


### PR DESCRIPTION
Closes #2639 

The current nginxplus playbook installs datadog and adds the deploy user (plus a bunch of common setup tasks), then installs nginxplus from scratch. This is overkill for the kinds of updates we do regularly, and it's slow to run.

To address these challenges, this PR:
- [ ] renames the current nginxplus playbook, with the datadog and common roleas `nginxplus_production_rebuild` for disaster recovery/migration use cases
- [ ] modifies the playbook named `nginxplus_production.yml` to focus on updates only
- [ ] adds tags to make uploading new SSL keys and certs quick and easy (`SSL` for specific tasks; `always` for restarts at the end)
Once this is merged, we should be able to run `ansible-playbook playbooks/nginxplus_production.yml -t SSL` to upload new/replaced SSL certs and keys.

If possible, let's wait to merge this until we can test it in the staging environment we're creating.