### PR TITLE
adds variables to manage nginx server hash table

### DIFF
--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -436,3 +436,8 @@ nginx_stream_template:
             port: 8080
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
+
+# manage the hash table that stores server names for fast lookup
+# increase the size first, when that stops working, increase the number of hash buckets in the table
+nginx_server_names_hash_bucket_size: 64
+nginx_server_names_hash_max_size: 512

--- a/roles/nginxplus/templates/nginx.conf.j2
+++ b/roles/nginxplus/templates/nginx.conf.j2
@@ -47,6 +47,8 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    server_names_hash_max_size {{ nginx_server_names_hash_max_size }}
+    server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }}
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Closes #2556.

Should address the error listed in that ticket. Though why the server hash table error prevented Ansible from creating a directory, and why the playbook ran okay once the directory was manually created . . . that's a bit of a mystery. Still, this seems like an issue we will run into repeatedly.

For now the values are in the role defaults file. These values may not change the actual settings at all - check what the default values for nginx are for these settings, and increase as necessary. 