### PR TITLE
Adds new Figgy servers, updates bind9 role

### DIFF
--- a/hosts
+++ b/hosts
@@ -69,7 +69,9 @@ lib-postgres3.princeton.edu
 figgy-staging2.princeton.edu
 [figgy_production]
 figgy1.princeton.edu
+figgy-web-prod-2.princeton.edu
 figgy3.princeton.edu
+figgy-web-prod-4.princeton.edu
 lib-proc6.princeton.edu
 lib-proc7.princeton.edu
 lib-proc8.princeton.edu
@@ -85,7 +87,9 @@ lib-proc10.princeton.edu
 lib-proc11.princeton.edu
 [figgy_production_webserver]
 figgy1.princeton.edu
+figgy-web-prod-2.princeton.edu
 figgy3.princeton.edu
+figgy-web-prod-4.princeton.edu
 [archivesspace_staging]
 lib-aspace-dev1.princeton.edu
 [lae_production]

--- a/roles/bind9/tasks/main.yml
+++ b/roles/bind9/tasks/main.yml
@@ -20,11 +20,11 @@
     regexp: '.*nameserver.*'
   when: running_on_server
 
-- name: Use dns forwarder nameserver
+- name: Use local dns nameserver
   lineinfile:
     dest: "/etc/resolv.conf"
     state: present
-    line: 'nameserver 128.112.200.253'
+    line: 'nameserver 127.0.0.53'
   notify:
     - restart bind
   when: running_on_server

--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -6,6 +6,7 @@ upstream figgy {
     server figgy1.princeton.edu resolve;
     server figgy-web-prod-2.princeton.edu resolve;
     server figgy3.princeton.edu resolve;
+    server figgy-web-prod-4.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_figgycookie
           lookup=$cookie_figgycookie

--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -4,6 +4,7 @@ proxy_cache_path /data/nginx/figgy/NGINX_cache/ keys_zone=figgycache:10m;
 upstream figgy {
     zone figgy 128k;
     server figgy1.princeton.edu resolve;
+    server figgy-web-prod-2.princeton.edu resolve;
     server figgy3.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_figgycookie

--- a/roles/nginxplus/tasks/conf/upload-config.yml
+++ b/roles/nginxplus/tasks/conf/upload-config.yml
@@ -31,6 +31,7 @@
   with_fileglob: "{{ nginx_http_upload_src }}"
   notify: Reload NGINX
   when: nginx_http_upload_enable
+  tags: update_conf
 
 - name: "Setup: Upload NGINX template Configuration Files"
   copy:
@@ -41,6 +42,7 @@
   with_fileglob: "{{ nginx_template_upload_src }}"
   notify: Reload NGINX
   when: nginx_template_upload_enable
+  tags: update_conf
 
 - name: "Setup: Ensure NGINX Stream Directory Exists"
   file:
@@ -48,6 +50,7 @@
     state: directory
     mode: 0755
   when: nginx_stream_upload_enable
+  tags: update_conf
 
 - name: "Setup: Upload NGINX Stream Configuration Files"
   copy:
@@ -58,6 +61,7 @@
   with_fileglob: "{{ nginx_stream_upload_src }}"
   notify: Reload NGINX
   when: nginx_stream_upload_enable
+  tags: update_conf
 
 - name: "Setup: Ensure NGINX HTML Directory Exists"
   file:
@@ -65,6 +69,7 @@
     state: directory
     mode: 0755
   when: nginx_html_upload_enable
+  tags: update_conf
 
 - name: "Setup: Upload NGINX HTML Files"
   copy:
@@ -75,6 +80,7 @@
   with_fileglob: "{{ nginx_html_upload_src }}"
   notify: Reload NGINX
   when: nginx_html_upload_enable
+  tags: update_conf
 
 - name: "Setup: Ensure SSL Certificate Directory Exists"
   file:


### PR DESCRIPTION
Closes #2654.
Closes [figgy#4868](https://github.com/pulibrary/figgy/issues/4868). 

Adds the two new Figgy web VMs to our inventory. Updates the bind9 role to use local DNS.
