### PR TITLE
[Figgy] run common first

### DIFF
--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -17,6 +17,7 @@
     - ../group_vars/figgy/production.yml
     - ../group_vars/figgy/production_webserver.yml
   roles:
+    - role: roles/common
     - {role: roles/memcached, when: inventory_hostname == 'figgy1.princeton.edu'}
     - {role: roles/rabbitmq, when: inventory_hostname == 'figgy1.princeton.edu'}
     - role: roles/figgy


### PR DESCRIPTION
I realize this exacerbates https://github.com/pulibrary/princeton_ansible/issues/1204 but the common role does have to run first so I propose merging this until we get a chance to work that issue.