### PR TITLE
Allow ws proxying for vireo

### DIFF
--- a/group_vars/vireo/staging.yml
+++ b/group_vars/vireo/staging.yml
@@ -1,4 +1,6 @@
 ---
+github_branch: 'shibboleth_auth'
+
 vireo_db_user: 'vireo_staging_db_user'
 vireo_db_password: "{{ vault_vireo_staging_db_password }}"
 vireo_db_name: 'vireo_staging_db'

--- a/roles/vireo/tasks/apache_config.yml
+++ b/roles/vireo/tasks/apache_config.yml
@@ -4,8 +4,10 @@
     name: "{{ item }}"
     state: present
   loop:
+    - rewrite
     - proxy
     - proxy_ajp
+    - proxy_wstunnel
     - proxy_http
 
 - name: vireo | remove apache http default

--- a/roles/vireo/tasks/main.yml
+++ b/roles/vireo/tasks/main.yml
@@ -61,7 +61,7 @@
   ansible.builtin.git:
     repo: 'https://github.com/PrincetonUniversityLibrary/pul-vireo.git'
     dest: "{{ application_code_dir }}"
-    version: main
+    version: '{{ github_branch | default("main") }}'
     update: true
     force: true
 

--- a/roles/vireo/templates/vireo.conf.j2
+++ b/roles/vireo/templates/vireo.conf.j2
@@ -18,11 +18,18 @@
   ProxyPass        /shibboleth-sp !
 
   # Proxy all other traffic to Tomcat
-  ProxyPass        / ajp://localhost:8009/
-  ProxyPassReverse / ajp://localhost:8009/
+  ProxyPass / http://127.0.0.1:8080/
+  ProxyPassReverse / http://127.0.0.1:8080/
   
+  RewriteEngine on
+  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
+  RewriteCond %{HTTP:CONNECTION} Upgrade$ [NC]
+  RewriteRule .* ws://localhost:8080%{REQUEST_URI} [P]
+  
+  ProxyPass       /ws2/  ws://localhost:8180/ws
+
   ErrorLog ${APACHE_LOG_DIR}/{{ inventory_hostname }}.error.log
-  CustomLog ${APACHE_LOG_DIR}/{{ inventory_hostname }}.acess.log combined
+  CustomLog ${APACHE_LOG_DIR}/{{ inventory_hostname }}.access.log combined
   SSLCertificateFile /etc/apache2/ssl/certs/{{ inventory_hostname }}.cert.cer
   SSLCertificateKeyFile /etc/apache2/ssl/private/{{ inventory_hostname }}.priv.key
   SSLCertificateChainFile /etc/apache2/ssl/certs/{{ inventory_hostname }}.chained.pem


### PR DESCRIPTION
This fixes an error where the vireo application can't access javascript
via the ws protocol

Work toward https://github.com/pulibrary/rdss-catchall/issues/32