### PR TITLE
[DPUL] Add certificate checks for all of DLS' applications.

### DIFF
--- a/group_vars/dpul_production.yml
+++ b/group_vars/dpul_production.yml
@@ -106,10 +106,23 @@ datadog_checks:
           - 'pomegranate:queue:default'
           - 'pomegranate:retry'
           - 'pomegranate:dead'
+  # Add certificate checks for all of our services.
+  # We do this here because it was already here - these checks will eventually
+  # be moved to Sensu.
   tls:
     init_config:
     instances:
       - server: dpul.princeton.edu
+        port: 443
+      - server: figgy.princeton.edu
+        port: 443
+      - server: maps.princeton.edu
+        port: 443
+      - server: libdeploy.princeton.edu
+        port: 443
+      - server: findingaids.princeton.edu
+        port: 443
+      - server: lae.princeton.edu
         port: 443
   nginx:
     init_config:


### PR DESCRIPTION
Run this on DPUL because we already have datadog running and paid for
there (vs appdeploy), and it's already configured for TLS checking one
domain.