### PR TITLE
Revert "Update lae ruby to 2.7"

### DIFF
--- a/group_vars/lae/production.yml
+++ b/group_vars/lae/production.yml
@@ -4,8 +4,8 @@ postgres_version: 10
 passenger_server_name: "lae1.princeton.edu"
 passenger_app_root: "/opt/lae-blacklight/current/public"
 passenger_app_env: "production"
-passenger_ruby: "/usr/bin/ruby2.7"
-ruby_version_override: "ruby2.7"
+passenger_ruby: "/usr/bin/ruby2.6"
+ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
 postgresql_is_local: false
 rails_app_name: "lae-blacklight"

--- a/group_vars/lae/staging.yml
+++ b/group_vars/lae/staging.yml
@@ -4,8 +4,8 @@ postgres_version: 10
 passenger_server_name: "lae-staging1.princeton.edu"
 passenger_app_root: "/opt/lae-blacklight/current/public"
 passenger_app_env: "staging"
-passenger_ruby: "/usr/bin/ruby2.7"
-ruby_version_override: "ruby2.7"
+passenger_ruby: "/usr/bin/ruby2.6"
+ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
 postgresql_is_local: false
 rails_app_name: "lae-blacklight"


### PR DESCRIPTION
Reverts pulibrary/princeton_ansible#2668

This project needs much more work than simple upgrading to ruby 2.7. This PR reverses that PR until we have time to devote to LAE.