### PR TITLE
Remove figgy 2 and 4 from the load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -4,9 +4,7 @@ proxy_cache_path /data/nginx/figgy/NGINX_cache/ keys_zone=figgycache:10m;
 upstream figgy {
     zone figgy 128k;
     server figgy1.princeton.edu resolve;
-    server figgy-web-prod-2.princeton.edu resolve;
     server figgy3.princeton.edu resolve;
-    server figgy-web-prod-4.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_figgycookie
           lookup=$cookie_figgycookie


### PR DESCRIPTION
this is temporary until their firewall rules are fixed
refs #4916
