### PR TITLE
Add a flashy debug message to the end of figgy webserver tasks

### DIFF
--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -32,8 +32,10 @@
         msg:
           - "****************************************************************"
           - "******************* FIGGY WEBSERVER SETUP **********************"
-          - "To finalize provisioning on a new figgy webserver, firewall rules"
-          - "must be adjusted by OIT"
+          - "To finalize provisioning on a new figgy webserver, Operations must"
+          - "must adjust the hardware firewall in the following ways: Allow "
+          - "port 80, 443, 6379 to libnet, Allow port 22 to Princeton,"
+          - "Allow http-audio and http-video."
           - "****************************************************************"
 
 - hosts: figgy_production_workers

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -28,6 +28,13 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
         channel: #server-alerts
+    - ansible.builtin.debug:
+        msg:
+          - "****************************************************************"
+          - "******************* FIGGY WEBSERVER SETUP **********************"
+          - "To finalize provisioning on a new figgy webserver, firewall rules"
+          - "must be adjusted by OIT"
+          - "****************************************************************"
 
 - hosts: figgy_production_workers
   remote_user: pulsys


### PR DESCRIPTION
refs pulibrary/figgy#4916

It looks like this (note text has been adjusted since this screenshot was taken):
![Screen Shot 2022-01-25 at 11 08 01 AM](https://user-images.githubusercontent.com/845363/151014094-09ee69e9-f9ab-41a6-b5e1-872a439aa28d.png)
