### PR TITLE
Fix failing tests

### DIFF
--- a/roles/appdeploy/molecule/default/verify.yml
+++ b/roles/appdeploy/molecule/default/verify.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   tasks:
   - name: Forever installed
-    shell: 'forever --version | grep v4.0.1'
+    shell: 'forever list | grep processes'
     register: result
     failed_when: result.rc != 0
     changed_when: false

--- a/roles/figgy/tasks/main.yml
+++ b/roles/figgy/tasks/main.yml
@@ -50,6 +50,7 @@
     - mendel.smb.credentials
     - mudd.smb.credentials
     - microforms.smb.credentials
+
 - name: Create mount to plum binaries
   mount:
     name: '/mnt/diglibdata/hydra_binaries'
@@ -209,16 +210,16 @@
     state: present
     update_cache: true
 
-- name: Install cogeo-mosaic prerequisites
+- name: Install cogeo-mosaic apt prerequisites
   apt:
     name: ['python3-setuptools', 'cython3']
     state: present
 
 - name: update pip3 for cogeo-mosaic
   pip:
-    name: pip
+    name: pip>21,!=21.2
     executable: pip3
-    state: latest
+    state: present
 
 - name: remove cogeo-mosaic requests dependency to ensure the correct version
   pip:


### PR DESCRIPTION
Closes #2683.
Fixes two recent test failures:

Error: linting failed in the figgy role because we were upgrading a package without any checks and balances
Fix: add a version parameter to the task

Error: verification failed in the appdeploy role because the verification test required a specific version of `forever`, but the install task installed the latest version, so as soon as a new version was released, the test started to fail
Fix: change the test to be version-agnostic
