### PR TITLE
Removes ProxyPass rules for /LibraryStaff

### DIFF
--- a/roles/libwww/templates/proxy_pass_rules.j2
+++ b/roles/libwww/templates/proxy_pass_rules.j2
@@ -118,9 +118,6 @@ ProxyPassReverse /AssignedSpaces https://lib-dbserver.princeton.edu/AssignedSpac
 ProxyPass /E-Series https://lib-dbserver.princeton.edu/E-Series
 ProxyPassReverse /E-Series https://lib-dbserver.princeton.edu/E-Series
 
-# ProxyPass /LibraryStaff https://lib-dbserver.princeton.edu/LibraryStaff
-# ProxyPassReverse /LibraryStaff https://lib-dbserver.princeton.edu/LibraryStaff
-
 ProxyPass /PreservationTracking https://lib-dbserver.princeton.edu/PreservationTracking
 ProxyPassReverse /PreservationTracking https://lib-dbserver.princeton.edu/PreservationTracking
 

--- a/roles/libwww/templates/proxy_pass_rules.j2
+++ b/roles/libwww/templates/proxy_pass_rules.j2
@@ -118,8 +118,8 @@ ProxyPassReverse /AssignedSpaces https://lib-dbserver.princeton.edu/AssignedSpac
 ProxyPass /E-Series https://lib-dbserver.princeton.edu/E-Series
 ProxyPassReverse /E-Series https://lib-dbserver.princeton.edu/E-Series
 
-ProxyPass /LibraryStaff https://lib-dbserver.princeton.edu/LibraryStaff
-ProxyPassReverse /LibraryStaff https://lib-dbserver.princeton.edu/LibraryStaff
+# ProxyPass /LibraryStaff https://lib-dbserver.princeton.edu/LibraryStaff
+# ProxyPassReverse /LibraryStaff https://lib-dbserver.princeton.edu/LibraryStaff
 
 ProxyPass /PreservationTracking https://lib-dbserver.princeton.edu/PreservationTracking
 ProxyPassReverse /PreservationTracking https://lib-dbserver.princeton.edu/PreservationTracking


### PR DESCRIPTION
Closes #2491.

For now, the branch just comments out the ProxyPass rules connecting `/LibraryStaff` to `https://lib-dbserver.princeton.edu/LibraryStaff`. 

I'm not sure what this content was or where it has gone. Should there be a different redirect in place? Possibly to the [Library Staff](https://library.princeton.edu/staff) page?