### PR TITLE
removes proxypass for voyagerapps

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -127,9 +127,6 @@
     location /geaccirc {
         proxy_pass https://lib-dbserver.princeton.edu/geaccirc/;
     }
-    location /voyagerapps {
-        proxy_pass https://lib-dbserver.princeton.edu/voyagerapps/;
-    }
     location /music/programs {
         proxy_pass https://lib-dbserver.princeton.edu/music/programs/;
     }


### PR DESCRIPTION
Closes #2529.

Removes proxypass redirect from `/voyagerapps` to `https://lib-dbserver.princeton.edu/voyagerapps/`. 
