### PR TITLE
Fixes idempotence test failure in Solr role

### DIFF
--- a/roles/solr/tasks/links.yml
+++ b/roles/solr/tasks/links.yml
@@ -15,6 +15,7 @@
     src: "{{ solr_home }}/pul_solr/current/solr_configs/{{ item.config_name }}/conf"
     dest: "{{ solr_data_dir }}/{{ item.core_name }}/conf"
     force: true
+    follow: false
   become: "true"
   become_user: "deploy"
   with_items: "{{ solr_core_configs }}"


### PR DESCRIPTION
Fixes a test failure uncovered in an idempotence test on #2693. The test failure was:
```
TASK [solr : Link Config Directories] ******************************************
  ok: [instance] => (item={'core_name': 'catalog', 'config_name': 'catalog-production'})
  Warning: : Cannot set fs attributes on a non-existent symlink target. follow
  should be set to False to avoid this.
```
Here's a link to the test run where the failure turned up:
https://github.com/pulibrary/princeton_ansible/runs/5023030869?check_suite_focus=true 

This PR sets the `follow` param on the `file` module to `false`, as the test failure message suggested.
