### PR TITLE
explicitly adds 'production' to all host groups for production machines

### DIFF
--- a/hosts
+++ b/hosts
@@ -56,7 +56,7 @@ cicognara1.princeton.edu
 cicognara2.princeton.edu
 [bibdata_workers]
 bibdata-worker2.princeton.edu
-[pulmap]
+[pulmap_production]
 maps1.princeton.edu
 maps2.princeton.edu
 [pulmap_staging]
@@ -121,7 +121,7 @@ dpul2.princeton.edu
 dpul-staging1.princeton.edu
 [geoserver]
 geoserv1.princeton.edu
-[zookeeper]
+[zookeeper_production]
 lib-zk1.princeton.edu
 lib-zk2.princeton.edu
 lib-zk3.princeton.edu
@@ -129,7 +129,7 @@ lib-zk3.princeton.edu
 lib-zk-staging1.princeton.edu
 lib-zk-staging2.princeton.edu
 lib-zk-staging3.princeton.edu
-[solrcloud]
+[solrcloud_production]
 lib-solr1.princeton.edu
 lib-solr2.princeton.edu
 lib-solr3.princeton.edu
@@ -137,14 +137,14 @@ lib-solr3.princeton.edu
 lib-solr-staging1.princeton.edu
 lib-solr-staging2.princeton.edu
 lib-solr-staging3.princeton.edu
-[solr8cloud_staging]
-lib-solr-staging4.princeton.edu
-lib-solr-staging5.princeton.edu
-lib-solr-staging6.princeton.edu
 [solr8cloud_production]
 lib-solr-prod4.princeton.edu
 lib-solr-prod5.princeton.edu
 lib-solr-prod6.princeton.edu
+[solr8cloud_staging]
+lib-solr-staging4.princeton.edu
+lib-solr-staging5.princeton.edu
+lib-solr-staging6.princeton.edu
 [ojs]
 ojs-staging1.princeton.edu
 ojs-dev1.princeton.edu
@@ -203,7 +203,7 @@ lib-jobs-staging1.princeton.edu
 lib-jobs-prod1.princeton.edu
 [lib_svn_staging]
 lib-svn-staging1.princeton.edu
-[lib_svn]
+[lib_svn_production]
 lib-svn-prod1.princeton.edu
 [postgresql_production]
 lib-postgres-prod1.princeton.edu

--- a/playbooks/lib_svn_production.yml
+++ b/playbooks/lib_svn_production.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: lib_svn
+- hosts: lib_svn_production
   remote_user: pulsys
   become: true
   vars_files:

--- a/playbooks/pulmap_production.yml
+++ b/playbooks/pulmap_production.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: pulmap
+- hosts: pulmap_production
   remote_user: pulsys
   become: true
   vars_files:

--- a/playbooks/solrcloud_production.yml
+++ b/playbooks/solrcloud_production.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: solrcloud
+- hosts: solrcloud_production
   remote_user: pulsys
   become: true
   vars_files:

--- a/playbooks/zookeeper_production.yml
+++ b/playbooks/zookeeper_production.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: zookeeper
+- hosts: zookeeper_production
   remote_user: pulsys
   become: true
   vars_files:


### PR DESCRIPTION
Closes #181.

Group names for all projects with both staging and production groups now reflect the environment name as well as the project name. No more `project` and `project_staging`.  However, some groups use `stage` instead of `staging` and `prod` instead of `production`. Should I update those group names as well? Or are we okay with a little variation as long as the group clearly indicates the environment it's targeting?