### PR TITLE
adds config for lib-statistics production site

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-statistics-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-statistics-prod.conf
@@ -1,0 +1,42 @@
+# Ansible managed
+proxy_cache_path /data/nginx/lib-statistics-prod/NGINX_cache/ keys_zone=lib-statistics-prodcache:10m;
+
+upstream libstatistics-prod {
+    zone libstatistics-prod 64k;
+    server lib-statistics-prod1.princeton.edu resolve;
+    sticky learn
+          create=$upstream_cookie_lib-statistics-prodcookie
+          lookup=$cookie_lib-statistics-prodcookie
+          zone=lib-statistics-prodclient_sessions:1m;
+}
+
+server {
+    listen 80;
+    server_name lib-statistics.princeton.edu;
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name lib-statistics.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/lib-statistics_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/lib-statistics_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        proxy_pass http://lib-statistics;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_cache lib-statistics-prodcache;
+        health_check interval=10 fails=3 passes=2;
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
+    }
+
+}

--- a/roles/nginxplus/files/conf/http/lib-statistics-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-statistics-prod.conf
@@ -29,7 +29,7 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-        proxy_pass http://lib-statistics;
+        proxy_pass http://libstatistics-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache lib-statistics-prodcache;
         health_check interval=10 fails=3 passes=2;


### PR DESCRIPTION
Closes #2115 (eventually).

This PR refers to the cert names from #2116. I'm opening it as a draft, however, because I have mostly copied the contents from other examples in the repo (specifically confluence and lib-static). I'm not sure if I used `lib-statistics-prod` and plain `lib-statistics` in the right places. I'm also not sure if additional steps are necessary to close #2115.
