### PR TITLE
Removing playbooks for library solr machines

### DIFF
--- a/playbooks/library_solr_production.yml
+++ b/playbooks/library_solr_production.yml
@@ -1,9 +1,0 @@
----
-- hosts: library_solr_prod
-  remote_user: pulsys
-  become: true
-  vars_files:
-    - ../site_vars.yml
-    - ../group_vars/library-solr/library-solr-prod.yml
-  roles:
-    - role: roles/solr

--- a/playbooks/library_solr_staging.yml
+++ b/playbooks/library_solr_staging.yml
@@ -1,9 +1,0 @@
----
-- hosts: library_solr_staging
-  remote_user: pulsys
-  become: true
-  vars_files:
-    - ../site_vars.yml
-    - ../group_vars/library-solr/library-solr-staging.yml
-  roles:
-    - role: roles/solr


### PR DESCRIPTION
The library drupal indexes were moved back into the cloud now that it is stable.

Leaving as a draft for now until we decide this is all stable.  Should be merged when https://github.com/pulibrary/pul_solr/pull/318 is merged.