### PR TITLE
Deduplicate playbooks

### DIFF
--- a/playbooks/lae.yml
+++ b/playbooks/lae.yml
@@ -1,0 +1,22 @@
+---
+# by default this playbook runs in the staging environment
+# to run in production, pass '-e runtime_env=production'
+- name: build the Latin American Ephemera site
+  hosts: lae_{{ runtime_env | default('staging') }}
+  remote_user: pulsys
+  become: true
+
+  vars_files:
+    - ../group_vars/lae/{{ runtime_env | default('staging') }}.yml
+
+  roles:
+    - role: roles/lae
+
+  post_tasks:
+    - name: tell everyone on slack you ran an ansible playbook
+      slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "{{ inventory_hostname }} completed"
+        channel: #server-alerts
+      delegate_to: localhost
+      when: not ansible_check_mode

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -1,0 +1,29 @@
+---
+# by default this playbook runs in the staging environment
+# to run in production, pass '-e runtime_env=production'
+- name: build the rails app for browsing research data in DataSpace
+  hosts: pdc_discovery_{{ runtime_env | default('staging') }}
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../site_vars.yml
+    - ../group_vars/pdc_discovery/common.yml
+    - ../group_vars/pdc_discovery/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/pdc_discovery/vault.yml
+  
+  vars:
+    - post_install: |
+        Possible Things left to do:
+        - run a cap deploy for pdc_discovery: https://github.com/pulibrary/pdc_discovery
+  
+  roles:
+    - role: roles/rails_app
+  
+  post_tasks:
+    - name: tell everyone on slack you ran an ansible playbook
+      slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "{{ inventory_hostname }} completed"
+        channel: #server-alerts
+      when: not ansible_check_mode
+


### PR DESCRIPTION
We currently have multiple playbooks for each project, one per environment. In most pairs, the only differences are the `hosts` and the `vars_files`. To streamline the repository, simplify maintenance, and reduce the risk of drift, we'd like to reduce this duplication where possible.

This branch creates two "unified" playbooks as proofs of concept:
- lae.yml
- pdc_discovery.yml

Each playbook can run be against production or staging. Both run against staging by default. The `hosts` and the `vars_files` are defined based on the variable `runtime_env` (though may be `ansible_env` would be better?). The existing playbooks are still there for comparison purposes.

This PR should stay a draft until these two playbooks have been tested. If the unified playbooks work, next steps would include:
- remove related `_production.yml` and `_staging.yml` playbooks
- do the same for other project playbook pairs
- audit `group_vars.yml` for duplication and drift
