### PR TITLE
nginx playbook needs 'always' tags on restart and announcement

### DIFF
--- a/playbooks/nginxplus_production.yml
+++ b/playbooks/nginxplus_production.yml
@@ -20,6 +20,7 @@
       service: 
         name: nginx
         state: restarted
+      tags: always
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
@@ -27,3 +28,4 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
         channel: #server-alerts
+      tags: always


### PR DESCRIPTION
Related to #2647.
closes #2733

When running the nginx playbooks with `--tags update_conf`, the `reload` task in the role ran, because it was tagged with `always`. However, the `restart nginx for realsies` task in the playbook did not run. If this task doesn't run, sites go down.

This PR adds `tags: always` to both tasks in the nginx production playbook. 