### PR TITLE
samba role needs cifs-utils to fully function

### DIFF
--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -2,8 +2,8 @@
 # For creating samba share, server-side
 ---
 - name: Install Samba packages
-  package:
-    name: ["samba-common", "samba", "samba-client"]
+  apt:
+    name: ["samba-common", "samba", "samba-client", "cifs-utils"]
     state: present
   tags: samba
 


### PR DESCRIPTION
when we install samba we need to add `cifs-utils` in order to create a mount
that works.

closes #2744
