### PR TITLE
add ansible-lint comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In all the steps below substitue your role name for `your_new_role`
    Run the following command from the root of this repo:
 
    ```bash
-   export your_new_role=<fil in the role name here>
+   export your_new_role=<fill in the role name here>
    molecule init role roles/$your_new_role --driver-name docker
    ```
 1. Set up to run from github actions `vi .github/workflows/molecule_tests.yml` add for your role at the end matrix of the roles

--- a/roles/example/ansible-lint
+++ b/roles/example/ansible-lint
@@ -1,12 +1,7 @@
 skip_list:
-  - 'ANSIBLE0002'
-  - 'ANSIBLE0006'
-  - 'ANSIBLE0010'
-  - ANSIBLE0016
-  - '403'
-  - '503'
-  - '305'
-  - '306'
-  - '301'
+  - "ANSIBLE0002"  # Trailing whitespace
+  - "503"  # Tasks that run when changed should likely be handlers
+  - "305"  # Use shell only when shell functionality is required
+  - "306"  # Shells that use pipes should set the pipefail option
 use_default_rules: true
 verbosity: 1


### PR DESCRIPTION
instead of copy and pasting blindly provide reasons in comments for why
we skip these linting tests

closes #2715
