### PR TITLE
[DPUL] Fix uploads directory ownership and use new dpul-staging2

### DIFF
--- a/hosts
+++ b/hosts
@@ -118,7 +118,7 @@ lib-redis.princeton.edu
 dpul1.princeton.edu
 dpul2.princeton.edu
 [dpul_staging]
-dpul-staging1.princeton.edu
+dpul-staging2.princeton.edu
 [geoserver]
 geoserv1.princeton.edu
 [zookeeper_production]

--- a/roles/dpul/tasks/main.yml
+++ b/roles/dpul/tasks/main.yml
@@ -1,21 +1,26 @@
 ---
 ## Symlink to Mounts
-- name: Create uploads directory
+- name: dpul | create uploads directory
   file:
     path: '/mnt/shared_data/dpul_{{ rails_app_env }}/uploads'
     state: 'directory'
     mode: 0755
   when: running_on_server
 
-- name: Create symlinks
+- name: dpul | create shared public directory
   file:
-    src: '{{ item.src }}'
-    dest: '{{ item.link }}'
+    path: '/opt/{{ rails_app_directory }}/shared/public'
+    state: 'directory'
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
+    mode: 0775
+  when: running_on_server
+
+- name: dpul | create uploads symlink as deploy user
+  become: true
+  become_user: '{{ deploy_user }}'
+  file:
+    src: '/mnt/shared_data/dpul_{{ rails_app_env }}/uploads'
+    dest: '/opt/{{ rails_app_directory }}/shared/public/uploads'
     state: 'link'
-    force: true
-  with_items:
-    - src: '/mnt/shared_data/dpul_{{ rails_app_env }}/uploads'
-      link: '/opt/{{ rails_app_directory }}/shared/public/uploads'
   when: running_on_server

--- a/roles/nginxplus/files/conf/http/dpul-staging.conf
+++ b/roles/nginxplus/files/conf/http/dpul-staging.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/dpul-staging/NGINX_cache/ keys_zone=dpul-stagingcac
 
 upstream dpul-staging {
     zone dpul-staging 64k;
-    server dpul-staging1.princeton.edu resolve;
+    server dpul-staging2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_dpulstagingcookie
           lookup=$cookie_dpulstagingcookie


### PR DESCRIPTION
Required updates to the dpul role to fix directory ownership of symlink to mounted shared/uploads.

Remove dpul-staging1 because we're going to rebuild it. We'll add it back
when it's ready

refs pulibrary/dpul#1296