### PR TITLE
adds new dpul-staging1 to hosts file

### DIFF
--- a/hosts
+++ b/hosts
@@ -118,6 +118,7 @@ lib-redis.princeton.edu
 dpul1.princeton.edu
 dpul2.princeton.edu
 [dpul_staging]
+dpul-staging1.princeton.edu
 dpul-staging2.princeton.edu
 [geoserver]
 geoserv1.princeton.edu


### PR DESCRIPTION
Closes #2752.

When the new dpul-staging infrastructure is ready to go, we'll need to merge this hostsfile change so future updates will apply to both machines. 

Related to #2748.
