### PR TITLE
adds dpul-staging1 to load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/dpul-staging.conf
+++ b/roles/nginxplus/files/conf/http/dpul-staging.conf
@@ -3,7 +3,9 @@ proxy_cache_path /data/nginx/dpul-staging/NGINX_cache/ keys_zone=dpul-stagingcac
 
 upstream dpul-staging {
     zone dpul-staging 64k;
+    server dpul-staging1.princeton.edu resolve;
     server dpul-staging2.princeton.edu resolve;
+    
     sticky learn
           create=$upstream_cookie_dpulstagingcookie
           lookup=$cookie_dpulstagingcookie


### PR DESCRIPTION
Closes #2759.

Adds the new dpul-staging1 server to the load balancer config.

The new server was already added to the Ansible hosts file by #2755.
