### PR TITLE
Automate access to the new studio machine

### DIFF
--- a/hosts
+++ b/hosts
@@ -269,6 +269,8 @@ lib-statistics-staging1
 appdeploy1.princeton.edu
 [ouranos_staging]
 ouranos-staging1.princeton.edu
+[studio_processors]
+lib-proc4.princeton.edu
 [ansible_tower]
 ansible-tower1.princeton.edu
 [monitor_backends]

--- a/playbooks/studio_processors.yml
+++ b/playbooks/studio_processors.yml
@@ -5,6 +5,10 @@
   vars_files:
     # the keys for the studio processing connection are kept here
     - ../group_vars/figgy/production.yml
+  vars:
+    # this box has a "Systems User", so the pulsys user is uid/gid 1001
+    user_uid: 1002
+    group_id: 1002
   roles:
     - role: roles/deploy_user
   post_tasks:

--- a/playbooks/studio_processors.yml
+++ b/playbooks/studio_processors.yml
@@ -1,0 +1,15 @@
+---
+- hosts: studio_processors
+  remote_user: pulsys
+  become: true
+  vars_files:
+    # the keys for the studio processing connection are kept here
+    - ../group_vars/figgy/production.yml
+  roles:
+    - role: roles/deploy_user
+  post_tasks:
+    - name: tell everyone on slack you ran an ansible playbook
+      slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "{{ inventory_hostname }} completed"
+        channel: #server-alerts

--- a/playbooks/studio_processors.yml
+++ b/playbooks/studio_processors.yml
@@ -7,8 +7,7 @@
     - ../group_vars/figgy/production.yml
   vars:
     # this box has a "Systems User", so the pulsys user is uid/gid 1001
-    user_uid: 1002
-    group_id: 1002
+    deploy_user_uid: 1002
   roles:
     - role: roles/deploy_user
   post_tasks:


### PR DESCRIPTION
Roel reported seeing `permission denied (publickey)` when trying to do the rake ingest of LAE material on the new studio processing machine. This is a baby step toward automating management of the studio processing machines - I think it will solve the immediate problem and I hope it will give us a foundation to build on, so we can automate whatever else needs to be installed/managed on those machines. 