### PR TITLE
Remove extra slashes on proxied geniza urls

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
@@ -57,10 +57,10 @@ server {
         health_check interval=10 fails=3 passes=2;
     }
     location /indexcards {
-        proxy_pass https://genizaprojects.princeton.edu/indexcards/;
+        proxy_pass https://genizaprojects.princeton.edu/indexcards;
     }
     location /jtsviewer {
-        proxy_pass https://genizaprojects.princeton.edu/jtsviewer/;
+        proxy_pass https://genizaprojects.princeton.edu/jtsviewer;
     }
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;
 }


### PR DESCRIPTION
removing the trailing slash on the proxy url — currently it's resulting in a double-slash in the url