### PR TITLE
Fix the postgres backup-and-restore playbook

### DIFF
--- a/hosts
+++ b/hosts
@@ -215,9 +215,6 @@ lib-postgres-prod1.princeton.edu
 [postgresql_staging]
 lib-postgres-staging1.princeton.edu
 lib-postgres-staging2.princeton.edu
-[postgres_hosts]
-lib-postgres-staging1.princeton.edu
-lib-postgres-prod1.princeton.edu
 [pgbouncer_staging]
 lib-pgbouncer-staging1.princeton.edu
 [libruby_dev]

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -69,7 +69,7 @@
     - name: unzip dumped database on remote_host
       ansible.builtin.unarchive:
         src: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
-        dest: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
+        dest: "{{ file_path }}/{{ now }}/"
         remote_src: true
         owner: postgres
         group: postgres

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -66,6 +66,18 @@
       become: true
       become_user: "{{ deploy_user }}"
 
+    - name: unzip dumped database on remote_host
+      community.general.unarchive:
+        src: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
+        dest: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
+        remote_src: true
+        owner: postgres
+        group: postgres
+        mode: 0644
+
+      delegate_to: "{{ remote_host }}"
+      tags: never
+
     - name: Create a new database with name "{{ db_name }}"
       community.postgresql.postgresql_db:
         name: "{{ db_name }}"

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -1,9 +1,19 @@
 # NOTE
-# You must use command-line "extra variables" to use this playbook. They are
-# used to specify the host group, and the value of the db_name you intend to backup
-# and the flag for the remote host e.g.:
-# $ ansible-playbook -e db_name=oawaiver_staging -e origin_host=lib-postgres-staging1.princeton.edu -e remote_host=lib-postgres-prod1.princeton.edu playbooks/postgresql_db_migration.yml # to back up
-# $ ansible-playbook -e db_name=oawaiver_staging -e origin_host=lib-postgres-staging1.princeton.edu -e remote_host=lib-postgres-prod1.princeton.edu --tags never playbooks/postgresql_db_migration.yml
+# You must use command-line "extra variables" with this playbook to define:
+# - the db_name you intend to backup
+# - the origin_host (where the current database lives)
+# - the remote_host (where you want the database backup to go)
+#
+# You must also define the hosts more specifically (staging? prod?)
+# For example: --limit lib-postgres-staging1
+#
+# By default, the playbook creates a backup, but it does not restore
+# To restore, run the playbook a second time, and pass --tags never
+#
+# For example, to back up:
+# $ ansible-playbook -e db_name=oawaiver_staging -e origin_host=lib-postgres-staging1.princeton.edu -e remote_host=lib-postgres-prod1.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
+# and to restore:
+# $ ansible-playbook -e db_name=oawaiver_staging -e origin_host=lib-postgres-staging1.princeton.edu -e remote_host=lib-postgres-prod1.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
 ---
 - hosts: postgres_hosts
   remote_user: pulsys

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -15,7 +15,7 @@
 # and to restore:
 # $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging1.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
 ---
-- hosts: postgres_hosts
+- hosts: postgres_{{ runtime_env | default('staging') }}
   remote_user: pulsys
   become: true
   vars:

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -53,7 +53,15 @@
         group: "{{ deploy_user }}"
         mode: 0644
 
-    - name: transfer of databases
+    - name: create /var/lib/migrate on remote_host
+      file:
+        path: "/var/lib/migrate/{{ now }}/"
+        mode: 0777
+        owner: "{{ deploy_user }}"
+        state: directory
+      delegate_to: "{{ remote_host }}"
+
+    - name: transfer the databases
       ansible.builtin.command: /usr/bin/rsync -avz "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz" "{{ remote_host }}:{{ file_path }}/{{ now }}" -e "ssh -o StrictHostKeyChecking=no"
       become: true
       become_user: "{{ deploy_user }}"
@@ -64,7 +72,6 @@
       become: true
       become_user: postgres
       tags: never
-
 
     - name: Restore the database
       community.postgresql.postgresql_db:

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -2,7 +2,7 @@
 # You must use command-line "extra variables" with this playbook to define:
 # - the db_name you intend to backup
 # - the origin_host (where the current database lives)
-# - the remote_host (where you want the database backup to go)
+# - the dest_host (where you want the database backup to go)
 #
 # You must also define the hosts more specifically (staging? prod?)
 # For example: --limit lib-postgres-staging1
@@ -11,9 +11,9 @@
 # To restore, run the playbook a second time, and pass --tags never
 #
 # For example, to back up:
-# $ ansible-playbook -e db_name=oawaiver_staging -e origin_host=lib-postgres-staging1.princeton.edu -e remote_host=lib-postgres-prod1.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
+# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging1.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
 # and to restore:
-# $ ansible-playbook -e db_name=oawaiver_staging -e origin_host=lib-postgres-staging1.princeton.edu -e remote_host=lib-postgres-prod1.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
+# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging1.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
 ---
 - hosts: postgres_hosts
   remote_user: pulsys
@@ -53,20 +53,20 @@
         group: "{{ deploy_user }}"
         mode: 0644
 
-    - name: create /var/lib/migrate on remote_host
+    - name: create /var/lib/migrate on dest_host
       file:
         path: "/var/lib/migrate/{{ now }}/"
         mode: 0777
         owner: "{{ deploy_user }}"
         state: directory
-      delegate_to: "{{ remote_host }}"
+      delegate_to: "{{ dest_host }}"
 
     - name: transfer the databases
-      ansible.builtin.command: /usr/bin/rsync -avz "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz" "{{ remote_host }}:{{ file_path }}/{{ now }}" -e "ssh -o StrictHostKeyChecking=no"
+      ansible.builtin.command: /usr/bin/rsync -avz "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz" "{{ dest_host }}:{{ file_path }}/{{ now }}" -e "ssh -o StrictHostKeyChecking=no"
       become: true
       become_user: "{{ deploy_user }}"
 
-    - name: unzip dumped database on remote_host
+    - name: unzip dumped database on dest_host
       ansible.builtin.unarchive:
         src: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
         dest: "{{ file_path }}/{{ now }}/"
@@ -74,7 +74,7 @@
         owner: postgres
         group: postgres
         mode: 0644
-      delegate_to: "{{ remote_host }}"
+      delegate_to: "{{ dest_host }}"
       tags: never
 
     - name: Create a new database with name "{{ db_name }}"
@@ -82,7 +82,7 @@
         name: "{{ db_name }}"
       become: true
       become_user: postgres
-      delegate_to: "{{ remote_host }}"
+      delegate_to: "{{ dest_host }}"
       tags: never
 
     - name: Restore the database
@@ -92,7 +92,7 @@
         target: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
       become: true
       become_user: postgres
-      delegate_to: "{{ remote_host }}"
+      delegate_to: "{{ dest_host }}"
       tags: never
 
 

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -67,7 +67,7 @@
       become_user: "{{ deploy_user }}"
 
     - name: unzip dumped database on remote_host
-      community.general.unarchive:
+      ansible.builtin.unarchive:
         src: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
         dest: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
         remote_src: true

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -74,7 +74,6 @@
         owner: postgres
         group: postgres
         mode: 0644
-
       delegate_to: "{{ remote_host }}"
       tags: never
 
@@ -83,6 +82,7 @@
         name: "{{ db_name }}"
       become: true
       become_user: postgres
+      delegate_to: "{{ remote_host }}"
       tags: never
 
     - name: Restore the database

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -16,8 +16,13 @@
 # $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging1.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
 ---
 - hosts: postgres_{{ runtime_env | default('staging') }}
+# once the "big postgres PR" goes in change this to:
+# - hosts: "{{ leader_db_host }}"
   remote_user: pulsys
   become: true
+# and add
+# include_vars: /path/to/group_vars/postgresql/
+# where leader_db_host is defined for all pgsql machines
   vars:
     - deploy_user: "pulsys"
     - file_path: "/var/lib/migrate"

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -29,6 +29,13 @@
       become_user: postgres
       ignore_errors: true
 
+    - name: gzip dumped database
+      community.general.archive:
+        path: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
+        dest: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
+        format: gz
+        force_archive: true
+
     - name: file permissions
       ansible.builtin.file:
         path: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"


### PR DESCRIPTION
As part of #2735 we want a playbook that will dump existing databases from the old hardware, transfer the dump to the new hardware, and import the data into postgres on the new hardware.

This PR updated an existing playbook to do the full end-to-end db migration. We tested this playbook on the ojs_staging database, and it worked a charm!
