### PR TITLE
Upgrade nodejs for orangelight, enable controlled upgrades generally

### DIFF
--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nodejs__upstream_release: 'node_8.x'
+nodejs__upstream_release: 'node_14.x'
 nodejs__upstream_key_id: '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280'
 
 # URL of the NodeSource APT repository in ``sources.list`` format.

--- a/roles/nodejs/molecule/default/prepare.yml
+++ b/roles/nodejs/molecule/default/prepare.yml
@@ -1,5 +1,0 @@
----
-- name: Install a legacy NodeJS package
-  hosts: all
-  roles:
-    - role: nodejs

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -106,5 +106,5 @@
 
 - name: Install node packages
   apt:
-    name: ["nodejs", "yarn"]
+    name: ["nodejs={{ nodejs_wanted_version }}", "yarn"]
     state: present

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -91,9 +91,13 @@
     nodejs_versions: "{{ packages['nodejs'] | map(attribute='version') | list }}"
   when: "'nodejs' in packages"
 
+- name: nodejs | deconstruct upstream variable
+  set_fact:
+    nodejs_deconstructed: "{{ nodejs__upstream_release.split('.')[0] }}"
+
 - name: Get the version we are trying to install from the upstream release number
   set_fact:
-    nodejs_wanted_version: "{{ nodejs__upstream_release | split ('_') | last | split ('.') | first }}"
+    nodejs_wanted_version: "{{ nodejs_deconstructed.split('__')[1] }}"
 
 - name: Desired node version match regex
   debug:

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -91,9 +91,9 @@
     nodejs_versions: "{{ packages['nodejs'] | map(attribute='version') | list }}"
   when: "'nodejs' in packages"
 
-- name: Get the version we are trying to install into a regex
+- name: Get the version we are trying to install from the upstream release number
   set_fact:
-    nodejs_wanted_version: "{{ nodejs__upstream_release | regex_replace('node_') | regex_replace('.x') | regex_replace('^(.*)$', '^\\1.') }}"
+    nodejs_wanted_version: "{{ nodejs__upstream_release | split ('_') | last | split ('.') | first }}"
 
 - name: Desired node version match regex
   debug:

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -91,15 +91,12 @@
     nodejs_versions: "{{ packages['nodejs'] | map(attribute='version') | list }}"
   when: "'nodejs' in packages"
 
-- name: nodejs | deconstruct upstream variable
+- name: Get desired node version from the upstream release number
   set_fact:
-    nodejs_deconstructed: "{{ nodejs__upstream_release.split('.')[0] }}"
+    nodejs_wanted_version: "{{ nodejs__upstream_release.split('.')[0].split('_')[1] }}"
+# this task assumes that the nodejs__upstream_release variable looks like "node_##.x"
 
-- name: Get the version we are trying to install from the upstream release number
-  set_fact:
-    nodejs_wanted_version: "{{ nodejs_deconstructed.split('__')[1] }}"
-
-- name: Desired node version match regex
+- name: Check desired node version
   debug:
     msg: "{{ nodejs_wanted_version }}"
 

--- a/roles/orangelight/vars/main.yml
+++ b/roles/orangelight/vars/main.yml
@@ -9,7 +9,7 @@ rails_app_dependencies:
   - pkg-config
   - libtool
   - autoconf
-nodejs__upstream_release: 'node_12.x'
+nodejs__upstream_release: 'node_16.x'
 nodejs__upstream_key_id: '68576280'
 passenger_ruby: "/usr/bin/ruby2.7"
 ruby_version_override: "ruby2.7"


### PR DESCRIPTION
For easy maintenance and controlled upgrades, we want the `nodejs` role to install a specific version.

Jane's change updates the version of `nodejs` for orangelight.

Alicia's change requires that version to be installed.
