### PR TITLE
Update the Postgres db backup playbook

### DIFF
--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -115,8 +115,7 @@
         encoding: 'UTF-8'
         owner: '{{ application_dbuser_name }}'
         target: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
-      state: 'restore'
-        # need to specify the db owner and make sure it owns all the tables as well as the db itself
+        state: 'restore'
       become: true
       become_user: postgres
       delegate_to: "{{ dest_host }}"

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -42,7 +42,12 @@
         target: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
       become: true
       become_user: postgres
-      ignore_errors: true
+      # async allows for long-running tasks
+      # sets the timeout to 30 minutes, checks every minute
+      async: 1800
+      poll: 60
+      # was probably to avoid timeouts
+      # ignore_errors: true
 
     - name: gzip dumped database
       community.general.archive:

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -15,7 +15,7 @@
 # and to restore:
 # $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging3.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1
 ---
-- hosts: postgres
+- hosts: postgresql_{{ runtime_env | default('staging') }}
 # once the "big postgres PR" goes in change this to:
 # - hosts: "{{ leader_db_host }}"
   remote_user: pulsys
@@ -29,6 +29,7 @@
     - now: "{{ ansible_date_time.date }}"
   vars_files:
     - ../group_vars/{{ project_name }}/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/{{ project_name }}/vault.yml
 
   tasks:
     - name: Create a backup directory
@@ -73,13 +74,13 @@
       delegate_to: "{{ dest_host }}"
 
     - name: transfer the databases
-      ansible.builtin.command: /usr/bin/rsync -avz "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz" "{{ dest_host }}:{{ file_path }}/{{ now }}" -e "ssh -o StrictHostKeyChecking=no"
+      ansible.builtin.command: /usr/bin/rsync -avz "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.gz" "{{ dest_host }}:{{ file_path }}/{{ now }}" -e "ssh -o StrictHostKeyChecking=no"
       become: true
       become_user: "{{ deploy_user }}"
 
     - name: unzip dumped database on dest_host
       ansible.builtin.unarchive:
-        src: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
+        src: "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.gz"
         dest: "{{ file_path }}/{{ now }}/"
         remote_src: true
         owner: postgres
@@ -94,7 +95,7 @@
 
     - name: PostgreSQL | create postgresql '{{ application_dbuser_name }}'
       postgresql_user:
-       name: '{{ application_dbuser_name }}'
+        name: '{{ application_dbuser_name }}'
         port: '{{ postgres_port | default(omit) }}'
         login_host: '{{ postgres_host | default(omit) }}'
         login_user: '{{ postgres_admin_user | default(omit) }}'
@@ -114,7 +115,7 @@
         name: "{{ application_db_name }}"
         encoding: 'UTF-8'
         owner: '{{ application_dbuser_name }}'
-        target: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
+        target: "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.sql"
         state: 'restore'
       become: true
       become_user: postgres
@@ -128,5 +129,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} backed up {{ db_name }}"
+        msg: "{{ inventory_hostname }} backed up {{ application_db_name }}"
         channel: #server-alerts

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -27,6 +27,9 @@
     - deploy_user: "pulsys"
     - file_path: "/var/lib/migrate"
     - now: "{{ ansible_date_time.date }}"
+  vars_files:
+    - ../group_vars/{{ project_name }}/{{ runtime_env | default('staging') }}.yml
+
   tasks:
     - name: Create a backup directory
       file:
@@ -38,8 +41,8 @@
     - name: run a database dump
       postgresql_db:
         state: dump
-        name: "{{ db_name }}"
-        target: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
+        name: "{{ application_db_name }}"
+        target: "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.sql"
       become: true
       become_user: postgres
       # async allows for long-running tasks
@@ -49,14 +52,14 @@
 
     - name: gzip dumped database
       community.general.archive:
-        path: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
-        dest: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
+        path: "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.sql"
+        dest: "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.gz"
         format: gz
         force_archive: true
 
     - name: file permissions
       ansible.builtin.file:
-        path: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.gz"
+        path: "{{ file_path }}/{{ now }}/{{ application_db_name }}.dump.gz"
         owner: "{{ deploy_user }}"
         group: "{{ deploy_user }}"
         mode: 0644
@@ -85,19 +88,35 @@
       delegate_to: "{{ dest_host }}"
       tags: never
 
-    - name: Create a new database with name "{{ db_name }}"
-      community.postgresql.postgresql_db:
-        name: "{{ db_name }}"
+# eventually maybe we can do this:
+#    - name: import the postgresql user creation tasks
+#      import_tasks: ../roles/postgresql/tasks/create_user.yml
+
+    - name: PostgreSQL | create postgresql '{{ application_dbuser_name }}'
+      postgresql_user:
+       name: '{{ application_dbuser_name }}'
+        port: '{{ postgres_port | default(omit) }}'
+        login_host: '{{ postgres_host | default(omit) }}'
+        login_user: '{{ postgres_admin_user | default(omit) }}'
+        login_password: '{{ postgres_admin_password | default(omit) }}'
+        password: '{{ application_dbuser_password }}'
+        encrypted: true
+        role_attr_flags: '{{ application_dbuser_role_attr_flags }}'
+        state: 'present'
       become: true
       become_user: postgres
       delegate_to: "{{ dest_host }}"
       tags: never
 
-    - name: Restore the database
+
+    - name: Restore the database with name "{{ application_db_name }}"
       community.postgresql.postgresql_db:
-        state: restore
-        name: "{{ db_name }}"
+        name: "{{ application_db_name }}"
+        encoding: 'UTF-8'
+        owner: '{{ application_dbuser_name }}'
         target: "{{ file_path }}/{{ now }}/{{ db_name }}.dump.sql"
+      state: 'restore'
+        # need to specify the db owner and make sure it owns all the tables as well as the db itself
       become: true
       become_user: postgres
       delegate_to: "{{ dest_host }}"

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -1,28 +1,32 @@
 # NOTE
 # You must use command-line "extra variables" with this playbook to define:
-# - the db_name you intend to backup
-# - the origin_host (where the current database lives)
+# - the project_name you intend to backup
+# - the host where the current database lives, with --limit 
 # - the dest_host (where you want the database backup to go)
 #
-# You must also define the hosts more specifically (staging? prod?)
-# For example: --limit lib-postgres-staging1
+# By default, this playbook runs against the staging infrastructure
+# to backup from production, pass -e runtime_env=production
+# since backups should come from a single server, not a group, be sure to pass a limit
+# For example: --limit lib-postgres-staging1.princeton.edu
 #
 # By default, the playbook creates a backup, but it does not restore
 # To restore, run the playbook a second time, and pass --tags never
 #
 # For example, to back up:
-# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging3.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1
+# $ ansible-playbook -e project_name=cdh_geniza -e dest_host=lib-postgres-staging3.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1.princeton.edu
 # and to restore:
-# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging3.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1
+# $ ansible-playbook -e project_name=cdh_geniza -e dest_host=lib-postgres-staging3.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1.princeton.edu
+
 ---
 - hosts: postgresql_{{ runtime_env | default('staging') }}
-# once the "big postgres PR" goes in change this to:
-# - hosts: "{{ leader_db_host }}"
+# To-do: once the "big postgres PR" goes in, can we use:
+# - hosts: "{{ leader_db_host }}" ?
   remote_user: pulsys
   become: true
-# and add
-# include_vars: /path/to/group_vars/postgresql/
+# we would need to add
+# /path/to/group_vars/postgresql/
 # where leader_db_host is defined for all pgsql machines
+# to the vars_files: section
   vars:
     - deploy_user: "pulsys"
     - file_path: "/var/lib/migrate"
@@ -89,7 +93,7 @@
       delegate_to: "{{ dest_host }}"
       tags: never
 
-# eventually maybe we can do this:
+#  To-do - can we use the existing task files from the postgresql role here?:
 #    - name: import the postgresql user creation tasks
 #      import_tasks: ../roles/postgresql/tasks/create_user.yml
 
@@ -108,7 +112,6 @@
       become_user: postgres
       delegate_to: "{{ dest_host }}"
       tags: never
-
 
     - name: Restore the database with name "{{ application_db_name }}"
       community.postgresql.postgresql_db:

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -11,11 +11,11 @@
 # To restore, run the playbook a second time, and pass --tags never
 #
 # For example, to back up:
-# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging1.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
+# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging3.princeton.edu playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1
 # and to restore:
-# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging1.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-staging1
+# $ ansible-playbook -e db_name=cdh_geniza -e origin_host=lib-postgres-prod1.princeton.edu -e dest_host=lib-postgres-staging3.princeton.edu --tags never playbooks/postgresql_db_migration.yml --limit lib-postgres-prod1
 ---
-- hosts: postgres_{{ runtime_env | default('staging') }}
+- hosts: postgres
 # once the "big postgres PR" goes in change this to:
 # - hosts: "{{ leader_db_host }}"
   remote_user: pulsys
@@ -46,8 +46,6 @@
       # sets the timeout to 30 minutes, checks every minute
       async: 1800
       poll: 60
-      # was probably to avoid timeouts
-      # ignore_errors: true
 
     - name: gzip dumped database
       community.general.archive:
@@ -103,6 +101,8 @@
       become: true
       become_user: postgres
       delegate_to: "{{ dest_host }}"
+      async: 1800
+      poll: 60
       tags: never
 
 


### PR DESCRIPTION
This PR updates the playbook for dumping and restoring postgresql databases:

- removes `ignore_errors`
- makes tasks that might take a long time asynchronous
- updates the comments in light of today's testing
- changes the `hosts` line, because we do not have separate `postgres_prod` and `postgres_staging` groups in our hosts file yet