### PR TITLE
[CATALOG] stop upstream sent too big header

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -55,6 +55,10 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        proxy_max_temp_file_size 0;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
         health_check interval=10 fails=2 passes=1 uri=/catalog/991234563506421;
     }
 

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -36,6 +36,10 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        proxy_max_temp_file_size 0;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
         health_check interval=10 fails=3 passes=2 uri=/catalog/1234567;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -33,13 +33,13 @@ server {
         proxy_pass http://catalog-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache catalog-stagingcache;
-        proxy_cache_revalidate on;
-        proxy_cache_min_uses 3;
-        proxy_cache_use_stale error timeout updating http_500 http_502
-                              http_503 http_504;
-        proxy_cache_background_update on;
-        proxy_cache_lock on;
-        proxy_cache_key "$host$request_uri $cookie_user";
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
+        proxy_max_temp_file_size 0;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
fixes #2804
Also synchronize staging config with qa and prod
copying values from https://github.com/pulibrary/princeton_ansible/search?q=proxy_buffer_size
see https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx