### PR TITLE
add a path to pdc-discovery

### DIFF
--- a/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
@@ -37,12 +37,11 @@ server {
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 
-    location /discovery {
-        proxy_pass http://pdc-discovery-prod;
+    location /discovery/ {
+        proxy_pass http://pdc-discovery-prod/discovery/;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache pdc-discovery-prodcache;
-        health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all

--- a/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
@@ -29,12 +29,11 @@ server {
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 
-    location / {
-        proxy_pass http://pdc-discovery-staging;
+    location /discovery/ {
+        proxy_pass http://pdc-discovery-staging/discovery/;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache pdc-discovery-stagingcache;
-        health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
the pdc-discovery project prefers to have a path added for their application
we add the path to the root of the domain which is a desired goal of the
project
Co-authored-by: Bess Sadler <bess@ibiblio.org>
