### PR TITLE
build nodejs

### DIFF
--- a/roles/appdeploy/defaults/main.yml
+++ b/roles/appdeploy/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for roles/appdeploy
+desired_version: v16.14.0

--- a/roles/appdeploy/defaults/main.yml
+++ b/roles/appdeploy/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for roles/appdeploy
-desired_version: v16.14.0
+desired_nodejs_version: v16.14.0

--- a/roles/appdeploy/molecule/default/converge.yml
+++ b/roles/appdeploy/molecule/default/converge.yml
@@ -7,5 +7,3 @@
         name: "appdeploy"
   vars:
     - running_on_server: false
-    - nodejs__upstream_release: 'node_12.x'
-    - nodejs__upstream_key_id: '68576280'

--- a/roles/appdeploy/tasks/main.yml
+++ b/roles/appdeploy/tasks/main.yml
@@ -1,9 +1,28 @@
 ---
-- name: Install "forever" node.js package globally.
+- name: appdeploy | Install "forever" node.js package globally.
   community.general.npm:
     name: forever
-    global: yes
-- name: Install "coffee-script" node.js package globally.
+    global: true
+
+- name: appdeploy | register forever binary path
+  ansible.builtin.file:
+    src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/forever/bin/forever"
+    dest: "/usr/local/bin/forever"
+    owner: root
+    group: root
+    state: link
+  changed_when: false
+
+- name: appdeploy | Install "coffee-script" node.js package globally.
   community.general.npm:
     name: coffee-script
-    global: yes
+    global: true
+
+- name: appdeploy | register coffee-script binary path
+  ansible.builtin.file:
+    src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/coffee-script/bin/coffee"
+    dest: "/usr/local/bin/coffee"
+    owner: root
+    group: root
+    state: link
+  changed_when: false

--- a/roles/appdeploy/tasks/main.yml
+++ b/roles/appdeploy/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: appdeploy | register forever binary path
   ansible.builtin.file:
-    src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/forever/bin/forever"
+    src: "/usr/local/node-{{ desired_nodejs_version }}-linux-x64/lib/node_modules/forever/bin/forever"
     dest: "/usr/local/bin/forever"
     owner: root
     group: root
@@ -20,7 +20,7 @@
 
 - name: appdeploy | register coffee-script binary path
   ansible.builtin.file:
-    src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/coffee-script/bin/coffee"
+    src: "/usr/local/node-{{ desired_nodejs_version }}-linux-x64/lib/node_modules/coffee-script/bin/coffee"
     dest: "/usr/local/bin/coffee"
     owner: root
     group: root

--- a/roles/nodejs/README.md
+++ b/roles/nodejs/README.md
@@ -3,35 +3,8 @@ Role Name
 
 Installs Nodejs (that's nodejs and yarn packages)
 
-Requirements
-------------
-
 
 Role Variables
 --------------
 
-
-Dependencies
-------------
-
-
-Example Playbook
-----------------
-
-Including an example of how to use your role (for instance, with variables
-passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: roles/nodejs }
-
-License
--------
-
-MIT
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a
-website (HTML is not allowed).
+desired_version: "v16.14.0"

--- a/roles/nodejs/README.md
+++ b/roles/nodejs/README.md
@@ -7,4 +7,4 @@ Installs Nodejs (that's nodejs and yarn packages)
 Role Variables
 --------------
 
-desired_version: "v16.14.0"
+desired_nodejs_version: "v16.14.0"

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -12,3 +12,6 @@ nodejs__yarn_upstream: true
 nodejs__yarn_upstream_key_id: '72ECF46A56B4AD39C907BBB71646B01B86E50310'
 # URL of the NodeSource APT repository in ``sources.list`` format.
 nodejs__yarn_upstream_repository: 'deb https://dl.yarnpkg.com/debian/ stable main'
+
+# default node
+desired_version: v16.14.0

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,10 +1,4 @@
 ---
-nodejs__upstream_release: 'node_8.x'
-nodejs__upstream_key_id: '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280'
-
-# URL of the NodeSource APT repository in ``sources.list`` format.
-nodejs__upstream_repository: 'deb https://deb.nodesource.com/{{ nodejs__upstream_release }} {{ ansible_distribution_release }} main'
-
 # Enable or disable support for Yarn upstream APT repository.
 nodejs__yarn_upstream: true
 

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -8,4 +8,4 @@ nodejs__yarn_upstream_key_id: '72ECF46A56B4AD39C907BBB71646B01B86E50310'
 nodejs__yarn_upstream_repository: 'deb https://dl.yarnpkg.com/debian/ stable main'
 
 # default node
-desired_version: v16.14.0
+desired_nodejs_version: v16.14.0

--- a/roles/nodejs/molecule/default/verify.yml
+++ b/roles/nodejs/molecule/default/verify.yml
@@ -3,17 +3,16 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: check nodejs package status
+  - name: check yarn package status
     package:
       name: "{{ item }}"
       state: present
     check_mode: true
     register: pkg_status
     loop:
-      - nodejs
       - yarn
 
-  - name: test for nodejs packages
+  - name: test for yarn packages
     assert:
       that:
         - not pkg_status.changed

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -47,8 +47,16 @@
 - name: nodejs | download nodejs version
   ansible.builtin.unarchive:
     src: "{{ nodejs_release_url }}/{{ desired_version }}/node-{{ desired_version }}-linux-x64.tar.gz"
-    dest: /usr/local/bin
+    dest: /usr/local
     remote_src: true
+
+- name: nodejs | create symbolic link
+  ansible.builtin.file:
+    src: "/usr/local/node-{{ desired_version }}-linux-x64/bin/node"
+    dest: "/usr/local/bin/node"
+    owner: root
+    group: root
+    state: link
 
 - name: nodejs | Install yarn packages
   apt:

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,45 +1,12 @@
 ---
-- name: nodejs | Get debsource APT GPG key
-  apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    state: present
-  register: debsource_servers
-  ignore_errors: true
-
-- name: Get upstream APT GPG key
-  apt_key:
-    id: "{{ nodejs__upstream_key_id }}"
-    keyserver: "hkp://pool.sks-keyservers.net"
-    state: present
-  register: pool_servers
-  when: debsource_servers is failed
-  ignore_errors: true
-
-- name: Get upstream APT GPG key from MIT
-  apt_key:
-    id: "{{ nodejs__upstream_key_id }}"
-    state: present
-    keyserver: "pgp.mit.edu"
-  register: mit_servers
-  when: pool_servers is failed
-  ignore_errors: true
-
-- name: Get upstream APT GPG key from PGP
-  apt_key:
-    id: "{{ nodejs__upstream_key_id }}"
-    state: present
-    keyserver: "keyserver.pgp.com"
-  when: mit_servers is failed
-  ignore_errors: true
-
-- name: Add upstream Yarn APT key from PGP
+- name: nodejs | Add upstream Yarn APT key yarn
   apt_key:
     url: https://dl.yarnpkg.com/debian/pubkey.gpg
     state: present
   register: yarn_servers
   ignore_errors: true
 
-- name: Add upstream Yarn APT key from PGP
+- name: nodejs | Add upstream Yarn APT key from sks-keyservsers
   apt_key:
     id: "{{ nodejs__yarn_upstream_key_id }}"
     keyserver: "hkp://pool.sks-keyservers.net"
@@ -48,7 +15,7 @@
   when: yarn_servers is failed
   ignore_errors: true
 
-- name: Add upstream Yarn APT key from MIT
+- name: nodejs | Add upstream Yarn APT key from MIT
   apt_key:
     id: "{{ nodejs__yarn_upstream_key_id }}"
     state: present
@@ -57,7 +24,7 @@
   register: yarnmit_servers
   ignore_errors: true
 
-- name: Add upstream Yarn APT key from PGP
+- name: nodejs | Add upstream Yarn APT key from PGP
   apt_key:
     id: "{{ nodejs__yarn_upstream_key_id }}"
     state: present
@@ -65,46 +32,25 @@
   when: yarnmit_servers is failed
   ignore_errors: true
 
-- name: Configure upstream APT repository
-  apt_repository:
-    repo: "{{ nodejs__upstream_repository }}"
-    state: present
-    update_cache: true
-  register: nodejs_repo
-  retries: 3
-  delay: 60
-  until: nodejs_repo is succeeded
-
-- name: Add upstream Yarn APT repository
+- name: nodejs | Add upstream Yarn APT repository
   apt_repository:
     repo: "{{ nodejs__yarn_upstream_repository }}"
     state: present
     update_cache: true
   ignore_errors: true
 
-- name: Gather the apt package facts
-  package_facts:
-    manager: auto
-
-- name: Get the versions of nodejs installed
-  set_fact:
-    nodejs_versions: "{{ packages['nodejs'] | map(attribute='version') | list }}"
-  when: "'nodejs' in packages"
-
-- name: Get the version we are trying to install into a regex
-  set_fact:
-    nodejs_wanted_version: "{{ nodejs__upstream_release | regex_replace('node_') | regex_replace('.x') | regex_replace('^(.*)$', '^\\1.') }}"
-
-- name: Desired node version match regex
-  debug:
-    msg: "{{ nodejs_wanted_version }}"
-
-- name: Check for the LTS release
-  set_fact:
-    nodejs_lts_installed: "{{ nodejs_versions | select('match', nodejs_wanted_version) | list | length > 0 }}"
-  when: nodejs_versions is defined
-
-- name: Install node packages
+- name: nodejs | uninstall any apt installed node
   apt:
-    name: ["nodejs", "yarn"]
+    name: ["nodejs"]
+    state: absent
+
+- name: nodejs | download nodejs version
+  ansible.builtin.unarchive:
+    src: "{{ nodejs_release_url }}/{{ desired_version }}/node-{{ desired_version }}-linux-x64.tar.gz"
+    dest: /usr/local/bin
+    remote_src: true
+
+- name: nodejs | Install yarn packages
+  apt:
+    name: ["yarn"]
     state: present

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,43 +1,29 @@
 ---
-- name: nodejs | Add upstream Yarn APT key yarn
+- name: nodejs | get yarn key from yarnpkg
   apt_key:
     url: https://dl.yarnpkg.com/debian/pubkey.gpg
     state: present
-  register: yarn_servers
-  ignore_errors: true
+  register: yarn_pkg_registered
 
-- name: nodejs | Add upstream Yarn APT key from sks-keyservsers
+- name: nodejs | get yarn keys from other sources
   apt_key:
     id: "{{ nodejs__yarn_upstream_key_id }}"
-    keyserver: "hkp://pool.sks-keyservers.net"
+    keyserver: "{{ item }}"
     state: present
-  register: yarnpool_servers
-  when: yarn_servers is failed
-  ignore_errors: true
-
-- name: nodejs | Add upstream Yarn APT key from MIT
-  apt_key:
-    id: "{{ nodejs__yarn_upstream_key_id }}"
-    state: present
-    keyserver: "pgp.mit.edu"
-  when: yarnpool_servers is failed
-  register: yarnmit_servers
-  ignore_errors: true
-
-- name: nodejs | Add upstream Yarn APT key from PGP
-  apt_key:
-    id: "{{ nodejs__yarn_upstream_key_id }}"
-    state: present
-    keyserver: "keyserver.pgp.com"
-  when: yarnmit_servers is failed
-  ignore_errors: true
+  when: yarn_pkg_registered is failed
+  register: yarn_key_registered
+  loop:
+    - "hkp://pool.sks-keyservers.net"
+    - "pgp.mit.edu"
+    - "keyserver.pgp.com"
+  failed_when:
+    - yarn_key_registered == 0
 
 - name: nodejs | Add upstream Yarn APT repository
   apt_repository:
     repo: "{{ nodejs__yarn_upstream_repository }}"
     state: present
     update_cache: true
-  ignore_errors: true
 
 - name: nodejs | uninstall any apt installed node
   ansible.builtin.apt:
@@ -52,22 +38,16 @@
     remote_src: true
   changed_when: false
 
-- name: nodejs | create symbolic link for node
+- name: nodejs | create symbolic links for node and npm
   ansible.builtin.file:
-    src: "/usr/local/node-{{ desired_version }}-linux-x64/bin/node"
-    dest: "/usr/local/bin/node"
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
     owner: root
     group: root
     state: link
-  changed_when: false
-
-- name: nodejs | create symbolic link for npm
-  ansible.builtin.file:
-    src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/npm/bin/npm-cli.js"
-    dest: "/usr/local/bin/npm"
-    owner: root
-    group: root
-    state: link
+  loop:
+    - { src: "/usr/local/node-{{ desired_version }}-linux-x64/bin/node", dest: "/usr/local/bin/node" }
+    - { src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/npm/bin/npm-cli.js", dest: "/usr/local/bin/npm" }
   changed_when: false
 
 - name: nodejs | Install yarn packages

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -52,10 +52,19 @@
     remote_src: true
   changed_when: false
 
-- name: nodejs | create symbolic link
+- name: nodejs | create symbolic link for node
   ansible.builtin.file:
     src: "/usr/local/node-{{ desired_version }}-linux-x64/bin/node"
     dest: "/usr/local/bin/node"
+    owner: root
+    group: root
+    state: link
+  changed_when: false
+
+- name: nodejs | create symbolic link for npm
+  ansible.builtin.file:
+    src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/npm/bin/npm-cli.js"
+    dest: "/usr/local/bin/npm"
     owner: root
     group: root
     state: link

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: nodejs | download nodejs version
   ansible.builtin.unarchive:
-    src: "{{ nodejs_release_url }}/{{ desired_version }}/node-{{ desired_version }}-linux-x64.tar.gz"
+    src: "{{ nodejs_release_url }}/{{ desired_nodejs_version }}/node-{{ desired_nodejs_version }}-linux-x64.tar.gz"
     dest: /usr/local
     remote_src: true
   changed_when: false
@@ -46,8 +46,8 @@
     group: root
     state: link
   loop:
-    - { src: "/usr/local/node-{{ desired_version }}-linux-x64/bin/node", dest: "/usr/local/bin/node" }
-    - { src: "/usr/local/node-{{ desired_version }}-linux-x64/lib/node_modules/npm/bin/npm-cli.js", dest: "/usr/local/bin/npm" }
+    - {src: "/usr/local/node-{{ desired_nodejs_version }}-linux-x64/bin/node", dest: "/usr/local/bin/node"}
+    - {src: "/usr/local/node-{{ desired_nodejs_version }}-linux-x64/lib/node_modules/npm/bin/npm-cli.js", dest: "/usr/local/bin/npm"}
   changed_when: false
 
 - name: nodejs | Install yarn packages

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -40,15 +40,17 @@
   ignore_errors: true
 
 - name: nodejs | uninstall any apt installed node
-  apt:
+  ansible.builtin.apt:
     name: ["nodejs"]
     state: absent
+  changed_when: false
 
 - name: nodejs | download nodejs version
   ansible.builtin.unarchive:
     src: "{{ nodejs_release_url }}/{{ desired_version }}/node-{{ desired_version }}-linux-x64.tar.gz"
     dest: /usr/local
     remote_src: true
+  changed_when: false
 
 - name: nodejs | create symbolic link
   ansible.builtin.file:
@@ -57,6 +59,7 @@
     owner: root
     group: root
     state: link
+  changed_when: false
 
 - name: nodejs | Install yarn packages
   apt:

--- a/roles/nodejs/vars/main.yml
+++ b/roles/nodejs/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for roles/nodejs
+nodejs_release_url: "https://nodejs.org/download/release/"

--- a/roles/rails_app/tasks/main.yml
+++ b/roles/rails_app/tasks/main.yml
@@ -4,6 +4,7 @@
     name: '{{ item }}'
     state: present
   loop: '{{ rails_app_dependencies }}'
+  changed_when: false
 
 - name: rails_app | Install site configuration
   template:


### PR DESCRIPTION
This PR eliminates the need for `apt` versions of node. Instead we download specific binaries from the nodejs project to install node. 
- add nodejs variables
- add specific node version info

It will supercede #2796 and #2787

