### PR TITLE
Configure PDC Discovery to deliver at subdirectory

### DIFF
--- a/group_vars/pdc_discovery/production.yml
+++ b/group_vars/pdc_discovery/production.yml
@@ -13,7 +13,7 @@ rails_app_env: "production"
 pdc_discovery_host_name: 'pdc-discovery-prod1.princeton.edu'
 pdc_discovery_honeybadger_key: '{{vault_pdc_discovery_honeybadger_key}}'
 
-solr_url: "http://lib-solr-prod4.princeton.edu:8983/solr/pdc-discovery-production"
+solr_url: "http://lib-solr8-prod.princeton.edu:8983/solr/pdc-discovery-production"
 
 # Note that this MUST stay in the environment-specific playbook.
 # Moving any of these to common.yml will not work.

--- a/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
@@ -42,6 +42,7 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache pdc-discovery-prodcache;
+        # health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all
@@ -66,7 +67,7 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache pdc-discovery-prodcache;
-        health_check interval=10 fails=3 passes=2;
+        # health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
Also, PDC Discovery production should point at the load balanced solr

Co-authored-by: Francis Kayiwa <kayiwa@pobox.com>

Work toward https://github.com/pulibrary/pdc_discovery/issues/169