### PR TITLE
switch pulfalight vars to use load-balanced Solr8

### DIFF
--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -59,7 +59,7 @@ rails_app_vars:
   - name: APPLICATION_PORT
     value: '{{application_port}}'
   - name: SOLR_URL
-    value: "http://lib-solr-prod4.princeton.edu:8983/solr/{{ pulfalight_solr_core }}"
+    value: "http://lib-solr8-prod.princeton.edu:8983/solr/{{ pulfalight_solr_core }}"
   - name: HONEYBADGER_API_KEY
     value: '{{pulfalight_honeybadger_key}}'
   - name: ASPACE_USER


### PR DESCRIPTION
Closes #2810.

We discovered today that pulfalight was pointing to an individual Solr box instead of using the load balancer to access Solr. This updates the config to use the load balancer. 