### PR TITLE
ignore apt get errors

### DIFF
--- a/roles/nginxplus/tasks/main.yml
+++ b/roles/nginxplus/tasks/main.yml
@@ -8,6 +8,7 @@
 
 - import_tasks: keys/sig-science-key.yml
   when: nginx_type == "plus"
+  ignore_errors: true
 
 - name: Install NGINX
   block:

--- a/roles/nginxplus/tasks/plus/setup-debian.yml
+++ b/roles/nginxplus/tasks/plus/setup-debian.yml
@@ -19,3 +19,4 @@
 - name: "Install: Update APT Cache"
   apt:
     update_cache: true
+  ignore_errors: true


### PR DESCRIPTION
the nginxplus pkg repos are down. This allows the playbook to run
