### PR TITLE
specifies nodejs version for pulfalight

### DIFF
--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -12,7 +12,7 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.7"
 ruby_version_override: "ruby2.7"
 bundler_version: "2.1.4"
-desired_nodejs_version: '12.16.1'
+desired_nodejs_version: 'v12.16.1'
 # nodejs__upstream_release: 'node_12.x'
 # nodejs__upstream_key_id: '68576280'
 rails_app_name: "pulfalight"

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -12,8 +12,9 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/bin/ruby2.7"
 ruby_version_override: "ruby2.7"
 bundler_version: "2.1.4"
-nodejs__upstream_release: 'node_12.x'
-nodejs__upstream_key_id: '68576280'
+desired_nodejs_version: '12.16.1'
+# nodejs__upstream_release: 'node_12.x'
+# nodejs__upstream_key_id: '68576280'
 rails_app_name: "pulfalight"
 rails_app_directory: "pulfalight"
 rails_app_symlinks: []

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -12,8 +12,9 @@ passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.7"
 ruby_version_override: "ruby2.7"
 bundler_version: "2.1.4"
-nodejs__upstream_release: 'node_12.x'
-nodejs__upstream_key_id: '68576280'
+desired_nodejs_version: '12.16.1'
+# nodejs__upstream_release: 'node_12.x'
+# nodejs__upstream_key_id: '68576280'
 rails_app_name: "pulfalight"
 rails_app_directory: "pulfalight"
 rails_app_symlinks: []

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -12,7 +12,7 @@ passenger_app_env: "staging"
 passenger_ruby: "/usr/bin/ruby2.7"
 ruby_version_override: "ruby2.7"
 bundler_version: "2.1.4"
-desired_nodejs_version: '12.16.1'
+desired_nodejs_version: 'v12.16.1'
 # nodejs__upstream_release: 'node_12.x'
 # nodejs__upstream_key_id: '68576280'
 rails_app_name: "pulfalight"

--- a/roles/nodejs/README.md
+++ b/roles/nodejs/README.md
@@ -8,3 +8,4 @@ Role Variables
 --------------
 
 desired_nodejs_version: "v16.14.0"
+NOTE: the value MUST begin with `v`, as in "v16.14.0" or "v12.16.1"

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -35,8 +35,8 @@
   ansible.builtin.unarchive:
     src: "{{ nodejs_release_url }}/{{ desired_nodejs_version }}/node-{{ desired_nodejs_version }}-linux-x64.tar.gz"
     dest: /usr/local
+    creates: /usr/local/node-{{ desired_nodejs_version }}-linux-x64
     remote_src: true
-  changed_when: false
 
 - name: nodejs | create symbolic links for node and npm
   ansible.builtin.file:


### PR DESCRIPTION
With the recent changes to the nodejs role, we can specify an exact version of NodeJS for each app.

This PR specifies the version for pulfalight, which should match https://github.com/pulibrary/pulfalight/blob/main/.tool-versions#L2. 