### PR TITLE
Keep Orangelight production and staging on Node 12

### DIFF
--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -13,6 +13,7 @@ rails_app_dependencies:
   - libtool
   - autoconf
 bundler_version: "2.1.4"
+desired_nodejs_version: 'v12.22.8'
 postgresql_is_local: false
 postgres_host: "lib-postgres-prod1.princeton.edu"
 postgres_admin_user: "postgres"

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -12,6 +12,7 @@ rails_app_dependencies:
   - libtool
   - autoconf
 bundler_version: "2.1.4"
+desired_nodejs_version: 'v12.22.8'
 postgresql_is_local: false
 postgres_host: "lib-postgres-staging1.princeton.edu"
 postgres_version: 13

--- a/roles/orangelight/vars/main.yml
+++ b/roles/orangelight/vars/main.yml
@@ -9,7 +9,5 @@ rails_app_dependencies:
   - pkg-config
   - libtool
   - autoconf
-nodejs__upstream_release: 'node_12.x'
-nodejs__upstream_key_id: '68576280'
 passenger_ruby: "/usr/bin/ruby2.7"
 ruby_version_override: "ruby2.7"


### PR DESCRIPTION
This upgrades qa to the new default version (16)