### PR TITLE
[Approvals] Upgrade ruby version to 2.7.5 and node to v12.22.5

### DIFF
--- a/group_vars/approvals/approvals_prod.yml
+++ b/group_vars/approvals/approvals_prod.yml
@@ -4,6 +4,8 @@ postgres_version: 10
 postgres_is_local: false
 passenger_server_name: "lib-approvals-prod1.princeton.edu"
 passenger_app_env: "production"
+passenger_ruby: "/usr/bin/ruby2.7"
+ruby_version_override: "ruby2.7"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_admin_user: '{{ vault_postgres_admin_user }}'
 app_db_host: '{{ postgres_host }}'
@@ -19,7 +21,6 @@ application_dbuser_role_attr_flags: 'SUPERUSER'
 app_host_name: 'approvals.princeton.edu'
 application_host_protocol: 'https'
 running_on_server: true
-ruby_version_override: "ruby2.6"
 bundler_version: '2.1.4'
 desired_nodejs_version: "v12.22.5"
 

--- a/group_vars/approvals/approvals_staging.yml
+++ b/group_vars/approvals/approvals_staging.yml
@@ -1,6 +1,8 @@
 ---
 passenger_server_name: "approvals-staging1.princeton.edu"
 passenger_app_env: "staging"
+passenger_ruby: "/usr/bin/ruby2.7"
+ruby_version_override: "ruby2.7"
 postgres_host: '{{ vault_postgres_host }}'
 postgres_version: 13
 postgres_is_local: false
@@ -22,6 +24,5 @@ running_on_server: true
 install_mailcatcher: true
 mailcatcher_user: 'pulsys'
 mailcatcher_group: 'pulsys'
-ruby_version_override: "ruby2.6"
 bundler_version: '2.1.4'
-desired_nodejs_version: "v10.24.1"
+desired_nodejs_version: "v12.22.5"


### PR DESCRIPTION
closes #2831 
closes #2832

I ran this on approvals staging and it upgraded node to v12.22.5 and ruby version to 2.7.5