### PR TITLE
[Approvals] move datadog role below approvals 

### DIFF
--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -10,9 +10,8 @@
     - ../group_vars/approvals/vault.yml
 
   roles:
-    - role: datadog
-      when: runtime_env == "prod"
     - role: roles/approvals
+    - {role: datadog, when: runtime_env == "prod"}
 
   post_tasks:
     - name: restart nginx


### PR DESCRIPTION
When I ran the approvals playbook in production it failed because of #2082.

I followed @carolyncole solution in https://github.com/pulibrary/princeton_ansible/commit/f7cfd34f6b9dd0b69991f936870764b55d9aeca3 and moved datadog role below the approvals role to avoid issue #2082 