### PR TITLE
updates bibdata and orangelight postgres vars for migrated env

### DIFF
--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -1,6 +1,11 @@
 ---
-postgres_host: "lib-postgres3.princeton.edu"
-postgres_version: 10
+postgres_host: "lib-postgres-staging3.princeton.edu"
+postgres_version: 13
+pg_hba_contype: "host"
+pg_hba_postgresql_user: "all"
+pg_hba_postgresql_database: "all"
+pg_hba_method: "md5"
+pg_hba_source: "{{ ansible_host }}/32"
 passenger_server_name: "bibdata-alma-staging.*"
 passenger_app_root: "/opt/marc_liberation/current/public"
 passenger_app_env: "production"
@@ -127,10 +132,11 @@ bibdata_samba_source_host: 'bibdata-alma-worker-staging1.princeton.edu'
 application_dbuser_name: "bibdata"
 application_db_name: "{{ bibdata_db }}"
 application_dbuser_password: "{{ bibdata_db_password }}"
-application_dbuser_role_attr_flags: "SUPERUSER,INHERIT,NOCREATEDB,NOCREATEROLE,NOREPLICATION"
+application_dbuser_role_attr_flags: "CREATEDB"
 db_clusteradmin_password: "{{ vault_postgres_admin_password }}"
-db_clusteradmin_user: "postgresadmin"
+db_clusteradmin_user: "postgres"
 
+# we might be able to delete these . . . ?
 postgres_port: "{{ bibdata_db_port }}"
 postgres_admin_user: "{{ db_clusteradmin_user }}"
 postgres_admin_password: "{{ db_clusteradmin_password }}"

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -13,9 +13,14 @@ rails_app_dependencies:
   - autoconf
 bundler_version: "2.1.4"
 postgresql_is_local: false
-postgres_host: "lib-postgres-staging1.princeton.edu"
+postgres_host: "lib-postgres-staging3.princeton.edu"
 postgres_version: 13
 postgres_admin_user: "postgres"
+pg_hba_contype: "host"
+pg_hba_postgresql_user: "all"
+pg_hba_postgresql_database: "all"
+pg_hba_method: "md5"
+pg_hba_source: "{{ ansible_host }}/32"
 ol_db_host: "{{ postgres_host }}"
 ol_db_name: "{{ vault_ol_qa_db_name }}"
 ol_db_user: "{{ vault_ol_qa_db_user}}"
@@ -41,7 +46,7 @@ rails_app_env: "alma_qa"
 application_db_name: "{{ ol_db_name }}"
 application_dbuser_name: "{{ ol_db_user }}"
 application_dbuser_password: "{{ ol_db_password }}"
-application_dbuser_role_attr_flags: "SUPERUSER"
+application_dbuser_role_attr_flags: "CREATEDB"
 ol_host_name: "catalog-alma-qa.princeton.edu"
 application_host_protocol: "https"
 ol_alma_qa_solr_url: http://lib-solr8-staging.princeton.edu:8983/solr/catalog-qa

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -14,9 +14,14 @@ rails_app_dependencies:
 bundler_version: "2.1.4"
 desired_nodejs_version: 'v12.22.8'
 postgresql_is_local: false
-postgres_host: "lib-postgres-staging1.princeton.edu"
+postgres_host: "lib-postgres-staging3.princeton.edu"
 postgres_version: 13
 postgres_admin_user: "postgres"
+pg_hba_contype: "host"
+pg_hba_postgresql_user: "all"
+pg_hba_postgresql_database: "all"
+pg_hba_method: "md5"
+pg_hba_source: "{{ ansible_host }}/32"
 ol_db_host: "{{ postgres_host }}"
 ol_db_name: "{{ vault_ol_staging_db_name }}"
 ol_db_user: "{{ vault_ol_staging_db_user}}"
@@ -42,7 +47,7 @@ rails_app_env: "staging"
 application_db_name: "{{ ol_db_name }}"
 application_dbuser_name: "{{ ol_db_user }}"
 application_dbuser_password: "{{ ol_db_password }}"
-application_dbuser_role_attr_flags: "SUPERUSER"
+application_dbuser_role_attr_flags: "CREATEDB"
 ol_host_name: "catalog-staging.princeton.edu"
 application_host_protocol: "https"
 ol_staging_solr_url: http://lib-solr8-staging.princeton.edu:8983/solr/catalog-staging


### PR DESCRIPTION
The staging and QA environments for bibdata and orangelight were migrated to our fresh, new postgresql infrastructure today. This PR updates the group variables so any future playbook runs will keep the correct configuration. 

Co-authored-by: Francis Kayiwa <kayiwa@pobox.com>