### PR TITLE
updates production vars for bibdata and orangelight

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -1,7 +1,12 @@
 ---
 timezone: "America/New_York"
-postgres_host: "lib-postgres-prod1.princeton.edu"
+postgres_host: "lib-postgres-prod3.princeton.edu"
 postgres_version: 13
+pg_hba_contype: "host"
+pg_hba_postgresql_user: "all"
+pg_hba_postgresql_database: "all"
+pg_hba_method: "md5"
+pg_hba_source: "{{ ansible_host }}/32"
 passenger_server_name: "bibdata-alma.*"
 passenger_app_root: "/opt/marc_liberation/current/public"
 passenger_app_env: "production"
@@ -128,10 +133,11 @@ bibdata_db_port: 5432
 application_dbuser_name: "bibdata"
 application_db_name: "{{ bibdata_db }}"
 application_dbuser_password: "{{ bibdata_db_password }}"
-application_dbuser_role_attr_flags: "SUPERUSER,INHERIT,NOCREATEDB,NOCREATEROLE,NOREPLICATION"
+application_dbuser_role_attr_flags: "CREATEDB"
 db_clusteradmin_password: "{{ vault_postgres_admin_password }}"
 db_clusteradmin_user: "postgres"
 
+# we might be able to get rid of these . . . ?
 postgres_port: "{{ bibdata_db_port }}"
 postgres_admin_user: "{{ db_clusteradmin_user }}"
 postgres_admin_password: "{{ db_clusteradmin_password }}"

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -19,6 +19,7 @@ postgres_host: "lib-postgres-prod3.princeton.edu"
 postgres_admin_user: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_version: 13
+postgres_port: "5432"
 pg_hba_contype: "host"
 pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -15,10 +15,15 @@ rails_app_dependencies:
 bundler_version: "2.1.4"
 desired_nodejs_version: 'v12.22.8'
 postgresql_is_local: false
-postgres_host: "lib-postgres-prod1.princeton.edu"
+postgres_host: "lib-postgres-prod3.princeton.edu"
 postgres_admin_user: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_version: 13
+pg_hba_contype: "host"
+pg_hba_postgresql_user: "all"
+pg_hba_postgresql_database: "all"
+pg_hba_method: "md5"
+pg_hba_source: "{{ ansible_host }}/32"
 ol_db_host: '{{ postgres_host }}'
 ol_db_name: '{{ vault_ol_db_name }}'
 ol_db_user: '{{ vault_ol_db_user }}'
@@ -43,7 +48,7 @@ rails_app_env: "production"
 application_db_name: "{{ ol_db_name }}"
 application_dbuser_name: "{{ ol_db_user }}"
 application_dbuser_password: "{{ ol_db_password }}"
-application_dbuser_role_attr_flags: "SUPERUSER"
+application_dbuser_role_attr_flags: "CREATEDB"
 ol_host_name: "catalog.princeton.edu"
 application_host_protocol: "https"
 ol_smtp_host: "lib-ponyexpr.princeton.edu"

--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -22,31 +22,29 @@ postgresql_users:
     db: "replicant"
     priv: "ALL"
     role_attr_flags: "SUPERUSER"
-postgresql_hba_entries:
-  - type: local
-    database: all
-    user: postgres
-    method: ident
-  - type: host
-    database: all
-    user: postgres
-    address: 127.0.0.1/32
-    method: ident
-  - type: host
-    database: all
-    user: postgres
-    address: 127.0.0.1/32
-    method: md5
-  - type: host
-    database: all
-    user: all
-    address: 128.112.200.0/21
-    method: md5
-postgres_leader: "lib-postgres-prod1"
-postgres_standby: "lib-postgres-prod2"
+postgres_leader: "{{ leader_db_ip }}"
+postgres_standby: "{{ standby_db_ip }}"
 postgresql_is_local: true
-postgresadmin: postgres
+postgresadmin: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
-postgres_admin_user: '{{ vault_postgres_admin_user }}'
 replication_user: "replicant"
 replication_database: "replicant"
+postgres_host: "{{ leader_db_ip }}"
+postgres_port: 5432
+postgres_admin_user: "{{ postgresadmin }}"
+
+datadog_api_key: "{{ vault_datadog_key }}"
+datadog_service_name: postgresql
+datadog_environment: prod
+datadog_config:
+  log_enabled: true
+  process_enabled: true
+datadog_typed_checks:
+  init_config:
+  logs:
+    - type: file
+      path: /var/lib/postgresql/{{ postgresql_version }}/main/pg_log/*.csv
+      service: database
+      source: postgresql
+      sourcecategory: postgresql_logs
+      tags: "postgresql, env:prod, role:postgresql"

--- a/host_vars/lib-postgres-prod2.princeton.edu.yml
+++ b/host_vars/lib-postgres-prod2.princeton.edu.yml
@@ -1,0 +1,8 @@
+---
+pg_enabled: false
+node_identifier: 2
+repmgr_master: false
+standby_db_host: lib-postgres-prod2.princeton.edu
+leader_db_host: lib-postgres-prod3.princeton.edu
+leader_db_ip: 128.112.204.69
+standby_db_ip: 128.112.204.64

--- a/host_vars/lib-postgres-prod3.princeton.edu.yml
+++ b/host_vars/lib-postgres-prod3.princeton.edu.yml
@@ -1,0 +1,8 @@
+---
+pg_enabled: false
+node_identifier: 1
+repmgr_master: true
+standby_db_host: lib-postgres-prod2.princeton.edu
+leader_db_host: lib-postgres-prod3.princeton.edu
+leader_db_ip: 128.112.204.69
+standby_db_ip: 128.112.204.64

--- a/hosts
+++ b/hosts
@@ -217,6 +217,7 @@ lib-svn-prod1.princeton.edu
 [postgresql_production]
 lib-postgres-prod3.princeton.edu
 lib-postgres-prod2.princeton.edu
+lib-postgres-prod1.princeton.edu
 [postgresql_staging]
 lib-postgres-staging3.princeton.edu
 lib-postgres-staging2.princeton.edu

--- a/playbooks/orangelight_production.yml
+++ b/playbooks/orangelight_production.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: orangelight_prod
+- hosts: orangelight_production
   remote_user: pulsys
   become: true
   vars_files:

--- a/playbooks/postgresql_production.yml
+++ b/playbooks/postgresql_production.yml
@@ -1,14 +1,27 @@
 ---
-- hosts: postgresql_production
+- name: install a replication postgresql cluster
+  hosts: postgresql_production
   remote_user: pulsys
   become: true
   vars_files:
-    - ../group_vars/postgresql/production.yml
+    - ../group_vars/postgresql/staging.yml
+    - ../host_vars/lib-postgres-prod3.princeton.edu.yml
+    - ../host_vars/lib-postgres-prod2.princeton.edu.yml
     - ../group_vars/postgresql/vault.yml
   roles:
+    - role: ../roles/datadog
     - role: ../roles/postgresql
 
   post_tasks:
+    - name: Replace node identifier on "{{ leader_db_host }}"
+      ansible.builtin.lineinfile:
+        path: /etc/repmgr.conf
+        regexp: "node_id=2"
+        line: "node_id=1"
+        owner: root
+        group: root
+        mode: '0644'
+      delegate_to: "{{ leader_db_host }}"
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"

--- a/playbooks/postgresql_staging.yml
+++ b/playbooks/postgresql_staging.yml
@@ -11,6 +11,15 @@
     - role: ../roles/postgresql
 
   post_tasks:
+    - name: Replace node identifier on "{{ leader_db_host }}"
+      ansible.builtin.lineinfile:
+        path: /etc/repmgr.conf
+        regexp: "node_id=2"
+        line: "node_id=1"
+        owner: root
+        group: root
+        mode: '0644'
+      delegate_to: "{{ leader_db_host }}"
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"

--- a/roles/postgresql/tasks/repmgr.yml
+++ b/roles/postgresql/tasks/repmgr.yml
@@ -66,7 +66,7 @@
     src: replication.conf.j2
     dest: "{{ postgres_conf_directory }}/conf.d/replication.conf"
     mode: 0644
-  delegate_to: '{{ postgres_leader }}'
+  delegate_to: '{{ leader_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local
@@ -76,7 +76,7 @@
   command: psql -c 'alter user {{ replication_user }} set search_path TO {{ replication_user }}, "$user", public;'
   become: true
   become_user: postgres
-  delegate_to: '{{ postgres_leader }}'
+  delegate_to: '{{ leader_db_host }}'
   changed_when: false
   when:
     - postgresql_is_local
@@ -91,7 +91,7 @@
   notify:
     - save repmgr log
     - restart postgresql
-  delegate_to: '{{ postgres_leader }}'
+  delegate_to: '{{ leader_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local
@@ -102,7 +102,7 @@
   service:
     name: postgresql
     state: stopped
-  delegate_to: '{{ postgres_standby }}'
+  delegate_to: '{{ standby_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local
@@ -112,17 +112,17 @@
   file:
     path: "{{ postgres_data_directory }}/*"
     state: absent
-  delegate_to: '{{ postgres_standby }}'
+  delegate_to: '{{ standby_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local
     - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | cloning standby
-  command: repmgr -h {{ postgres_leader }} -U replicant -d replicant -f {{ repmgr_config }} standby clone -F
+  command: repmgr -h {{ leader_db_host }} -U replicant -d replicant -f {{ repmgr_config }} standby clone -F
   become: true
   become_user: postgres
-  delegate_to: '{{ postgres_standby }}'
+  delegate_to: '{{ standby_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local
@@ -132,7 +132,7 @@
   service:
     name: postgresql
     state: started
-  delegate_to: '{{ postgres_standby }}'
+  delegate_to: '{{ standby_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local
@@ -143,7 +143,7 @@
   register: repmgr_log
   become: true
   become_user: postgres
-  delegate_to: '{{ postgres_standby }}'
+  delegate_to: '{{ standby_db_host }}'
   when:
     - running_on_server
     - postgresql_is_local


### PR DESCRIPTION
We are migrating the production catalog to use our shiny, new postgresql replicated environment. This PR updates the variables for bibdata and orangelight to match the new settings.

Do not merge until after the migration is complete and the dust has settled.