### PR TITLE
upgrade ruby to 2.7.5

### DIFF
--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -26,7 +26,7 @@ application_dbuser_password: "{{ vault_oawaiver_prod_db_password }}"
 application_dbuser_role_attr_flags: 'SUPERUSER'
 
 # System Ruby
-ruby_version_override: "ruby2.6"
+ruby_version_override: "ruby2.7"
 bundler_version: "2.2.19"
 
 # System Node.js

--- a/group_vars/oawaiver/staging.yml
+++ b/group_vars/oawaiver/staging.yml
@@ -26,7 +26,7 @@ application_dbuser_password: "{{ vault_oawaiver_staging_db_password }}"
 application_dbuser_role_attr_flags: 'CREATEDB'
 
 # System Ruby
-ruby_version_override: "ruby2.6"
+ruby_version_override: "ruby2.7"
 bundler_version: "2.2.19"
 
 # System Node.js


### PR DESCRIPTION
this update oawaiver to ruby 2.7 
the tool versions on [oawaiver](https://github.com/pulibrary/oawaiver/blob/main/.tool-versions)
suggest that this has already happened.

if yes. It closes https://github.com/pulibrary/oawaiver/issues/56
