### PR TITLE
Redirect top level traffic to /discovery

### DIFF
--- a/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
@@ -37,6 +37,12 @@ server {
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 
+    # Redirect top level traffic to /discovery 
+    # until the top level has content.
+    location / {
+        return 302 https://$server_name/discovery/;
+    }
+
     location /discovery/ {
         proxy_pass http://pdc-discovery-prod/discovery/;
         proxy_set_header X-Forwarded-Host $host;

--- a/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
@@ -28,6 +28,12 @@ server {
     ssl_certificate_key        /etc/nginx/conf.d/ssl/private/pdc-discovery-staging_princeton_edu_priv.key;
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
+    
+    # Redirect top level traffic to /discovery 
+    # until the top level has content.
+    location / {
+        return 302 https://$server_name/discovery/;
+    }
 
     location /discovery/ {
         proxy_pass http://pdc-discovery-staging/discovery/;


### PR DESCRIPTION
Eventually, we want https://datacommons.princeton.edu
to be a separate application from
https://datacommons.princeton.edu/discovery. However, until that top
level content has been populated, send traffic to /discovery.

Fixes https://github.com/pulibrary/pdc_discovery/issues/232