### PR TITLE
Update load balancing strategy for the library website.

### DIFF
--- a/roles/nginxplus/files/conf/http/library-prod.conf
+++ b/roles/nginxplus/files/conf/http/library-prod.conf
@@ -5,7 +5,7 @@ limit_req_zone $binary_remote_addr zone=libweb_ip_rate_limit:10m rate=5r/s;
 
 upstream library-prod {
     zone library-prod 256k;
-    least_conn;
+    least_time last_byte inflight;
     server library-prod1.princeton.edu resolve;
     server library-prod3.princeton.edu resolve;
     server library-prod4.princeton.edu resolve;

--- a/roles/nginxplus/files/conf/http/library-staging.conf
+++ b/roles/nginxplus/files/conf/http/library-staging.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/library-staging/NGINX_cache/ keys_zone=library-stag
 
 upstream library-staging {
     zone library-staging 256k;
-    least_conn;
+    least_time last_byte inflight;
     server library-staging1.princeton.edu resolve;
     server library-staging2.princeton.edu resolve;
     sticky learn


### PR DESCRIPTION
Transfer traffic to whichever nodes are responding the fastest.

nginx documentation: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#least_time

Similar to https://github.com/pulibrary/princeton_ansible/issues/2790