### PR TITLE
Handle libimages at iiif.princeton.edu

### DIFF
--- a/roles/nginxplus/files/conf/http/libimages.conf
+++ b/roles/nginxplus/files/conf/http/libimages.conf
@@ -49,6 +49,7 @@ server {
 server {
     listen 443 ssl;
     server_name libimages1.princeton.edu;
+    server_name libimages.princeton.edu;
 
     ssl_certificate            /etc/nginx/conf.d/ssl/certs/libimages1_princeton_edu_chained.pem;
     ssl_certificate_key        /etc/nginx/conf.d/ssl/private/libimages1_princeton_edu_priv.key;
@@ -92,6 +93,14 @@ server {
         rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).jpg$" "/loris/$1%2F$2/$3/$4/$5/$6.jpg";
         rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).jpg$" "/loris/$1%2F$2/$3/$4/$5/$6.jpg";
         rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).jpg$" "/loris/$1%2F$2/$3/$4/$5/$6.jpg";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
+        rewrite "^/loris/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*)/([^\\\\]*).png$" "/loris/$1%2F$2/$3/$4/$5/$6.png";
         return 301 "https://iiif.princeton.edu$uri";
     }
     location / {
@@ -99,6 +108,7 @@ server {
         rewrite "^/loris/(.*)/(.*)/info.json$" "/fixinfo/$1/$2/info.json" last;
         rewrite "^/loris/(.*)/(.*).jp2$" "/fixnoinforedirect/$1/$2.jp2" last;
         rewrite "^/loris/(.*)/(.*)/(.*)/(.*)/(.*)/(.*).jpg$" "/fixrequest/$1/$2/$3/$4/$5/$6.jpg" last;
+        rewrite "^/loris/(.*)/(.*)/(.*)/(.*)/(.*)/(.*).png$" "/fixrequest/$1/$2/$3/$4/$5/$6.png" last;
         return 301 "https://iiif.princeton.edu$uri";
     }
 }


### PR DESCRIPTION
Refs #2619 and pulibrary/figgy#5022

I don't think we need a new certificate - I downloaded the cert info and it looks like @kayiwa was clever and added both `libimages` and `libimages1` to the same cert:

```
X509v3 Subject Alternative Name:
                DNS:libimages.princeton.edu, DNS:libimages1.princeton.edu
```