### PR TITLE
make all converge playbooks include running_on_server

### DIFF
--- a/roles/php/molecule/default/converge.yml
+++ b/roles/php/molecule/default/converge.yml
@@ -1,6 +1,8 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    - running_on_server: false
   tasks:
     - name: "Include roles/php"
       include_role:

--- a/roles/rvm/molecule/default/converge.yml
+++ b/roles/rvm/molecule/default/converge.yml
@@ -1,6 +1,8 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    - running_on_server: false
   tasks:
     - name: "Include roles/rvm"
       include_role:


### PR DESCRIPTION
We were seeing failures on tests in the `common` role when called by molecule from `rvm` and `php` roles. The error was:
```
"The conditional check 'running_on_server' failed. The error was: error while evaluating conditional (running_on_server): 'running_on_server' is undefined
```
Which was strange, because the `converge.yml` playbook for the `common` role clearly set `running_on_server: false`. 

It looks like Molecule only loads vars from the converge playbook of the role that kicks off a test run, not from any dependent roles. So it wasn't the `common` role that was causing the problem. This should fix the issue globally. 