### PR TITLE
removes workaround for obsolete apt issue

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: Remove specified repository from sources list
-  ansible.builtin.apt_repository:
-    repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
-    state: absent
-  register: phusion_repo
-  changed_when: false
-  failed_when:
-    - phusion_repo is failed
-
 - name: common | update cache
   apt:
     update_cache: true


### PR DESCRIPTION
The task being removed here is causing idempotency failures on a bunch of roles.

The original problem was an apt repo that disappeared. The original workaround was added as part of #2499. I'm hoping that the broken repo has now been removed from our machines and we can delete the workaround task.