### PR TITLE
Ruby role checks ruby version before installing

### DIFF
--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -9,22 +9,18 @@
   apt_repository:
     repo: "ppa:brightbox/ruby-ng"
     state: present
-  ignore_errors: true
+    update_cache: true
 
 - name: check ruby version
   command: ruby -v
   register: installed_ruby
-  ignore_errors: True
-
-- name: print ruby version
-  debug:
-    var: installed_ruby
+  ignore_errors: true
+  changed_when: false
 
 - name: install Ruby "{{ ruby_version }}"
   apt:
     name: ["{{ ruby_version }}", "{{ ruby_version }}-dev", "ruby-switch"]
     state: present
-    update_cache: true
   when: installed_ruby.rc !=0 or installed_ruby.stdout.split()[1] != ruby_version
   register: packages_installed
 

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -11,15 +11,26 @@
     state: present
   ignore_errors: true
 
+- name: check ruby version
+  command: ruby -v
+  register: installed_ruby
+  ignore_errors: True
+
+- name: print ruby version
+  debug:
+    var: installed_ruby
+
 - name: install Ruby "{{ ruby_version }}"
   apt:
     name: ["{{ ruby_version }}", "{{ ruby_version }}-dev", "ruby-switch"]
     state: present
     update_cache: true
+  when: installed_ruby.rc !=0 or installed_ruby.stdout.split()[1] != ruby_version
   register: packages_installed
 
 - name: switch to Ruby "{{ ruby_version }}" release for the system default
   command: ruby-switch --set "{{ ruby_version }}"
+  when: installed_ruby.rc !=0 or installed_ruby.stdout.split()[1] != ruby_version
   changed_when: false
 
 - name: uninstall bundler to get specific version


### PR DESCRIPTION
Closes #2276.

I tested this by:
- installing Ruby 2.7 using the ruby role
- running the role again with `ruby_version` set to `ruby2.6`
- SSH'ing to the box before, between, and after the two playbook runs
