### PR TITLE
use 'figgy_solr_name' and 'solr_port' to set production Solr URL

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -28,7 +28,8 @@ figgy_ezid_password: '{{vault_figgy_ezid_password}}'
 rabbitmq_user: '{{figgy_rabbit_user}}'
 rabbitmq_password: '{{figgy_rabbit_password}}'
 rails_app_env: "production"
-figgy_solr_name: figgy-staging
+figgy_solr_name: figgy-production
+solr_port: "8983"
 figgy_host_name: 'figgy.princeton.edu'
 figgy_honeybadger_key: '{{vault_figgy_honeybadger_key}}'
 application_db_name: '{{figgy_db_name}}'
@@ -41,7 +42,7 @@ application_host: '{{passenger_server_name}}'
 application_host_protocol: 'https'
 project_db_host: '{{postgres_host}}'
 redis_bind_interface: '0.0.0.0'
-figgy_solr_url: 'http://lib-solr8-prod.princeton.edu:8983/solr/figgy-production'
+figgy_solr_url: 'http://lib-solr8-prod.princeton.edu:{{solr_port}}/solr/{{figgy_solr_name}}'
 rails_app_vars:
   - name: SECRET_KEY_BASE
     value: '{{vault_figgy_secret_key}}'


### PR DESCRIPTION
Closes #182.

Updates the production group_vars for figgy to match the staging group_vars for figgy. Sets `SOLR_URL` from the variables `figgy_solr_name` and `solr_port` in production. 

This should not change behavior/outcomes. It just makes the two environments harmonize. 