### PR TITLE
clean up .gitignore, allow use of direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,11 @@
-# Vagrant related files
-/.vagrant
-*.retry
 # hide keys
 pulsys_rsa_key*
-# images are too large
-ubuntu-16.04.virtualbox.box
 # vault merging
 .ansible-vault-password
-# Ignore Vagrant file 
-Vagrantfile
-images/*
 # keep gz and sql files from accidental commit
 *.gz
 *.sql
+# for use with direnv
+.envrc
+# macOS cooties
+.DS_Store

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 python 3.9.0
 ruby 2.6.5
+direnv 2.30.3


### PR DESCRIPTION
I rely heavily on [direnv](https://direnv.net/) to de-clutter my
profile. Furthermore it has an [asdf-plugin](https://github.com/asdf-community/asdf-direnv) that -thus far- feels faster than the `asdf-shims`
Also removes vagrant references