### PR TITLE
Postgresql fixes

### DIFF
--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -72,8 +72,10 @@ postgres_data_directory: "/var/lib/postgresql/{{ postgres_version }}/{{ postgres
 
 # HBA Connections
 postgres_hba_entries: []
-pg_hba_postgresql_user: "all" # "{{ application_dbuser_name }}"
-pg_hba_postgresql_database: "all" # "{{ application_db_name }}"
+pg_hba_postgresql_user: "all"
+pg_hba_postgresql_database: "all"
+# test if we can use "{{ application_dbuser_name }}" and "{{ application_db_name }}"
+# and the user can still create a database
 pg_hba_method: "md5"
 pg_hba_source: "host"
 repmgr_config: "/etc/repmgr.conf"

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -72,8 +72,8 @@ postgres_data_directory: "/var/lib/postgresql/{{ postgres_version }}/{{ postgres
 
 # HBA Connections
 postgres_hba_entries: []
-pg_hba_postgresql_user: "{{ application_dbuser_name }}"
-pg_hba_postgresql_database: "{{ application_db_name }}"
+pg_hba_postgresql_user: "all" # "{{ application_dbuser_name }}"
+pg_hba_postgresql_database: "all" # "{{ application_db_name }}"
 pg_hba_method: "md5"
 pg_hba_source: "host"
 repmgr_config: "/etc/repmgr.conf"

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -72,8 +72,8 @@ postgres_data_directory: "/var/lib/postgresql/{{ postgres_version }}/{{ postgres
 
 # HBA Connections
 postgres_hba_entries: []
-pg_hba_postgresql_user: "pguser"
-pg_hba_postgresql_database: "dbname"
+pg_hba_postgresql_user: "{{ application_dbuser_name }}"
+pg_hba_postgresql_database: "{{ application_db_name }}"
 pg_hba_method: "md5"
 pg_hba_source: "host"
 repmgr_config: "/etc/repmgr.conf"

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -40,7 +40,7 @@ replication_user: []
 replication_database: []
 replication_user_password: "changethis"
 db_clusteradmin_password: "changethis"
-postgres_admin_user_password: "change"
+postgres_admin_password: "change"
 sudoers_dir: "/etc/sudoers.d"
 postgres_locale_parts:
   - "en_US"  # Locale

--- a/roles/postgresql/tasks/create_db.yml
+++ b/roles/postgresql/tasks/create_db.yml
@@ -11,7 +11,7 @@
   when:
     - running_on_server
     - not postgresql_is_local
-  changed_when: false
+  run_once: true
 
 - name: PostgreSQL | create postgresql server database
   postgresql_db:


### PR DESCRIPTION
Closes #2815.

- Sets the task that creates databases to `run_once`.
- Corrects the name of the psql admin password var.
- Tried re-using `application_db_*` variables for the `pg_hba` configuration task, but ultimately gave database connections access to `all` in `pg_hba.conf` so they can create databases - this helped #2871 work but we may be able to change it in future - added a comment for Future Us.  