### PR TITLE
Remove pdc-describe-staging2 from rotation

### DIFF
--- a/roles/nginxplus/files/conf/http/pdc-describe_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_staging.conf
@@ -4,7 +4,10 @@ proxy_cache_path /data/nginx/pdc-describe-staging/NGINX_cache/ keys_zone=pdc-des
 upstream pdc-describe-staging {
     zone pdc-describe-staging 64k;
     server pdc-describe-staging1.princeton.edu resolve;
-    server pdc-describe-staging2.princeton.edu resolve;
+    
+#    Remove staging2 from rotation so we can use it to test upgrade to ruby 3    
+#    server pdc-describe-staging2.princeton.edu resolve;
+
     sticky learn
           create=$upstream_cookie_pdcdescribestagingcookie
           lookup=$cookie_pdcdescribestagingcookie


### PR DESCRIPTION
Remove it from load balancer rotation so we can use it to test a ruby 3.0 upgrade