### PR TITLE
allow approvals playbook to run

### DIFF
--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -11,7 +11,8 @@
 
   roles:
     - role: roles/approvals
-    - {role: datadog, when: runtime_env == "prod"}
+    - role: datadog
+      when: runtime_env | default('staging') == "prod"
 
   post_tasks:
     - name: restart nginx


### PR DESCRIPTION
fixes
```
fatal: [lib-approvals-staging1.princeton.edu]: FAILED! => {"msg": "The conditional check 'runtime_env == \"prod\"' failed. The error was: error while evaluating conditional (runtime_env == \"prod\"): 'runtime_env' is undefined\n\nThe error appears to be in '/Users/colec/projects/princeton_ansible/roles/datadog/tasks/pkg-debian.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Install apt-transport-https\n  ^ here\n"}
```