### PR TITLE
Includes ansible play name in slack alerts, uses FQCN for slack module

### DIFF
--- a/playbooks/abid.yml
+++ b/playbooks/abid.yml
@@ -17,5 +17,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/abid.yml
+++ b/playbooks/abid.yml
@@ -15,7 +15,7 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/annotations.yml
+++ b/playbooks/annotations.yml
@@ -14,7 +14,7 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/annotations.yml
+++ b/playbooks/annotations.yml
@@ -16,5 +16,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/ansible_tower.yml
+++ b/playbooks/ansible_tower.yml
@@ -11,5 +11,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/ansible_tower.yml
+++ b/playbooks/ansible_tower.yml
@@ -9,7 +9,7 @@
     - role: roles/postgresql
 
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/appdeploy_production.yml
+++ b/playbooks/appdeploy_production.yml
@@ -12,6 +12,6 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts
       delegate_to: localhost

--- a/playbooks/appdeploy_production.yml
+++ b/playbooks/appdeploy_production.yml
@@ -14,4 +14,3 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts
-      delegate_to: localhost

--- a/playbooks/appdeploy_production.yml
+++ b/playbooks/appdeploy_production.yml
@@ -10,7 +10,7 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -21,7 +21,7 @@
         state: restarted
 
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -23,5 +23,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -22,5 +22,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "Ansible ran {{ ansible_play_name }} on {{ inventory_hostname }}"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -20,7 +20,7 @@
       when: runtime_env | default('staging') == "production"
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/deploy_user.yml
+++ b/playbooks/deploy_user.yml
@@ -6,7 +6,7 @@
     - role: deploy_user
   post_tasks:
   - name: tell everyone on slack you ran an ansible playbook
-    slack:
+    community.general.slack:
       token: "{{ vault_pul_slack_token }}"
-      msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
       channel: #server-alerts

--- a/playbooks/lae.yml
+++ b/playbooks/lae.yml
@@ -14,9 +14,9 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts
       delegate_to: localhost
       when: not ansible_check_mode

--- a/playbooks/remove_user.yml
+++ b/playbooks/remove_user.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: remove user authorized_keys
+  hosts: all
   remote_user: pulsys
   become: true
   pre_tasks:
@@ -13,7 +14,7 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/researchdata.yml
+++ b/playbooks/researchdata.yml
@@ -17,7 +17,7 @@
         name: nginx
         state: restarted
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}
         channel: #server-alerts

--- a/playbooks/ruby_office.yml
+++ b/playbooks/ruby_office.yml
@@ -1,12 +1,13 @@
 ---
-- hosts: ruby_office
+- name: run the rubyoffice role
+  hosts: ruby_office
   remote_user: pulsys
   become: true
   roles:
     - role: rubyoffice
   post_tasks:
   - name: tell everyone on slack you ran an ansible playbook
-    slack:
+    community.general.slack:
       token: "{{ vault_pul_slack_token }}"
-      msg: "{{ inventory_hostname }} completed"
+      msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
       channel: #server-alerts

--- a/playbooks/studio_processors.yml
+++ b/playbooks/studio_processors.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: studio_processors
+- name: add deploy users to studio processing machines
+  hosts: studio_processors
   remote_user: pulsys
   become: true
   vars_files:
@@ -12,7 +13,7 @@
     - role: roles/deploy_user
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/upgrade_apache.yml
+++ b/playbooks/upgrade_apache.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: apache_servers
+- name: upgrade apache version
+  hosts: apache_servers
   remote_user: pulsys
   become: true
 
@@ -19,7 +20,7 @@
         state: restarted
 
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "apache upgrade and restart complete on {{ inventory_hostname }}"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/playbooks/zookeeper.yml
+++ b/playbooks/zookeeper.yml
@@ -21,7 +21,7 @@
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       when: runtime_env == production
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: Ansible ran {{ ansible_play_name }}successfully on {{ inventory_hostname }}
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts


### PR DESCRIPTION
Partial fix for #2852.

Starts updating playbooks to mention the play name when they send an alert to slack.
Uses `community.general.slack` in the slack task.
Updates playbooks starting with `a` and `b` and playbooks that have already been consolidated (see #2726).