### PR TITLE
tidies up repomgr tasks

### DIFF
--- a/roles/postgresql/tasks/repmgr.yml
+++ b/roles/postgresql/tasks/repmgr.yml
@@ -59,7 +59,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - pgpass_stat.exists
+    - pgpass_stat.stat.exists
 
 - name: PostgreSQL | add replication postgresql configuration
   ansible.builtin.template:

--- a/roles/postgresql/tasks/repmgr.yml
+++ b/roles/postgresql/tasks/repmgr.yml
@@ -81,7 +81,6 @@
   when:
     - postgresql_is_local
     - running_on_server
-    # - inventory_hostname in groups["gcp_postgresql_leader"]
 
 - name: PostgreSQL | register leader
   ansible.builtin.command: repmgr -f {{ repmgr_config }} primary register --force -S postgres
@@ -95,7 +94,6 @@
   when:
     - running_on_server
     - postgresql_is_local
-    # - inventory_hostname in groups["gcp_postgresql_leader"]
   ignore_errors: true
 
 - name: PostsgreSQL | stop postgres on standby
@@ -106,7 +104,6 @@
   when:
     - running_on_server
     - postgresql_is_local
-    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | remove pg data
   ansible.builtin.file:
@@ -116,7 +113,6 @@
   when:
     - running_on_server
     - postgresql_is_local
-    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | cloning standby
   ansible.builtin.command: repmgr -h {{ leader_db_host }} -U replicant -d replicant -f {{ repmgr_config }} standby clone -F
@@ -126,7 +122,6 @@
   when:
     - running_on_server
     - postgresql_is_local
-    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | start postgres
   ansible.builtin.service:
@@ -136,7 +131,6 @@
   when:
     - running_on_server
     - postgresql_is_local
-    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | register standby
   ansible.builtin.command: repmgr -f {{ repmgr_config }} standby register --force
@@ -147,7 +141,6 @@
   when:
     - running_on_server
     - postgresql_is_local
-    # - inventory_hostname in groups["gcp_postgresql_standby"]
   notify:
     - save repmgr log
     - restart postgresql

--- a/roles/postgresql/tasks/repmgr.yml
+++ b/roles/postgresql/tasks/repmgr.yml
@@ -58,8 +58,8 @@
   changed_when: false
   when:
     - running_on_server
-    - pgpass_stat.stat.exists
     - postgresql_is_local
+    - pgpass_stat.exists
 
 - name: PostgreSQL | add replication postgresql configuration
   ansible.builtin.template:
@@ -81,7 +81,7 @@
   when:
     - postgresql_is_local
     - running_on_server
-    - inventory_hostname in groups["gcp_postgresql_leader"]
+    # - inventory_hostname in groups["gcp_postgresql_leader"]
 
 - name: PostgreSQL | register leader
   ansible.builtin.command: repmgr -f {{ repmgr_config }} primary register --force -S postgres
@@ -95,7 +95,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - inventory_hostname in groups["gcp_postgresql_leader"]
+    # - inventory_hostname in groups["gcp_postgresql_leader"]
   ignore_errors: true
 
 - name: PostsgreSQL | stop postgres on standby
@@ -106,7 +106,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - inventory_hostname in groups["gcp_postgresql_standby"]
+    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | remove pg data
   ansible.builtin.file:
@@ -116,7 +116,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - inventory_hostname in groups["gcp_postgresql_standby"]
+    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | cloning standby
   ansible.builtin.command: repmgr -h {{ leader_db_host }} -U replicant -d replicant -f {{ repmgr_config }} standby clone -F
@@ -126,7 +126,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - inventory_hostname in groups["gcp_postgresql_standby"]
+    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | start postgres
   ansible.builtin.service:
@@ -136,7 +136,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - inventory_hostname in groups["gcp_postgresql_standby"]
+    # - inventory_hostname in groups["gcp_postgresql_standby"]
 
 - name: PostgreSQL | register standby
   ansible.builtin.command: repmgr -f {{ repmgr_config }} standby register --force
@@ -147,7 +147,7 @@
   when:
     - running_on_server
     - postgresql_is_local
-    - inventory_hostname in groups["gcp_postgresql_standby"]
+    # - inventory_hostname in groups["gcp_postgresql_standby"]
   notify:
     - save repmgr log
     - restart postgresql


### PR DESCRIPTION
Closes #2943.
Closes #2945.

For 2943:
If the task that generates that variable is skipped, Ansible cannot evaluate the conditions on the next task.
The fix was to change the order of the conditions so that when `postgresql_is_local` is true, the task is skipped without evaluating the contents of `pgpass_stat`.

For 2945:
This was left over from testing on google cloud. 
