### PR TITLE
Set no_log on postgresql tasks with sensitive data

### DIFF
--- a/roles/postgresql/tasks/create_users.yml
+++ b/roles/postgresql/tasks/create_users.yml
@@ -34,6 +34,7 @@
   become: true
   become_user: "{{ postgres_admin_user }}"
   loop: "{{ postgresql_users }}"
+  no_log: true
 
 - name: PostgreSQL | change postgresql database owner
   community.general.postgresql_db:


### PR DESCRIPTION
One task in the postgresql role uses the `postgres` and `replicant` users, printing out their passwords in the output. Currently anyone who can run that role can also access those passwords, but as we move to Tower/the Platform, that will not necessarily be true.

This PR sets `no_log: true` on that task.