### PR TITLE
Revise indexcards redirect with request uri

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
@@ -65,7 +65,7 @@ server {
         health_check interval=10 fails=3 passes=2;
     }
     location /indexcards {
-        return 301 https://genizaprojects.princeton.edu/$request_uri;
+        return 301 https://genizaprojects.princeton.edu$request_uri;
     }
     location /jtsviewer {
         proxy_pass https://genizaprojects.princeton.edu/jtsviewer;

--- a/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
@@ -65,7 +65,7 @@ server {
         health_check interval=10 fails=3 passes=2;
     }
     location /indexcards {
-        return 301 https://genizaprojects.princeton.edu/indexcards$request_uri;
+        return 301 https://genizaprojects.princeton.edu/$request_uri;
     }
     location /jtsviewer {
         proxy_pass https://genizaprojects.princeton.edu/jtsviewer;


### PR DESCRIPTION
small tweak to the indexcards redirect — I think based on how it's behaving that `$request_uri` includes the `/indexcards` portion of the url, since right now it's getting doubled  on the redirect