### PR TITLE
change second play name for nginx playbook

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -13,7 +13,7 @@
   roles:
     - role: ../roles/nginxplus
 
-- name: restart nginx and announce success
+- name: restart nginx with updated loadbalancer configuration
   hosts: nginxplus
   remote_user: pulsys
   strategy: linear


### PR DESCRIPTION
Follow up on #2954.

Related to #2852.

With better Slack alerting, the name of the last play gets reported. This PR updates the name of the last play in the nginx playbook to make it more user-friendly and communicative. 