### PR TITLE
Adds a playbook for SSL cert renewals

### DIFF
--- a/playbooks/cert_renewal.yml
+++ b/playbooks/cert_renewal.yml
@@ -6,8 +6,6 @@
 # for example: '-e cert_path=/home/foo/ssl_certs/'
 - name: Generate a new cert and key
   hosts: localhost
-  vars:
-    cert_path: ~/.ssl/
   tasks:
   - name: Generate a new private key
     openssl_privatekey:

--- a/playbooks/cert_renewal.yml
+++ b/playbooks/cert_renewal.yml
@@ -3,7 +3,8 @@
 # pass the first element of the FQDN as '-e host_name=value'
 # for example: '-e host_name=fun' would generate a cert for fun.princeton.edu
 # also pass the path of the directory where you want the key and cert to live
-# for example: '-e cert_path=/home/foo/ssl_certs/'
+# with no trailing slash
+# for example: '-e cert_path=/home/foo/ssl_certs'
 - name: Generate a new cert and key
   hosts: localhost
   tasks:

--- a/playbooks/cert_renewal.yml
+++ b/playbooks/cert_renewal.yml
@@ -1,0 +1,32 @@
+---
+# you must pass two variables:
+# pass the first element of the FQDN as '-e host_name=value'
+# for example: '-e host_name=fun' would generate a cert for fun.princeton.edu
+# also pass the path of the directory where you want the key and cert to live
+# for example: '-e cert_path=/home/foo/ssl_certs/'
+- name: Generate a new cert and key
+  hosts: localhost
+  vars:
+    cert_path: ~/.ssl/
+  tasks:
+  - name: Generate a new private key
+    openssl_privatekey:
+      path: "{{ cert_path }}/{{ host_name }}_princeton_edu_priv.key"
+      size: 2048
+      type: RSA
+    register: new_key
+
+  - name: Generate CSR
+    community.crypto.openssl_csr:
+      path: "{{ cert_path }}/{{ host_name }}_princeton_edu.csr"
+      privatekey_path: "{{ new_key.filename }}"
+      common_name: "{{ host_name }}.princeton.edu"
+      country_name: US
+      state_or_province_name: "New Jersey"
+      locality_name: Princeton
+      email_address: lsupport@princeton.edu
+      organization_name: "The Trustees of Princeton University"
+      organizational_unit_name: OIT
+
+# Do we need this bit of config?
+# default_bits = 2048


### PR DESCRIPTION
This playbook automates the first step (Create the Certificate Signing Request) of https://github.com/pulibrary/pul-the-hard-way/blob/main/services/create_ssl_certs.md. 