### PR TITLE
Remove bibdata-worker2, update bibdata task to run only on worker boxes

### DIFF
--- a/hosts
+++ b/hosts
@@ -14,8 +14,6 @@ cicognara-staging1.princeton.edu
 [cicognara_production]
 cicognara1.princeton.edu
 cicognara2.princeton.edu
-[bibdata_workers]
-bibdata-worker2.princeton.edu
 [pulmap_production]
 maps1.princeton.edu
 maps2.princeton.edu

--- a/roles/bibdata/.yamllint
+++ b/roles/bibdata/.yamllint
@@ -8,5 +8,6 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
+  empty-lines: disable
   line-length: disable
   truthy: disable

--- a/roles/bibdata/tasks/main.yml
+++ b/roles/bibdata/tasks/main.yml
@@ -7,3 +7,5 @@
 - include_tasks: mounts.yml
 
 - include_tasks: redis_overcommit_memory.yml
+  when: "'worker' in inventory_hostname"
+

--- a/roles/bibdata/tasks/main.yml
+++ b/roles/bibdata/tasks/main.yml
@@ -4,8 +4,10 @@
     name: ["cifs-utils", "python3-psycopg2"]
     state: present
 
-- include_tasks: mounts.yml
+- name: include tasks to mount disks
+  include_tasks: mounts.yml
 
-- include_tasks: redis_overcommit_memory.yml
+- name: include tasks to set redis config for workers
+  include_tasks: redis_overcommit_memory.yml
   when: "'worker' in inventory_hostname"
 


### PR DESCRIPTION
Closes #2965.

Removes the `bibdata_workers` group and the obsolete `bibdata-worker2` VM from the hosts file.

A check for references to the `bibdata_workers` group turned up [this task](https://github.com/pulibrary/princeton_ansible/blob/abf065ba53dcf51d9a85fcacd23783d1eceb1358/roles/bibdata/tasks/redis_overcommit_memory.yml) in the bibdata role that looks like it should execute only on worker boxes.

I added a condition to the task include statement so that task will only execute on worker boxes, but I'm not sure if that's the correct logic or not. 