### PR TITLE
removes pulfalight surge boxes from hosts file

### DIFF
--- a/hosts
+++ b/hosts
@@ -149,9 +149,6 @@ pulfa3-staging1.princeton.edu
 [pulfalight_production]
 pulfalight-prod1.princeton.edu
 pulfalight-prod2.princeton.edu
-pulfalight-prod3.princeton.edu
-pulfalight-prod4.princeton.edu
-pulfalight-prod5.princeton.edu
 [pulfalight_production_workers]
 pulfalight-worker1.princeton.edu
 [locator_staging]

--- a/roles/nginxplus/files/conf/http/pulfalight-prod.conf
+++ b/roles/nginxplus/files/conf/http/pulfalight-prod.conf
@@ -6,9 +6,6 @@ upstream pulfalight-prod {
     zone pulfalight-prod 64k;
     server pulfalight-prod1.princeton.edu resolve max_fails=0;
     server pulfalight-prod2.princeton.edu resolve max_fails=3;
-    server pulfalight-prod3.princeton.edu resolve max_fails=3;
-    server pulfalight-prod4.princeton.edu resolve max_fails=3;
-    server pulfalight-prod5.princeton.edu resolve max_fails=3;
     sticky learn
           create=$upstream_cookie_pulfalightprodcookie
           lookup=$cookie_pulfalightprodcookie


### PR DESCRIPTION
Traffic to pulfalight no longer requires extra hardware. Removing the three surge VMs from the rotation. 

Related to #2911.