### PR TITLE
Temporarily deactivate the sqs_queue url in bibdata-qa

### DIFF
--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -106,8 +106,8 @@ rails_app_vars:
     value: "{{ vault_scsb_s3_access_key_local }}"
   - name: AWS_SECRET_ACCESS_KEY
     value: "{{ vault_scsb_s3_secret_access_key_local }}"
-  - name: SQS_QUEUE_URL
-    value: "{{ vault_sqs_queue_url }}"
+  # - name: SQS_QUEUE_URL
+  #   value: "{{ vault_sqs_queue_url }}"
   - name: BIBDATA_REDIS_URL
     value: 'bibdata-worker-qa1.princeton.edu'
   - name: BIBDATA_REDIS_DB


### PR DESCRIPTION
closes #3038 

I ran the playbook on bibdata-qa and confirmed that the `SQS_QUEUE_URL` env is not in the box.