### PR TITLE
make db user tasks 'run_once' to avoid failures

### DIFF
--- a/roles/postgresql/tasks/create_users.yml
+++ b/roles/postgresql/tasks/create_users.yml
@@ -14,6 +14,7 @@
     - running_on_server
     - not postgresql_is_local
   changed_when: false
+  run_once: true
 
 - name: PostgreSQL | create postgresql db server users
   community.postgresql.postgresql_user:
@@ -35,6 +36,7 @@
   become_user: "{{ postgres_admin_user }}"
   loop: "{{ postgresql_users }}"
   no_log: true
+  run_once: true
 
 - name: PostgreSQL | change postgresql database owner
   community.postgresql.postgresql_db:
@@ -50,3 +52,4 @@
     - running_on_server
     - not postgresql_is_local
   changed_when: false
+  run_once: true


### PR DESCRIPTION
Closes #3042.

When running on multiple VMs, the postgresql tasks that create users will cause failures on the first run. This marks those tasks `run_once` to avoid race conditions.
