### PR TITLE
add condition and comment to sqs_poller tasks

### DIFF
--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -13,6 +13,8 @@
   roles:
     - role: roles/bibdata
     - role: roles/bibdata_sqs_poller
+      when: runtime_env | default('staging') != "qa"
+      # temporarily run the sqs_poller tasks in staging and prod but not in qa
     - role: roles/sidekiq_worker
       when: "'worker' in inventory_hostname"
     - role: 'hr_share'


### PR DESCRIPTION
Closes #3041.

With this change, the bibdata playbook should include tasks from `bibdata_sqs_poller` when `runtime_env` is set to `production` or to `staging`, and skip the tasks from `bibdata_sqs_poller` when `runtime_env` is set to `qa`.

Running the playbook won't remove anything from the QA boxes or decommission anything, but it will avoid putting things back onto those boxes.