### PR TITLE
annotate deploy user playbook

### DIFF
--- a/playbooks/deploy_user.yml
+++ b/playbooks/deploy_user.yml
@@ -1,6 +1,6 @@
 ---
-# This playbook should not be run on all hosts during business hours.  
-# If you are running it outside the maintenance window please run with a limit flag.
+# Only run this playbook on all hosts in a maintenance window, because no one can deploy while the playbook is running.
+# If you are running it outside the maintenance window please run it on one box at a time using a limit flag.
 # For example: `ansible-playbook playbooks/deploy_user.yml --limit slavery-prod1.princeton.edu`
 - name: Add deploy user
   hosts: all


### PR DESCRIPTION
This PR incorporates the comments from #3030, letting folks know why running the `deploy_user` playbook on all hosts during the work-day is not a great idea. 

