### PR TITLE
we add a fix to expired certs not running

### DIFF
--- a/playbooks/update_expired_certs.yml
+++ b/playbooks/update_expired_certs.yml
@@ -5,7 +5,16 @@
   remote_user: pulsys
   become: true
   tasks:
-    - name: Update apt
+    - name: Add an apt key by id from a keyserver
+      ansible.builtin.apt_key:
+        keyserver: keyserver.ubuntu.com
+        id: "{{ recv_key | default(omit) }}"
+      when: recv_key is defined
+
+    - name: update release info
+      ansible.builtin.command: apt-get --allow-releaseinfo-change update
+
+    - name: Update apt certificates
       ansible.builtin.apt:
         name: ca-certificates
         update_cache: true


### PR DESCRIPTION
if you pass the missing recv_key variable this will replace the missing
keys

Co-authored-by: Alicia Cozine<acozine@users.noreply.github.com>
