### PR TITLE
we add conditional logging

### DIFF
--- a/roles/passenger/templates/passenger.j2
+++ b/roles/passenger/templates/passenger.j2
@@ -11,7 +11,14 @@ server {
   set_real_ip_from 128.112.203.146;
   real_ip_header X-Real-IP;
 
-  access_log /var/log/nginx/access.log custom;
+  access_log /var/log/nginx/access.log custom if=$loadbalancer_enable;
 
   {{passenger_extra_config}}
+}
+
+map $remote_addr $loadbalancer_enable {
+     "128.112.203.144" 0;
+     "128.112.203.145" 0;
+     "128.112.203.146" 0;
+     default 1;
 }


### PR DESCRIPTION
Do we really need to record health checks from the loadbalancers? This
PR adds conditional logging which eliminates all requests (usually
health checks) from the load balancer.
OK?
