### PR TITLE
[DSS] Use the /catalog path for health checking DSS

### DIFF
--- a/roles/nginxplus/files/conf/http/dss-prod.conf
+++ b/roles/nginxplus/files/conf/http/dss-prod.conf
@@ -36,7 +36,7 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/catalog interval=10 fails=3 passes=2;
     }
 
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;

--- a/roles/nginxplus/files/conf/http/dss-staging.conf
+++ b/roles/nginxplus/files/conf/http/dss-staging.conf
@@ -35,7 +35,7 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/catalog interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
The root page is a redirect, which fails health checks. /catalog will
exercise Solr.