### PR TITLE
Updating common to pass molecule

### DIFF
--- a/roles/common/molecule/default/converge.yml
+++ b/roles/common/molecule/default/converge.yml
@@ -5,5 +5,5 @@
     - running_on_server: false
   tasks:
     - name: "Include common"
-      include_role:
+      ansible.builtin.include_role:
         name: "common"

--- a/roles/common/molecule/default/verify.yml
+++ b/roles/common/molecule/default/verify.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   tasks:
   - name: check common package status
-    package:
+    ansible.builtin.apt:
       name: "{{ item }}"
       state: present
     check_mode: true
@@ -24,6 +24,6 @@
       - duf
 
   - name: test packages are installed
-    assert:
+    ansible.builtin.assert:
       that:
         - not pkg_status.changed


### PR DESCRIPTION
fixes 'fqcn-builtins: Use FQCN for builtin actions' lint errors