### PR TITLE
disable waf on solr

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-solr-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr-staging.conf
@@ -33,8 +33,8 @@ server {
     client_max_body_size 0;
 
     location / {
-        app_protect_enable on;
-        app_protect_security_log_enable on;
+#        app_protect_enable on;
+#        app_protect_security_log_enable on;
         proxy_pass http://$upstream;
         proxy_cache lib-solr-stagingcache;
         proxy_cache_methods POST;

--- a/roles/nginxplus/files/conf/http/lib-solr8-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8-staging.conf
@@ -20,8 +20,8 @@ server {
     client_max_body_size 0;
 
     location / {
-        app_protect_enable on;
-        app_protect_security_log_enable on;
+#        app_protect_enable on;
+#        app_protect_security_log_enable on;
         proxy_pass http://lib-solr8-staging;
         proxy_cache_methods POST;
         proxy_set_header Connection "";


### PR DESCRIPTION
the stricter http requests of the WAF make our services look like
attacks

Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
