### PR TITLE
[figgy] Remove lib-proc8

### DIFF
--- a/hosts
+++ b/hosts
@@ -32,14 +32,12 @@ figgy3.princeton.edu
 figgy-web-prod-4.princeton.edu
 lib-proc6.princeton.edu
 lib-proc7.princeton.edu
-lib-proc8.princeton.edu
 lib-proc9.princeton.edu
 lib-proc10.princeton.edu
 lib-proc11.princeton.edu
 [figgy_production_workers]
 lib-proc6.princeton.edu
 lib-proc7.princeton.edu
-lib-proc8.princeton.edu
 lib-proc9.princeton.edu
 lib-proc10.princeton.edu
 lib-proc11.princeton.edu


### PR DESCRIPTION
It's broken and it seems easier to make a new box.

refs pulibrary/figgy#5328