### PR TITLE
add passenger-config to the postrotate

### DIFF
--- a/roles/passenger/meta/main.yml
+++ b/roles/passenger/meta/main.yml
@@ -12,10 +12,10 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - 18.04
+        - bionic
 
 # To install ruby from source, which you must do to use ruby 3+, define
 # install_ruby_from_source: true
 dependencies:
-  - { role: 'ruby_s', when: install_ruby_from_source is defined and install_ruby_from_source|bool == true }
-  - { role: 'ruby', when: install_ruby_from_source is not defined or install_ruby_from_source|bool == false }
+  - {role: 'ruby_s', when: install_ruby_from_source is defined and install_ruby_from_source|bool == true}
+  - {role: 'ruby', when: install_ruby_from_source is not defined or install_ruby_from_source|bool == false}

--- a/roles/passenger/molecule/default/Dockerfile.j2
+++ b/roles/passenger/molecule/default/Dockerfile.j2
@@ -7,7 +7,7 @@ FROM {{ item.image }}
 {% endif %}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -28,12 +28,6 @@
   changed_when: false
   # TODO: This changed when should be removed when we upgrade to molecule 3
 
-# Nginx and passenger installation.
-- name: Phusion | Define nginx_passenger_packages
-  ansible.builtin.set_fact:
-    nginx_passenger_packages: "{{ __nginx_passenger_packages_16_04 }}"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 18
-
 - name: Phusion | Install Nginx and Passenger.
   ansible.builtin.apt:
     name: "{{ nginx_passenger_packages }}"
@@ -47,13 +41,14 @@
     mode: 0644
   notify: restart nginx
 
-- name: Phusion | Copy Passenger configuration into place.
-  ansible.builtin.template:
-    src: passenger.conf.j2
-    dest: /etc/nginx/passenger.conf
-    mode: 0644
-  notify: restart nginx
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 18
+- name: Phusion | Insert/Update passenger-config reopen nginx rotate line
+  ansible.builtin.blockinfile:
+    path: "/etc/logrotate.d/nginx"
+    marker: "## ANSIBLE MANAGED BLOCK ###"
+    insertafter: "invoke-rc.d nginx rotate >/dev/null 2>&1"
+    block: |
+      passenger-config reopen-logs >/dev/null 2>&1 || true
+  changed_when: false
 
 - name: Phusion | Configure passenger virtual host.
   ansible.builtin.template:


### PR DESCRIPTION
this allows nginx to rotate the error logs
remove references to xenial which we no longer use

this closes #3150
