### PR TITLE
Ensuring that the client_max_body_size is set to 0 for pdc-describe NGINX config. files

### DIFF
--- a/group_vars/pdc_describe/production.yml
+++ b/group_vars/pdc_describe/production.yml
@@ -3,6 +3,7 @@ postgres_host: 'lib-postgres-prod3.princeton.edu'
 
 passenger_server_name: "pdc-describe-prod1.princeton.edu"
 passenger_app_env: "production"
+passenger_extra_config: "client_max_body_size 0;"
 
 pdc_describe_db_name: 'pdc_describe_prod'
 

--- a/group_vars/pdc_describe/staging.yml
+++ b/group_vars/pdc_describe/staging.yml
@@ -3,6 +3,7 @@ postgres_host: 'lib-postgres-staging3.princeton.edu'
 
 passenger_server_name: "{{ inventory_hostname }}"
 passenger_app_env: "staging"
+passenger_extra_config: "client_max_body_size 0;"
 
 pdc_describe_db_name: 'pdc_describe_staging'
 


### PR DESCRIPTION
This ensures that the `413` errors are no longer raised for form `POST` file uploads