### PR TITLE
reverts back to lib-postgres3

### DIFF
--- a/group_vars/dss/production.yml
+++ b/group_vars/dss/production.yml
@@ -1,8 +1,8 @@
 ---
-postgres_host: "lib-postgres-prod3.princeton.edu"
+postgres_host: "lib-postgres3.princeton.edu"
 postgres_admin_user: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
-postgres_version: 13
+postgres_version: 10
 postgres_port: "5432"
 pg_hba_contype: "host"
 pg_hba_postgresql_user: "all"

--- a/group_vars/dss/staging.yml
+++ b/group_vars/dss/staging.yml
@@ -1,6 +1,6 @@
 ---
-postgres_host: "lib-postgres-staging3.princeton.edu"
-postgres_version: 13
+postgres_host: "lib-postgres3.princeton.edu"
+postgres_version: 10
 postgres_admin_user: "postgres"
 pg_hba_contype: "host"
 pg_hba_postgresql_user: "all"


### PR DESCRIPTION
we have encountered migration problems that require a revert back to the
lib-postgres3 database

Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
