### PR TITLE
Use ruby 2.7.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 python 3.10.0
-ruby 2.6.5
+ruby 2.7.5
 direnv 2.30.3


### PR DESCRIPTION
I've been using ruby 2.7.5 for a while for the lpass integration, and it's been working well.