### PR TITLE
[Orangelight] Rotate the sitemap generator logs

### DIFF
--- a/roles/orangelight/tasks/main.yml
+++ b/roles/orangelight/tasks/main.yml
@@ -1,2 +1,6 @@
 ---
-# tasks file for roles/orangelight
+- name: orangelight | rotate the logs for the sitemap cron job
+  ansible.builtin.template:
+    src: 'logrotate.d.sitemap.j2'
+    dest: '/etc/logrotate.d/sitemap_cron'
+    mode: 0644

--- a/roles/orangelight/templates/logrotate.d.sitemap.j2
+++ b/roles/orangelight/templates/logrotate.d.sitemap.j2
@@ -1,0 +1,13 @@
+# logrotate configuration for /tmp/ol_sitemap.log {{ ansible_managed | comment }}
+
+/tmp/ol_sitemap.log {
+  maxsize 5M
+  daily
+  rotate 2
+  copytruncate
+  delaycompress
+  compress
+  notifempty
+  missingok
+  su root root
+}


### PR DESCRIPTION
Closes https://github.com/pulibrary/orangelight/issues/1909

Just a draft for now, in case work on https://github.com/pulibrary/orangelight/issues/1665 affects this PR.  I have not run this yet.