### PR TITLE
[Researchdata] add missing datadog role to prod

### DIFF
--- a/playbooks/researchdata.yml
+++ b/playbooks/researchdata.yml
@@ -10,6 +10,8 @@
     - ../group_vars/researchdata/vault.yml
   roles:
     - role: roles/researchdata
+    - role: roles/datadog
+      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: restart nginx


### PR DESCRIPTION
Without this role, the researchdata playbook doesn't know that it should replace the datadog api_key in the datadog config files.