### PR TITLE
Mudd-dbs: file permissions to allow deploy

### DIFF
--- a/roles/mudd/tasks/main.yml
+++ b/roles/mudd/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 # tasks file for roles/mudd
 - name: Create a directory shared config
-  file:
+  ansible.builtin.file:
     path: '/opt/mudd-dbs/shared/config/initializers'
     state: 'directory'
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
-    mode: 0644
+    mode: 0744
 
 - name: copy template datbase config file
-  template:
+  ansible.builtin.template:
     src: database.yml.j2
     dest: "/opt/mudd-dbs/shared/config/database.yml"
     owner: '{{ deploy_user }}'
@@ -17,7 +17,7 @@
     mode: 0644
 
 - name: copy template secrets config file
-  template:
+  ansible.builtin.template:
     src: secrets.yml.j2
     dest: "/opt/mudd-dbs/shared/config/secrets.yml"
     owner: '{{ deploy_user }}'
@@ -25,9 +25,9 @@
     mode: 0644
 
 - name: copy template secret_token config file
-  template:
+  ansible.builtin.template:
     src: secret_token.rb.j2
     dest: "/opt/mudd-dbs/shared/config/initializers/secret_token.rb"
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
-    mode: 0644
+    mode: 0744


### PR DESCRIPTION
With `0644` permissions on this directory and file, deploying to staging fails.  Switching to `0744` allows the deploy to go through.

I also added fully qualified module names.