### PR TITLE
add ignore error while we wait for a robust solution

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,6 +4,7 @@
     name: "{{ item }}"
     state: present
     update_cache: true
+  ignore_errors: true
   loop:
     - ca-certificates
     - apt-transport-https
@@ -18,6 +19,7 @@
     name: '{{ common_packages }}'
     state: present
     update_cache: true
+  ignore_errors: true
   changed_when: false
 
 - name: common | copy tmux.conf


### PR DESCRIPTION
we currently have the playbook stop running when apt-get update step

Co-authored-by: Alicia Cozine<acozine@users.noreply.github.com>
Co-authored-by: Anna Headley <hackartisan@users.noreply.github.com>
Co-authored-by: Bess Sadler <bess@users.noreply.github.com>
Co-authored-by: Carolyn Cole <carolyncole@users.noreply.github.com>
Co-authored-by: Max Kadel <maxkadel@users.noreply.github.com>
Co-authored-by: regineheberlein <regineheberlein@users.noreply.github.com>
Co-authored-by: Ryan Laddusaw <rladdusaw@users.noreply.github.com>
Co-authored-by: Tyler Wade <twade968@users.noreply.github.com>
