### PR TITLE
explicitly add nginx group_vars, use new inventory groups

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -4,17 +4,19 @@
 # to replace SSL certificates and keys, run with `-t SSL`
 
 - name: update loadbalancer configuration
-  hosts: nginxplus
+  hosts: nginxplus_production # default to staging when we get a staging environment going
   remote_user: pulsys
   strategy: linear
   become: true
+  vars_files:
+    - ../group_vars/nginxplus/main.yml
 
   # updates existing load balancer
   roles:
     - role: ../roles/nginxplus
 
 - name: restart nginx with updated loadbalancer configuration
-  hosts: nginxplus
+  hosts: nginxplus_production
   remote_user: pulsys
   strategy: linear
   become: true

--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -1,9 +1,11 @@
 ---
 - name: rebuild nginx with datadog
-  hosts: nginxplus
+  hosts: nginxplus_production # default to staging when we get a staging environment going
   remote_user: pulsys
   strategy: free
   become: true
+  vars_files:
+    - ../group_vars/nginxplus/main.yml
 
 # rebuilds the load balancer from scratch
   roles:
@@ -12,7 +14,7 @@
     - role: ../roles/nginxplus
 
 - name: restart nginx and announce success
-  hosts: nginxplus
+  hosts: nginxplus_production # default to staging when we get a staging environment going
   remote_user: pulsys
   strategy: linear
   become: true


### PR DESCRIPTION
We changed the inventory group name from `nginx` to `nginx_production`. Now we need to explicitly load group_vars and call the correct group name.

We should not need the group_vars for the second play . . . 