### PR TITLE
Change pulbot default env from prod to staging

### DIFF
--- a/group_vars/appdeploy/production.yml
+++ b/group_vars/appdeploy/production.yml
@@ -36,6 +36,8 @@ rails_app_vars:
     value: '{{db_password}}'
   - name: APP_DB_HOST
     value: '{{postgres_host}}'
+  - name: HUBOT_DEPLOY_DEFAULT_ENVIRONMENT
+    value: 'staging'
   - name: HUBOT_SLACK_TOKEN
     value: '{{vault_hubot_slack_token}}'
   - name: HUBOT_GITHUB_TOKEN


### PR DESCRIPTION
If you don't give an environment, pulbot defaults to deploying to production. This runs the risk of accidental deployments to production. 

We're shifting to having most ansible-playbooks defaulting to staging, and running on production if that environment is explicitly passed as an argument - this follows that pattern. (see also https://github.com/pulibrary/hubot-deploy/blob/main/src/scripts/deploy.coffee#L26). 

shoutout to @tpendragon for pointing to the right spots to change.