### PR TITLE
[Figgy] Change CDL ingest folder.

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -147,7 +147,7 @@ rails_app_vars:
   - name: OCR_OUT_PATH
     value: '/mnt/illiad/images'
   - name: CDL_IN_PATH
-    value: '/mnt/illiad/cdl_scans'
+    value: '/mnt/illiad/cdl_scans/figgy_ingest'
   - name: ASPACE_URL
     value: 'https://aspace.princeton.edu/staff/api'
   - name: ASPACE_USER

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: figgy_production_webserver
+- hosts: figgy_production_webservers
   remote_user: pulsys
   become: true
   strategy: free


### PR DESCRIPTION
Something's stealing files out of the cdl_scans folder and we can't
figure out what it is. To get things moving again, we're going to switch
to a subfolder.

Refs pulibrary/figgy#5396