### PR TITLE
I3308 app configs is only for rails

### DIFF
--- a/playbooks/remove_app_configs.yml
+++ b/playbooks/remove_app_configs.yml
@@ -1,0 +1,19 @@
+---
+- name: Remove app_configs checking from apache servers
+  hosts: apache_servers
+  remote_user: pulsys
+  become: true
+  become_user: deploy
+  tasks:
+    - name: don't check for app_configs in .bashrc
+      ansible.builtin.lineinfile:
+        dest: "/home/deploy/.bashrc"
+        state: absent
+        regexp: '^for f in ~/app_configs/\*; do source \$f; done$'
+
+  post_tasks:
+  - name: tell everyone on slack you ran an ansible playbook
+    community.general.slack:
+      token: "{{ vault_pul_slack_token }}"
+      msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
+      channel: #server-alerts

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -18,22 +18,6 @@
     key: "{{ item.key }}"
   with_items: "{{ deploy_ssh_users }}"
 
-- name: deploy_user | create app_configs directory
-  ansible.builtin.file:
-    path: '/home/{{ deploy_user }}/app_configs'
-    state: 'directory'
-    owner: '{{ deploy_user }}'
-    group: '{{ deploy_user }}'
-    mode: '0744'
-
-- name: deploy_user | load app configs
-  ansible.builtin.lineinfile: >
-              dest="/home/{{ deploy_user }}/.bashrc"
-              state=present
-              regexp='^for f in ~/app_configs/\*; do source \$f; done$'
-              line="for f in ~/app_configs/*; do source $f; done"
-              insertbefore=BOF
-
 - name: deploy_user | allow "authorized_key" files
   ansible.builtin.lineinfile: >
               dest=/etc/ssh/sshd_config

--- a/roles/rails_app/tasks/main.yml
+++ b/roles/rails_app/tasks/main.yml
@@ -6,8 +6,16 @@
   loop: '{{ rails_app_dependencies }}'
   changed_when: false
 
-- name: rails_app | Install site configuration
-  template:
+- name: rails_app | create app_configs directory
+  ansible.builtin.file:
+    path: '/home/{{ deploy_user }}/app_configs'
+    state: 'directory'
+    owner: '{{ deploy_user }}'
+    group: '{{ deploy_user }}'
+    mode: '0744'
+
+- name: rails_app | Install site configuration into app_configs
+  ansible.builtin.template:
     src: 'rails_app_config'
     dest: '/home/{{ deploy_user }}/app_configs/{{ rails_app_name }}'
     owner: '{{ deploy_user }}'
@@ -15,6 +23,14 @@
     mode: 0644
   tags:
     - site_config
+
+- name: rails_app | load envvars from app_configs directory
+  ansible.builtin.lineinfile:
+    dest: "/home/{{ deploy_user }}/.bashrc"
+    state: present
+    regexp: '^for f in ~/app_configs/\*; do source \$f; done$'
+    line: "for f in ~/app_configs/*; do source $f; done"
+    insertbefore: BOF
 
 - name: rails_app | Create app directory structure
   file:


### PR DESCRIPTION
closes #3308 

The .bashrc line that causes this error was previously added as part of the deploy_user role, but it is really only needed in the rails_app role, so I moved it to the rails_app role.

This PR also includes a separate one-time playbook to remove all those .bashrc lines from the apache servers.  I wasn't sure if it should be part of this repo or not, since it probably won't be very useful after it is run...

[Example deployment logs before](https://gist.github.com/pulbot/5d972e59c4b436856ff9bbbc4379d89f) running the remove_app_configs playbook vs. [after](https://gist.github.com/pulbot/d6fe94e21d1cc10767d3262b867d20d2)