### PR TITLE
add a syntax nginx semi colon

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -51,7 +51,7 @@
     }
 
     location /amp_up_training/ {
-        proxy_pass https://firestone-renovations-staging.princeton.edu/amp_up_training/
+        proxy_pass https://firestone-renovations-staging.princeton.edu/amp_up_training/;
     }
 
     location /special-collections {

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -133,10 +133,6 @@
     location /music/ReelToReel {
         proxy_pass https://lib-dbserver.princeton.edu/music/ReelToReel/;
     }
-    location /amp_up_training {
-        proxy_pass https://lib-static-prod.princeton.edu/amp_up_training/;
-    }
-
     # 1 libphp-dev
     location /hrc {
         proxy_pass http://libphp-dev.princeton.edu/hrc/;


### PR DESCRIPTION
remove the multi-use of amp_training
Co-authored-by: Bess Sadler <bess@users.noreply.github.com>
Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: Eliot Jordan <eliotjordan@users.noreply.github.com>
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
Co-authored-by: Max Kadel <maxkadel@users.noreply.github.com>
Co-authored-by: Stephanie Ayers <stephayers@users.noreply.github.com>
