### PR TITLE
keep lib-postgres3 only for prod

### DIFF
--- a/inventory/all_projects/postgresql
+++ b/inventory/all_projects/postgresql
@@ -7,4 +7,3 @@ lib-postgres3.princeton.edu
 [postgresql_staging]
 lib-postgres-staging3.princeton.edu
 lib-postgres-staging2.princeton.edu
-lib-postgres3.princeton.edu


### PR DESCRIPTION
Today we saw outages in production when we ran the new "apt update" playbook against all staging machines. Traced the problem to an inventory issue.

Because `lib-postgres3` contains both production and staging databases, originally we put the machine in both the `postgresql_production` and `postgresql_staging` groups. Keeping it in only the production group for now.

The eventual fix for this problem is to separate prod and staging fully, see #2735. 