### PR TITLE
updates all bare 'include' statements to 'include_tasks'

### DIFF
--- a/group_vars/ojs/main.yml
+++ b/group_vars/ojs/main.yml
@@ -19,6 +19,7 @@ pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
 postgres_version: "13"
 
+ojs_site_adminname: "{{ vault_ojs_site_adminname }}"
 ojs_site_adminpassword: "{{ vault_ojs_site_adminpassword }}"
 ojs_db_host: "{{ project_db_host }}"
 ojs_site_repoid: "pul_ojs"

--- a/group_vars/ojs/main.yml
+++ b/group_vars/ojs/main.yml
@@ -21,6 +21,7 @@ postgres_version: "13"
 
 ojs_site_adminname: "{{ vault_ojs_site_adminname }}"
 ojs_site_adminpassword: "{{ vault_ojs_site_adminpassword }}"
+ojs_site_email: "{{ vault_ojs_site_email }}"
 ojs_db_host: "{{ project_db_host }}"
 ojs_site_repoid: "pul_ojs"
 

--- a/roles/ojs/defaults/main.yml
+++ b/roles/ojs/defaults/main.yml
@@ -12,9 +12,12 @@ backup_scripts_dir: "/home/{{ deploy_user }}/backup_scripts"
 
 postgresql_is_local: true
 postgres_version: "13"
-ojs_site_email: "{{ vault_ojs_site_email }}"
-ojs_site_adminname: "{{ vault_ojs_site_adminname }}"
-ojs_site_adminpassword: "{{ vault_ojs_site_adminpassword }}"
+# fake values for use in CI
+# real values are pointed at the group_vars/vault.yml
+# from group_vars/<env>.yml files
+ojs_site_email: "foo@princeton.edu"
+ojs_site_adminname: "site_adminname"
+ojs_site_adminpassword: "site_adminpassword"
 ojs_home: "/var/www/ojs-{{ ojs_version }}"
 ojs_db_user: "ojs_db_user"
 ojs_db_password: "{{ journals_password | default('change_me') }}"

--- a/roles/ojs/tasks/install_ojs.yml
+++ b/roles/ojs/tasks/install_ojs.yml
@@ -1,3 +1,4 @@
+---
 - name: ojs | copy config file
   command: "cp config.TEMPLATE.inc.php config.inc.php"
   args:

--- a/roles/ojs/tasks/install_ojs.yml
+++ b/roles/ojs/tasks/install_ojs.yml
@@ -1,0 +1,89 @@
+- name: ojs | copy config file
+  command: "cp config.TEMPLATE.inc.php config.inc.php"
+  args:
+    chdir: "{{ ojs_home }}"
+  become: true
+  become_user: "{{ deploy_user }}"
+  when: ojs_is_installed is false
+  changed_when: false
+
+- name: ojs | write expect script for OJS interactive installation
+  template:
+    src: "script.exp.j2"
+    dest: "{{ ojs_home }}/script.exp"
+    owner: "{{ deploy_user }}"
+    group: www-data
+    mode: 0700
+
+- name: ojs | run expect script for OJS interactive installation
+  command: "/usr/bin/expect {{ ojs_home }}/script.exp"
+  args:
+    chdir: "{{ ojs_home }}"
+  become: true
+  become_user: "{{ deploy_user }}"
+
+- name: ojs | remove expect script
+  file:
+    path: "{{ ojs_home }}/script.exp"
+    state: absent
+
+- name: ojs | remove apache document root
+  file:
+    path: "{{ apache.docroot }}"
+    state: absent
+
+- name: ojs | install htaccess config for mod_rewrite
+  template:
+    src: htaccess
+    dest: "{{ ojs_home }}/.htaccess"
+    owner: "{{ deploy_user }}"
+    group: www-data
+    mode: 0644
+
+- name: ojs | create ojs local directory
+  file:
+    path: "/etc/apache2/ssl/{{ item }}"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: 0775
+  with_items:
+    - private
+    - certs
+
+- name: ojs | copy apache cert files
+  copy:
+    src: "files/certs/{{ item }}"
+    dest: "/etc/apache2/ssl/certs/"
+  changed_when: false
+  when: running_on_server
+  with_items:
+    - "{{ inventory_hostname }}_cert.cer"
+    - "{{ inventory_hostname }}_chained.pem"
+
+- name: ojs | copy apache private files
+  copy:
+    src: "files/private/{{ item }}"
+    dest: "/etc/apache2/ssl/private/"
+  when: running_on_server
+  with_items:
+    - "{{ inventory_hostname }}_priv.key"
+
+- name: ojs | add OJS template
+  template:
+    src: "ojs.conf.j2"
+    dest: "/etc/apache2/sites-available/ojs.conf"
+    mode: 0644
+
+- name: ojs | remove apache2 default
+  file:
+    path: "/etc/apache2/sites-enabled/000-default.conf"
+    state: absent
+
+- name: ojs | symbolic link to ojs config
+  file:
+    src: "/etc/apache2/sites-available/ojs.conf"
+    dest: "/etc/apache2/sites-enabled/ojs.conf"
+    state: link
+  when: running_on_server
+  notify: restart apache2

--- a/roles/ojs/tasks/main.yml
+++ b/roles/ojs/tasks/main.yml
@@ -58,7 +58,7 @@
   with_items:
     - public
 
-# this task fails idempotency checks without the 
+# this task fails idempotency checks without the
 # changed_when line, I don't understand why . . .
 - name: ojs | create a directory to store uploaded files
   ansible.builtin.file:

--- a/roles/ojs/tasks/main.yml
+++ b/roles/ojs/tasks/main.yml
@@ -3,13 +3,13 @@
 ## file so you can start over with a fresh installation.
 
 - name: ojs | install prerequisites
-  include: "install_prerequisites.yml"
+  include_tasks: "install_prerequisites.yml"
 
 - name: ojs | clean, if necessary
-  include: "clean.yml"
+  include_tasks: "clean.yml"
 
 - name: ojs | determine if ojs is installed already
-  include: "check_ojs_installation.yml"
+  include_tasks: "check_ojs_installation.yml"
   changed_when: false
 
 - name: ojs | add {{ deploy_user }} to www-data
@@ -174,10 +174,10 @@
   notify: restart apache2
 
 - name: ojs | enable PHP file uploads
-  include: "enable_php_uploads.yml"
+  include_tasks: "enable_php_uploads.yml"
 
 - name: ojs | automate backups
-  include: "automate_backups.yml"
+  include_tasks: "automate_backups.yml"
 
 - name: ojs | clone translation repository
   ansible.builtin.git:

--- a/roles/ojs/tasks/main.yml
+++ b/roles/ojs/tasks/main.yml
@@ -8,10 +8,6 @@
 - name: ojs | clean, if necessary
   include_tasks: "clean.yml"
 
-- name: ojs | determine if ojs is installed already
-  include_tasks: "check_ojs_installation.yml"
-  changed_when: false
-
 - name: ojs | add {{ deploy_user }} to www-data
   user:
     name: "{{ deploy_user }}"
@@ -71,107 +67,13 @@
     recurse: true
     mode: 0775
 
-- name: ojs | copy config file
-  command: "cp config.TEMPLATE.inc.php config.inc.php"
-  args:
-    chdir: "{{ ojs_home }}"
-  become: true
-  become_user: "{{ deploy_user }}"
-  when: ojs_is_installed is false
-  changed_when: false
+- name: ojs | determine if ojs is installed already
+  include_tasks: "check_ojs_installation.yml"
 
-- name: ojs | write expect script for OJS interactive installation
-  template:
-    src: "script.exp.j2"
-    dest: "{{ ojs_home }}/script.exp"
-    owner: "{{ deploy_user }}"
-    group: www-data
-    mode: 0700
+- name: ojs | install ojs
+  include_tasks: "install_ojs.yml"
   when:
     - ojs_is_installed is false
-    - running_on_server
-
-- name: ojs | run expect script for OJS interactive installation
-  command: "/usr/bin/expect {{ ojs_home }}/script.exp"
-  args:
-    chdir: "{{ ojs_home }}"
-  become: true
-  become_user: "{{ deploy_user }}"
-  when:
-    - ojs_is_installed is false
-    - running_on_server
-
-- name: ojs | remove expect script
-  file:
-    path: "{{ ojs_home }}/script.exp"
-    state: absent
-
-- name: ojs | remove apache document root
-  file:
-    path: "{{ apache.docroot }}"
-    state: absent
-  changed_when: false
-
-- name: ojs | install htaccess config for mod_rewrite
-  template:
-    src: htaccess
-    dest: "{{ ojs_home }}/.htaccess"
-    owner: "{{ deploy_user }}"
-    group: www-data
-    mode: 0644
-  changed_when: false
-
-- name: ojs | create ojs local directory
-  file:
-    path: "/etc/apache2/ssl/{{ item }}"
-    state: directory
-    owner: "root"
-    group: "root"
-    mode: 0775
-  with_items:
-    - private
-    - certs
-  changed_when: false
-
-- name: ojs | copy apache cert files
-  copy:
-    src: "files/certs/{{ item }}"
-    dest: "/etc/apache2/ssl/certs/"
-  changed_when: false
-  when: running_on_server
-  with_items:
-    - "{{ inventory_hostname }}_cert.cer"
-    - "{{ inventory_hostname }}_chained.pem"
-
-- name: ojs | copy apache private files
-  copy:
-    src: "files/private/{{ item }}"
-    dest: "/etc/apache2/ssl/private/"
-  changed_when: false
-  when: running_on_server
-  with_items:
-    - "{{ inventory_hostname }}_priv.key"
-
-- name: ojs | add OJS template
-  template:
-    src: "ojs.conf.j2"
-    dest: "/etc/apache2/sites-available/ojs.conf"
-    mode: 0644
-
-- name: ojs | remove apache2 default
-  file:
-    path: "/etc/apache2/sites-enabled/000-default.conf"
-    state: absent
-  changed_when: false
-
-- name: ojs | symbolic link to ojs config
-  file:
-    src: "/etc/apache2/sites-available/ojs.conf"
-    dest: "/etc/apache2/sites-enabled/ojs.conf"
-    state: link
-  when: running_on_server
-  changed_when: false
-  notify: restart apache2
 
 - name: ojs | enable PHP file uploads
   include_tasks: "enable_php_uploads.yml"

--- a/roles/ojs/tasks/main.yml
+++ b/roles/ojs/tasks/main.yml
@@ -58,6 +58,8 @@
   with_items:
     - public
 
+# this task fails idempotency checks without the 
+# changed_when line, I don't understand why . . .
 - name: ojs | create a directory to store uploaded files
   ansible.builtin.file:
     path: "{{ ojs_file_uploads }}"
@@ -66,6 +68,7 @@
     group: www-data
     recurse: true
     mode: 0775
+  changed_when: false
 
 - name: ojs | determine if ojs is installed already
   include_tasks: "check_ojs_installation.yml"

--- a/roles/omp/tasks/main.yml
+++ b/roles/omp/tasks/main.yml
@@ -3,13 +3,13 @@
 ## file so you can start over with a fresh installation.
 
 - name: omp | install prerequisites
-  include: "install_prerequisites.yml"
+  include_tasks: "install_prerequisites.yml"
 
 - name: omp | clean, if necessary
-  include: "clean.yml"
+  include_tasks: "clean.yml"
 
 - name: omp | determine if omp is installed already
-  include: "check_omp_installation.yml"
+  include_tasks: "check_omp_installation.yml"
   changed_when: false
 
 - name: omp | add {{ deploy_user }} to www-data
@@ -175,4 +175,4 @@
   notify: restart apache2
 
 - name: omp | automate backups
-  include: "automate_backups.yml"
+  include_tasks: "automate_backups.yml"

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -10,3 +10,9 @@
     name: 'nginx'
     enabled: true
     state: restarted
+
+- name: restart apache
+  service:
+    name: apache2
+    enabled: true
+    state: restarted

--- a/roles/php/tasks/configure-nginx.yml
+++ b/roles/php/tasks/configure-nginx.yml
@@ -10,7 +10,7 @@
   register: phpcli
 
 - name: Run the tasks for the PHP CLI
-  include: php-cli.yml
+  include_tasks: php-cli.yml
   when: phpcli.stat.exists
 
 - name: install php

--- a/roles/php/tasks/configure-nginx.yml
+++ b/roles/php/tasks/configure-nginx.yml
@@ -30,6 +30,7 @@
     owner: nginx
     group: adm
   when: running_on_server
+  notify: restart nginx
 
 - name: make sure fpm runs as nginx
   lineinfile:

--- a/roles/php/tasks/configure.yml
+++ b/roles/php/tasks/configure.yml
@@ -10,11 +10,11 @@
   register: phpcli
 
 - name: php | Run the tasks for the PHP CLI
-  include: php-cli.yml
+  include_tasks: php-cli.yml
   when: phpcli.stat.exists
 
 - name: php | Run the tasks for the Apache PHP module
-  include: mod-php.yml
+  include_tasks: mod-php.yml
   when: modphp.stat.exists
 
 - name: php | disable php apache module

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -30,11 +30,11 @@
     update_cache: true
   when: datadog_enabled
 
-- include: configure.yml
+- include_tasks: configure.yml
   when: php_webserver == 'apache2'
   notify: restart apache
 
-- include: configure-nginx.yml
+- include_tasks: configure-nginx.yml
   when: php_webserver == 'nginx'
   notify: restart nginx
 

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -32,11 +32,9 @@
 
 - include_tasks: configure.yml
   when: php_webserver == 'apache2'
-  notify: restart apache
 
 - include_tasks: configure-nginx.yml
   when: php_webserver == 'nginx'
-  notify: restart nginx
 
 - name: php | uninstall eol php
   apt:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -12,4 +12,4 @@
     - postgresql-client-{{ postgres_version }}
 
 # tasks file for roles/postgres
-- include: readonly_user.yml
+- include_tasks: readonly_user.yml

--- a/roles/psql/tasks/main.yml
+++ b/roles/psql/tasks/main.yml
@@ -77,6 +77,6 @@
 - name: flush handlers
   meta: flush_handlers
 
-- include: databases.yml
-- include: users.yml
-- include: repmgr.yml
+- include_tasks: databases.yml
+- include_tasks: users.yml
+- include_tasks: repmgr.yml

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -36,7 +36,7 @@
   when: redis__overcommit_memory_enable|bool
 
 - name: redis | configure redis-server service
-  include: redis-server.yml
+  include_tasks: redis-server.yml
   when: redis__server_enabled|bool
 
 - name: redis | disable Redis Server service if not enabled

--- a/roles/samba/tasks/main.yml
+++ b/roles/samba/tasks/main.yml
@@ -7,4 +7,4 @@
     state: present
   tags: samba
 
-- include: samba_server.yml
+- include_tasks: samba_server.yml

--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -15,16 +15,16 @@
   when: lib_zk1_host_name != "localhost" and lib_zk2_host_name != "localhost" and lib_zk3_host_name != "localhost"
 
 - name: solr cloud install node
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - install
 
 - name: configure solr cloud
-  include: config.yml
+  include_tasks: config.yml
   tags:
     - configure
 
 - name: run solr service
-  include: service.yml
+  include_tasks: service.yml
   tags:
     - service

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: install.yml
-- include: config.yml
-- include: service.yml
+- include_tasks: install.yml
+- include_tasks: config.yml
+- include_tasks: service.yml


### PR DESCRIPTION
Closes #3305.

The use of `include` without any indication of what to include (role? tasks? vars?) is deprecated and the functionality will disappear in Ansible 2.16. Using the specific directives is clearer, anyway.

This PR updates the few instances we still had of generic `include` directives.