### PR TITLE
testing a new approach to psql table ownership

### DIFF
--- a/playbooks/test_psql.yml
+++ b/playbooks/test_psql.yml
@@ -1,0 +1,36 @@
+---
+- name: try updating postgresql db table ownership
+  hosts: postgresql_{{ runtime_env | default('staging') }}
+  remote_user: pulsys
+  become: true
+  vars:
+    - project_name: pulmap
+
+  vars_files:
+    - ../group_vars/{{ project_name }}/{{ app_runtime_env | default(runtime_env) | default('staging') }}.yml
+    # - ../group_vars/{{ project_name }}/main.yml  # some roles have this
+    - ../group_vars/{{ project_name }}/vault.yml
+  tasks:
+    - name: PostgreSQL | change postgresql database owner
+      community.postgresql.postgresql_owner:
+        db: "{{ application_db_name }}"
+        port: "{{ postgres_port }}"
+        login_host: "{{ postgres_host }}"
+        login_user: "{{ postgres_admin_user }}"
+        login_password: "{{ postgres_admin_password }}"
+        new_owner: "{{ application_dbuser_name }}"
+        obj_type: "{{ item }}"
+      with_items:
+        - database
+        - table
+        - tablespace
+        - view
+      when:
+        - running_on_server
+        - not postgresql_is_local
+      changed_when: false
+      run_once: true
+
+
+
+

--- a/roles/postgresql/tasks/create_users.yml
+++ b/roles/postgresql/tasks/create_users.yml
@@ -39,15 +39,19 @@
   run_once: true
 
 - name: PostgreSQL | change postgresql database owner
-  community.postgresql.postgresql_db:
-    name: "{{ application_db_name }}"
+  community.postgresql.postgresql_owner:
+    db: "{{ application_db_name }}"
     port: "{{ postgres_port }}"
     login_host: "{{ postgres_host }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ postgres_admin_password }}"
-    encoding: "UTF-8"
-    state: "present"
-    owner: "{{ application_dbuser_name }}"
+    new_owner: "{{ application_dbuser_name }}"
+    obj_type: "{{ item }}"
+  with_items:
+    - database
+    - table
+    - tablespace
+    - view
   when:
     - running_on_server
     - not postgresql_is_local


### PR DESCRIPTION
Closes #3286 

Updates the way we set ownership on postgresql databases and the tables within them. We will test this on the next migration.

Co-authored-by: Francis Kayiwa <kayiwa@users.noreply.github.com>
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>