### PR TITLE
remove nginxplus production

### DIFF
--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -19,7 +19,6 @@ locator_production
 lockers_and_study_spaces_production
 mudd_production
 mysql_production
-nginxplus_production
 oawaiver_production
 obsd_httpd_production
 ojs_production

--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -2,10 +2,8 @@
 # by default this playbook runs in the staging environment
 # to run in qa, pass '-e runtime_env=qa'
 # to run in production, pass '-e runtime_env=production'
-# when running this playbook in production log into the
-# standby lib-adc{1,2} and run the update manually and 
-# restart it. This will prevent both production loadbalancers
-# from going down at the same time
+# remember that the loadbalancing machines are not included
+# and will need to be manually updated
 - name: update the Operating System apt packages 
   hosts: "{{ runtime_env | default('staging') }}"
   remote_user: pulsys


### PR DESCRIPTION
we are removing the loadbalancers because having both restart
immediately after the other would be disastrous

Co-authored-by: Alicia Cozine<acozine@users.noreply.github.com>
Co-authored-by: Bess Sadler <bess@users.noreply.github.com>
Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>
