### PR TITLE
Ensure all roles update the cache for CI

### DIFF
--- a/roles/abid/molecule/default/converge.yml
+++ b/roles/abid/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include common"
       include_role:

--- a/roles/apache2/molecule/default/converge.yml
+++ b/roles/apache2/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/apache2"
       include_role:

--- a/roles/appdeploy/molecule/default/converge.yml
+++ b/roles/appdeploy/molecule/default/converge.yml
@@ -1,6 +1,11 @@
 ---
 - name: Converge
   hosts: all
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include appdeploy"
       include_role:

--- a/roles/approvals/molecule/default/converge.yml
+++ b/roles/approvals/molecule/default/converge.yml
@@ -8,6 +8,11 @@
     - rails_app_name: 'approvals'
     - install_mailcatcher: true
   become: true
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include approvals"
       include_role:

--- a/roles/bibdata_sqs_poller/molecule/default/converge.yml
+++ b/roles/bibdata_sqs_poller/molecule/default/converge.yml
@@ -4,6 +4,11 @@
   vars:
     - running_on_server: false
   become: true
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include bibdata_sqs_poller"
       include_role:

--- a/roles/composer/molecule/default/converge.yml
+++ b/roles/composer/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/composer"
       include_role:

--- a/roles/dpul/molecule/default/converge.yml
+++ b/roles/dpul/molecule/default/converge.yml
@@ -4,6 +4,11 @@
   vars:
     - running_on_server: false
   become: true
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include dpul"
       ansible.builtin.include_role:

--- a/roles/drupal/molecule/default/converge.yml
+++ b/roles/drupal/molecule/default/converge.yml
@@ -9,6 +9,11 @@
     - drupal_docroot: "/var/www/drupal"
     - apache_app_path: "{{ drupal_docroot }}"
     - drupal_major_version: 7
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/drupal"
       include_role:

--- a/roles/drupal9/molecule/default/converge.yml
+++ b/roles/drupal9/molecule/default/converge.yml
@@ -9,6 +9,11 @@
     - systems_user: 'deploy'
     - force_settings: false
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/drupal9"
       include_role:

--- a/roles/drush/molecule/default/converge.yml
+++ b/roles/drush/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/drush"
       include_role:

--- a/roles/friends_of_pul/molecule/default/converge.yml
+++ b/roles/friends_of_pul/molecule/default/converge.yml
@@ -1,21 +1,24 @@
 ---
 - name: Converge
   hosts: all
-  pre_tasks:
-  - name: install iproute
-    apt:
-      name: iproute2
-      state: present
-      update_cache: true
-  - name: rerun setup
-    setup:
-      gather_subset:
-        - network
   vars:
     - running_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
     - mariadb_server__root_password: "{{ vault_maridb_password | default('change_me') }}"
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
+  - name: install iproute
+    apt:
+      name: iproute2
+      state: present
+  - name: rerun setup
+    setup:
+      gather_subset:
+        - network
   tasks:
     - name: "Include roles/friends_of_pul"
       include_role:

--- a/roles/geaccirc/molecule/default/converge.yml
+++ b/roles/geaccirc/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/geaccirc"
       include_role:

--- a/roles/lockers_and_study_spaces/molecule/default/converge.yml
+++ b/roles/lockers_and_study_spaces/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include lockers_and_study_spaces"
       include_role:

--- a/roles/mysql/molecule/default/converge.yml
+++ b/roles/mysql/molecule/default/converge.yml
@@ -6,6 +6,11 @@
     - mysql_server: true
     - mysql_root_password: changethis
   become: true
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "MySQL Role"
       include_role:

--- a/roles/ouranos/molecule/default/converge.yml
+++ b/roles/ouranos/molecule/default/converge.yml
@@ -1,6 +1,11 @@
 ---
 - name: Converge
   hosts: all
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include ouranos"
       include_role:

--- a/roles/pas/molecule/default/converge.yml
+++ b/roles/pas/molecule/default/converge.yml
@@ -5,6 +5,11 @@
     - running_on_server: false
     - xtradb_nodes_group: "all"
     - xtradb_leader_node: "instance"
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/pas"
       include_role:

--- a/roles/pgbouncer/molecule/default/playbook.yml
+++ b/roles/pgbouncer/molecule/default/playbook.yml
@@ -7,6 +7,11 @@
     - replication_user: "replicant"
     - repmgr_config: "/etc/repmgr.conf"
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   roles:
     - role: psql
       postgresql_ext_install_postgis: true

--- a/roles/php/molecule/default/converge.yml
+++ b/roles/php/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/php"
       include_role:

--- a/roles/postgresql/molecule/default/converge.yml
+++ b/roles/postgresql/molecule/default/converge.yml
@@ -4,6 +4,11 @@
   vars:
     - running_on_server: false
   become: true
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include postgresql"
       include_role:

--- a/roles/researchdata/molecule/default/converge.yml
+++ b/roles/researchdata/molecule/default/converge.yml
@@ -6,6 +6,11 @@
     - drupal_db_password: 'drupal'
     - force_settings: false
     - drupal_web_owner: 'www-data'
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/researchdata"
       include_role:

--- a/roles/rvm/molecule/default/converge.yml
+++ b/roles/rvm/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/rvm"
       include_role:

--- a/roles/special_collections/molecule/default/converge.yml
+++ b/roles/special_collections/molecule/default/converge.yml
@@ -5,6 +5,11 @@
     - running_on_server: false
     - mysql_server: true
     - mysql_root_password: 'change_me'
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include roles/molecule_mariadb"
       include_role:

--- a/roles/studio_proc/molecule/default/converge.yml
+++ b/roles/studio_proc/molecule/default/converge.yml
@@ -4,6 +4,11 @@
   vars:
     - running_on_server: false
   become: true
+  pre_tasks:
+    - name: update cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "studio_proc"
       include_role:


### PR DESCRIPTION
Partial fix for #3013.

Without a pre-task to update the cache, the common role usually fails with `fatal: [instance]: FAILED! => {"changed": false, "msg": "No package matching 'htop' is available"}`. So we need to update the cache explicitly for testing before we can remove the `update_cache: true` settings from tasks within various roles.