### PR TITLE
Update drupal9 and PHP roles to pass CI

### DIFF
--- a/roles/drupal9/defaults/main.yml
+++ b/roles/drupal9/defaults/main.yml
@@ -13,3 +13,4 @@ drupal_base_dir: '/var/www'
 drupal_project: 'drupal9'
 drupal_docroot: "{{ drupal_base_dir }}/{{ drupal_project }}"
 php_version: '7.4'
+php_webserver: 'apache2'

--- a/roles/drupal9/defaults/main.yml
+++ b/roles/drupal9/defaults/main.yml
@@ -13,3 +13,4 @@ drupal_base_dir: '/var/www'
 drupal_project: 'drupal9'
 drupal_docroot: "{{ drupal_base_dir }}/{{ drupal_project }}"
 php_version: '7.4'
+php_webserver: 'nginx'

--- a/roles/drupal9/defaults/main.yml
+++ b/roles/drupal9/defaults/main.yml
@@ -13,4 +13,3 @@ drupal_base_dir: '/var/www'
 drupal_project: 'drupal9'
 drupal_docroot: "{{ drupal_base_dir }}/{{ drupal_project }}"
 php_version: '7.4'
-php_webserver: 'apache2'

--- a/roles/drupal9/meta/main.yml
+++ b/roles/drupal9/meta/main.yml
@@ -20,5 +20,6 @@ dependencies:
   - role: nodejs
   - role: composer
   - role: postgresql
-  - role: nginxplus
+# nginxplus role runs as a dependency of the PHP role
+#   - role: nginxplus
   - role: capistrano

--- a/roles/drupal9/molecule/default/converge.yml
+++ b/roles/drupal9/molecule/default/converge.yml
@@ -9,7 +9,6 @@
     - systems_user: 'deploy'
     - force_settings: false
     - running_on_server: false
-    - php_webserver: 'apache2'
   pre_tasks:
     - name: update cache
       apt:

--- a/roles/drupal9/molecule/default/converge.yml
+++ b/roles/drupal9/molecule/default/converge.yml
@@ -9,6 +9,7 @@
     - systems_user: 'deploy'
     - force_settings: false
     - running_on_server: false
+    - php_webserver: 'apache2'
   pre_tasks:
     - name: update cache
       apt:

--- a/roles/drupal9/tasks/main.yml
+++ b/roles/drupal9/tasks/main.yml
@@ -88,13 +88,18 @@
     mode: 0644
   notify: Restart NGINX
 
-- name: drupal9 | install npm for git actions
-  ansible.builtin.apt:
-    name: ["nodejs", "nodejs-dev", "node-gyp", "libssl1.0-dev"]
-    state: build-dep
-    update_cache: true
-  changed_when: false
-  when: not running_on_server
+# If you install nodejs-dev with apt, it uninstalls php7.4-dev
+# So we cannot install both with apt
+# Commenting this task out, we will install node
+# using the NodeJS role
+#
+# - name: drupal9 | install npm for git actions
+#   ansible.builtin.apt:
+#     name: ["nodejs", "nodejs-dev", "node-gyp", "libssl1.0-dev"]
+#     state: build-dep
+#     update_cache: true
+#   changed_when: false
+#   when: not running_on_server
 
 - name: drupal9 | install php packages
   ansible.builtin.apt:

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -11,7 +11,7 @@
     enabled: true
     state: restarted
 
-- name: restart apache
+- name: restart apache2
   service:
     name: apache2
     enabled: true

--- a/roles/php/tasks/configure-apache2.yml
+++ b/roles/php/tasks/configure-apache2.yml
@@ -30,4 +30,4 @@
   apache2_module:
     state: present
     name: php{{ php_version }}
-  notify: restart apache
+  notify: restart {{ php_webserver }}

--- a/roles/php/tasks/configure-nginx.yml
+++ b/roles/php/tasks/configure-nginx.yml
@@ -17,7 +17,6 @@
   apt:
     name: "php{{ php_version }}-fpm"
     state: present
-    update_cache: true
 
 - name: uninstall Apache
   apt:

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -17,11 +17,11 @@
 - name: php | install php
   apt:
     name: ["php{{ php_version }}", "php{{ php_version }}-dev", "php{{ php_version }}-curl", "php{{ php_version }}-zip"]
-    state: latest
+    state: present
     update_cache: true
   changed_when: false
   tags: ['skip_ansible_lint']
-  notify: restart apache
+  notify: restart {{ php_webserver }}
 
 - name: php | Install datadog trace php repository
   apt:
@@ -30,7 +30,7 @@
     update_cache: true
   when: datadog_enabled
 
-- include_tasks: configure.yml
+- include_tasks: configure-apache2.yml
   when: php_webserver == 'apache2'
 
 - include_tasks: configure-nginx.yml

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -18,8 +18,6 @@
   apt:
     name: ["php{{ php_version }}", "php{{ php_version }}-dev", "php{{ php_version }}-curl", "php{{ php_version }}-zip"]
     state: present
-    update_cache: true
-  changed_when: false
   tags: ['skip_ansible_lint']
   notify: restart {{ php_webserver }}
 


### PR DESCRIPTION
A first attempt to fix #3013 ran into an idempotence failure on the `drupal9` role. This turned out be caused by a conflict in apt. You cannot install both `nodejs-dev` and `php7.4-dev` with apt - when you install the second one, apt uninstalls the first one.

We agreed to install NodeJS from source rather than as an apt package.

Fixing this problem uncovered a failure in the PHP role. Although the role accepted either apache2 or nginx as its webserver, some tasks hardcoded apache2 as the server to restart.

This PR fixes both of these issues.