### PR TITLE
reduces number of mysql logs we send to datadog

### DIFF
--- a/group_vars/mysql/production.yml
+++ b/group_vars/mysql/production.yml
@@ -25,18 +25,21 @@ datadog_typed_checks:
           service: mysql-database-service
           source: mysql
 
-        - type: file
-          path: /var/log/mysql/mysql_slow.log
-          service: mysql-database-service
-          source: mysql
-          log_processing_rules:
-            - type: multi_line
-              name: new_slow_query_log_entry
-              pattern: "# Time:"
-              # If mysqld was started with `--log-short-format`, use:
-              # pattern: "# Query_time:"
-
-        - type: file
-          path: /var/log/mysql/mysql.log
-          service: mysql-database-service
-          source: mysql
+        # removing these logs from datadog to reduce our bill
+        # leaving comments in case we need to reinstate them for debugging
+        #
+        # - type: file
+        #   path: /var/log/mysql/mysql_slow.log
+        #   service: mysql-database-service
+        #   source: mysql
+        #   log_processing_rules:
+        #     - type: multi_line
+        #       name: new_slow_query_log_entry
+        #       pattern: "# Time:"
+        #       # If mysqld was started with `--log-short-format`, use:
+        #       # pattern: "# Query_time:"
+        # 
+        # - type: file
+        #   path: /var/log/mysql/mysql.log
+        #   service: mysql-database-service
+        #   source: mysql


### PR DESCRIPTION
We have seen >800K logs sent from mysql to datadog, compared to <36K for other things we monitor. The additional logging may have been added for a debugging session at some point and never removed. We are not using it intensively enough (at all?) to justify the added cost.

The PR would stop sending everything except the error logs. @kayiwa does that seem like the right thing, at least for now?
