### PR TITLE
triggers an nginx restart when new config gets loaded

### DIFF
--- a/roles/rails_app/handlers/main.yml
+++ b/roles/rails_app/handlers/main.yml
@@ -1,1 +1,5 @@
 ---
+- name: restart nginx
+  ansible.builtin.service:
+    name: nginx
+    state: restarted

--- a/roles/rails_app/tasks/main.yml
+++ b/roles/rails_app/tasks/main.yml
@@ -23,6 +23,7 @@
     mode: 0644
   tags:
     - site_config
+  notify: restart nginx
 
 - name: rails_app | load envvars from app_configs directory
   ansible.builtin.lineinfile:


### PR DESCRIPTION
Closes #3257.

Adds a handler for restarting nginx to the rails_app role. With this in place we should be able to use the `site_config` tag to refresh configuration without running the entire rails_app role and all of its dependencies, but still restart nginx to use the new config.
