### PR TITLE
add a redirect to the legacy hc3 website

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_test_web.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_web.conf
@@ -68,8 +68,6 @@ server {
         deny all;
     }
 
-    location /hc3 {
-        return 301 https://hc3-test.princeton.edu$request_uri;
-    }
+    include /etc/nginx/conf.d/templates/cdh_hc3.conf;
     include /etc/nginx/conf.d/templates/staging-maintenance.conf;
 }

--- a/roles/nginxplus/files/conf/http/templates/cdh_hc3.conf
+++ b/roles/nginxplus/files/conf/http/templates/cdh_hc3.conf
@@ -1,0 +1,1 @@
+rewrite ^/hc3(.*)$ https://hc3.psb-prod.princeton.edu/ redirect;


### PR DESCRIPTION
There is a need to preserve access to the old hc3 CMS
