### PR TITLE
updates ruby_s role to support upgrades, ease idempotency

### DIFF
--- a/roles/ruby_s/README.md
+++ b/roles/ruby_s/README.md
@@ -1,6 +1,6 @@
 ## Ruby
 
-Builds Ruby from source
+Builds, upgrades, or downgrades Ruby from source, ensuring you have the correct version of Ruby.
 
 ### Requirements
 
@@ -8,27 +8,27 @@ None
 
 ### Role Variables
 
-if you need a different version of ruby use the example on
+Installs the value of `ruby_version_default` by default. If you need a different version of ruby, set `ruby_version_override` using the pattern `ruby-x.y.z`. 
 
-`defaults/main.yml`
+e.g `ruby_version_override: ruby-3.0.0`
 
-e.g `desired_ruby_version: "3.0.0"` and `ruby_version_override: ruby-3.0.0`
+This is most reliably set in your `group_vars/<your_role>/[common|main].yml`
 
-this is most reliably set in your `group_vars/<your_role>/vars.yml`
+### Upgrading from Ruby 2.x installed with apt
 
-### Upgrading from Ruby 2.x
-
-If you are upgrading a system from a previous ansible build that used brightbox
-ruby packages (which is probably the case for anything at PUL using ruby 2.x): 
+If you are upgrading a system from a previous ansible build that used the `ruby` role
+to install ruby from the brightbox ruby packages (PPAs) using apt, which is probably
+the case for anything at PUL using ruby 2.x:
 
 * In `group_vars/<your project>/[common|main].yml`:
-  * If `passenger_ruby` is set, remove it. The default value is `/usr/local/bin/ruby` and that's what we want.
+  * If `passenger_ruby` is set, update it to `/usr/local/bin/ruby`. Current default setting in the passenger role is `/usr/bin/ruby` - eventually we should update that!
   * Update these values:
   ```
   # Use Ruby 3.0.3 and install from source
   install_ruby_from_source: true
   ruby_version_override: "ruby-3.0.3"
   bundler_version: "2.3.11"
+  passenger_ruby: "/usr/local/bin/ruby"
   ```
 * Make sure you update your project to use bundler 2.3.11 and re-generate Gemfile.lock
 

--- a/roles/ruby_s/defaults/main.yml
+++ b/roles/ruby_s/defaults/main.yml
@@ -4,4 +4,4 @@ ruby_version: "{{ ruby_version_override | default(ruby_version_default) }}"
 ruby_version_default: "ruby-2.7.0"
 ubuntu_ruby_version: "{{ ubuntu_ruby_version_override | default(ubuntu_ruby_version_default) }}"
 ubuntu_ruby_version_default: "ruby2.7"
-desired_ruby_version: "2.7.0"
+install_path: /opt/install

--- a/roles/ruby_s/tasks/cleanup.yml
+++ b/roles/ruby_s/tasks/cleanup.yml
@@ -3,11 +3,15 @@
   community.general.gem:
     name: bundler
     state: absent
-  changed_when: false
 
-- name: ruby | remove installed ruby
+- name: ruby | check for apt-installed rubies
+  ansible.builtin.package_facts:
+    manager: apt
+  register: all_packages
+
+- name: ruby | remove any package that begins with 'ruby'
   ansible.builtin.apt:
-    name: ["{{ ubuntu_ruby_version }}", "{{ ubuntu_ruby_version }}-dev", "ruby-switch"]
+    name: "{{ ansible_facts.packages | list | select('match', '^ruby') }}"
     state: absent
 
 - name: ruby | remove the Brightbox repository
@@ -20,6 +24,5 @@
     name: bundler
     state: absent
     user_install: false
-  changed_when: false
   when:
     - bundler_version is defined

--- a/roles/ruby_s/tasks/install_from_source.yml
+++ b/roles/ruby_s/tasks/install_from_source.yml
@@ -1,0 +1,83 @@
+---
+- name: ruby | lookup download path and checksum from ruby-lang release index
+  ansible.builtin.shell: curl https://cache.ruby-lang.org/pub/ruby/index.txt | grep {{ ruby_version }}.tar.gz
+  register: ruby_index_line
+
+- name: ruby | separate index entry values
+  ansible.builtin.set_fact:
+    ruby_values: "{{ ruby_index_line.stdout | regex_findall('(\\S+)') }}"
+
+- name: ruby | get ruby url
+  ansible.builtin.set_fact:
+    ruby_gzip_url: "{{ ruby_values[1] }}"
+
+- name: ruby | get ruby checksum
+  ansible.builtin.set_fact:
+    ruby_sha_256: "{{ ruby_values[3] }}"
+
+- name: ruby | ensure install path exists
+  ansible.builtin.file:
+    path: "{{ install_path }}"
+    state: directory
+    mode: 0644
+
+# the next two tasks find and uninstall previous ruby versions
+# installed from source, to allow upgrading/downgrading from one
+# ruby version installed from source to another
+- name: ruby | look for ruby installed from source
+  ansible.builtin.find:
+    paths: "{{ install_path }}"
+    file_type: directory
+    patterns: "^ruby"
+    use_regex: true
+  register: source_rubies
+
+- name: ruby | uninstall any ruby installed from source
+  ansible.builtin.shell: cd {{ item.path }} && make uninstall
+  loop: "{{ source_rubies.files }}"
+  when: source_rubies.matched > 0
+
+- name: ruby | download ruby
+  ansible.builtin.get_url:
+    url: "{{ ruby_gzip_url }}"
+    checksum: "sha256:{{ ruby_sha_256 }}"
+    dest: "{{ install_path }}/{{ ruby_version }}.tar.gz"
+
+- name: ruby | unzip ruby file
+  ansible.builtin.unarchive:
+    src: "{{ install_path }}/{{ ruby_version }}.tar.gz"
+    dest: "{{ install_path }}/"
+    creates: "{{ install_path }}/{{ ruby_version }}/compile.c"
+    copy: false
+
+- name: ruby | configure ruby
+  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && ./configure --enable-shared
+
+- name: ruby | make ruby
+  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make
+
+- name: ruby | install ruby
+  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make install
+  become: true
+
+- name: ruby | uninstall wrong version of bundler
+  community.general.gem:
+    name: bundler
+    state: absent
+
+- name: ruby | install global bundler, specific version
+  community.general.gem:
+    name: bundler
+    version: "{{ bundler_version }}"
+    user_install: false
+  when: bundler_version is defined
+
+- name: ruby | install global bundler, any version
+  community.general.gem:
+    name: bundler
+    user_install: false
+  when: bundler_version is undefined
+
+- name: ruby | update rubygems
+  ansible.builtin.command: gem update --system
+  become: true

--- a/roles/ruby_s/tasks/main.yml
+++ b/roles/ruby_s/tasks/main.yml
@@ -1,84 +1,23 @@
 ---
-- name: ruby | check version
+- name: ruby | check existing ruby version
   ansible.builtin.shell: ruby -v | awk "{print $2}"
   register: installed_ruby
   changed_when: false
 
-- name: prints out the installed_ruby variables
-  ansible.builtin.debug:
-    msg: ruby version "{{ installed_ruby.stdout }}"
-
-- include_tasks: cleanup.yml
+# our test env does not have ruby installed
+# only run cleanup when ruby is installed AND it's the wrong version
+- name: ruby | remove wrong ruby versions with apt
+  ansible.builtin.include_tasks: cleanup.yml
   when:
-    - installed_ruby.stdout | length > 0 and installed_ruby.stdout != "{{ desired_ruby_version }}"
+    - installed_ruby.stderr is not search("not found")
+    # installed_ruby.stdout contains something like
+    # 'ruby 2.7.0p243 (2018-12-21 revision . . . )'
+    # ruby_version contains something like 'ruby-3.1.0'
+    # regex pulls out x.y.z to compare '2.7.0' to '3.1.0'
+    - installed_ruby.stdout | regex_search('\d+\.\d+\.\d+') != ruby_version | regex_search('\d+\.\d+\.\d+')
 
-- name: ruby |lookup download path and checksum from ruby-lang release index
-  ansible.builtin.shell: curl https://cache.ruby-lang.org/pub/ruby/index.txt | grep {{ ruby_version }}.tar.gz
-  register: ruby_index_line
-  changed_when: false
-
-- name: ruby | separate index entry values
-  ansible.builtin.set_fact:
-    ruby_values: "{{ ruby_index_line.stdout | regex_findall('(\\S+)') }}"
-
-- name: get ruby url
-  ansible.builtin.set_fact:
-    ruby_gzip_url: "{{ ruby_values[1] }}"
-
-- name: get ruby checksum
-  ansible.builtin.set_fact:
-    ruby_sha_256: "{{ ruby_values[3] }}"
-
-- name: ruby | setup install directory
-  ansible.builtin.set_fact:
-    install_path: "/opt/install"
-
-- name: ruby | ensure install directory exists
-  ansible.builtin.file:
-    path: "{{ install_path }}"
-    state: directory
-    mode: 0644
-
-- name: ruby | download ruby
-  ansible.builtin.get_url:
-    url: "{{ ruby_gzip_url }}"
-    checksum: "sha256:{{ ruby_sha_256 }}"
-    dest: "{{ install_path }}/{{ ruby_version }}.tar.gz"
-
-- name: ruby | unzip ruby file
-  ansible.builtin.unarchive:
-    src: "{{ install_path }}/{{ ruby_version }}.tar.gz"
-    dest: "{{ install_path }}/"
-    creates: "{{ install_path }}/{{ ruby_version }}/compile.c"
-    copy: false
-
-- name: ruby | configure ruby
-  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && ./configure --enable-shared creates={{ install_path }}/{{ ruby_version }}/Makefile
-
-- name: ruby | make ruby
-  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make
-  changed_when: false
-
-- name: ruby | install ruby
-  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make install
-  become: true
-  changed_when: false
-
-- name: ruby | update rubygems
-  ansible.builtin.command: gem update --system
-  become: true
-  changed_when: false
-
-- name: ruby | install global bundler, specific version
-  community.general.gem:
-    name: bundler
-    version: "{{ bundler_version }}"
-    user_install: false
-  when: bundler_version is defined
-  changed_when: false
-
-- name: ruby | install global bundler, any version
-  community.general.gem:
-    name: bundler
-    user_install: false
-  when: bundler_version is undefined
+# install from source when ruby is not installed OR it's the wrong version
+- name: ruby | install, upgrade, or downgrade ruby from source
+  ansible.builtin.include_tasks: install_from_source.yml
+  when:
+    - (installed_ruby.stderr is search("not found")) or (installed_ruby.stdout | regex_search('\d+\.\d+\.\d+') != ruby_version | regex_search('\d+\.\d+\.\d+'))


### PR DESCRIPTION
Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>

Closes #3317.

This PR uses a single commit for a bunch of work that was previously done on #3373. We are disentangling the changes to the `ruby_s` role from the changes to bibdata, so we can upgrade ruby on other projects from the `main` branch.

Changes include:
- removes all apt packages that begin with `ruby`, so we don't have to know what version was installed by apt
- adds a check for the existing ruby version
- only installs from source when the existing ruby version is different from the desired ruby version
- moves the shell tasks (for building ruby from source) into the conditional tasks file so we can remove `changed_when: false` and still pass idempotency testing
- adds a make uninstall step so the role can upgrade/downgrade ruby when ruby was previously installed from source
