### PR TITLE
Make the geoserver playbook non-destructive

### DIFF
--- a/playbooks/geoserver_production.yml
+++ b/playbooks/geoserver_production.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: geoserver
+- name: install geoserver
+  hosts: geoserver
   remote_user: pulsys
   become: true
   vars_files:
@@ -14,7 +15,7 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts

--- a/roles/geoserver/defaults/main.yml
+++ b/roles/geoserver/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # defaults file for roles/geoserver
 geoserver_version: "2.15.2"
-geoserver_file: "geoserver-{{ geoserver_version }}-war.zip"
+geoserver_zip: "geoserver-{{ geoserver_version }}-war.zip"
+geoserver_file: "geoserver-{{ geoserver_version }}-war"
 # APT settings
 postgresql_apt_key_id: ACCC4CF8
 postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"

--- a/roles/geoserver/defaults/main.yml
+++ b/roles/geoserver/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for roles/geoserver
 geoserver_version: "2.15.2"
+# zip files for later geoserver versions omit the '-war'
+# see, for example, https://pulmirror.princeton.edu/mirror/geoserver/2.16.5/
 geoserver_zip: "geoserver-{{ geoserver_version }}-war.zip"
 geoserver_file: "geoserver-{{ geoserver_version }}-war"
 # APT settings

--- a/roles/geoserver/meta/main.yml
+++ b/roles/geoserver/meta/main.yml
@@ -9,13 +9,14 @@ galaxy_info:
 
   min_ansible_version: 2.9
 
-
   platforms:
     - name: Ubuntu
       versions:
         - 18.04
 
-
 dependencies:
+  # the playbook runs five roles in this order:
+  # tomcat8, deploy_user, postgresql, samba, and geoserver
+  # do we need to update this file? 
   - role: deploy_user
   - role: tomcat8

--- a/roles/geoserver/meta/main.yml
+++ b/roles/geoserver/meta/main.yml
@@ -17,6 +17,6 @@ galaxy_info:
 dependencies:
   # the playbook runs five roles in this order:
   # tomcat8, deploy_user, postgresql, samba, and geoserver
-  # do we need to update this file? 
+  # do we need to update this file?
   - role: deploy_user
   - role: tomcat8

--- a/roles/geoserver/tasks/main.yml
+++ b/roles/geoserver/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: check geoserver_version
   ansible.builtin.stat:
-    path: /var/lib/tomcat8/webapps/{{ geoserver_file }}
+    path: /opt/{{ geoserver_zip }}
   register: current_geoserver_file
 
 - name: install or upgrade geoserver if necessary

--- a/roles/geoserver/tasks/main.yml
+++ b/roles/geoserver/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-- name: download geoserver war file
-  ansible.builtin.get_url:
-    url: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
-    dest: /var/lib/tomcat8/webapps/{{ geoserver_file }}
+- name: check geoserver_version
+  ansible.builtin.stat:
+    path: /var/lib/tomcat8/webapps/{{ geoserver_file }}
   register: current_geoserver_file
 
 - name: install or upgrade geoserver if necessary
   ansible.builtin.include_tasks:
     file: upgrade_geoserver.yml
-  when: current_geoserver_file.changed
+  when: not current_geoserver_file.stat.exists

--- a/roles/geoserver/tasks/main.yml
+++ b/roles/geoserver/tasks/main.yml
@@ -1,53 +1,10 @@
 ---
-- name: stop tomcat server
-  service:
-    name: tomcat8
-    state: stopped
-  changed_when: false
+- name: check geoserver_version
+  ansible.builtin.stat:
+    path: /var/lib/tomcat8/webapps/{{ geoserver_version }}/{{ geoserver_file }}
+  register: current_geoserver_file
 
-- name: unarchive war file
-  unarchive:
-    src: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
-    dest: /var/lib/tomcat8/webapps
-    remote_src: true
-  notify:
-    - restart tomcat
-  changed_when: false
-
-- name: Configure postgresql repository key
-  apt_key:
-    url: "{{ postgresql_apt_key_url }}"
-
-- name: Configure postgresql repository
-  apt_repository:
-    repo: "{{ postgresql_apt_repo }}"
-
-- name: add postgresql repository
-  apt_repository:
-    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main'
-    state: present
-
-- name: install postgis software
-  apt:
-    name: ["postgresql-10-postgis-2.4", "postgis", "postgresql-10-pgrouting"]
-    state: present
-  notify:
-    - restart postgresql
-
-- name: Create symlinks
-  file:
-    src: '{{ item.src }}'
-    dest: '{{ item.link }}'
-    owner: '{{ deploy_user }}'
-    group: '{{ deploy_user }}'
-    state: 'link'
-    force: true
-  with_items:
-    - src: '/srv/shares/plum_geo_data'
-      link: '/var/lib/tomcat8/webapps/geoserver/data/plum_geo_data'
-    - src: '/srv/shares/figgy_geo_data'
-      link: '/var/lib/tomcat8/webapps/geoserver/data/figgy_geo_data'
-    - src: '/mnt/libimages2/data/jp2s/plum_prod'
-      link: '/var/lib/tomcat8/webapps/geoserver/data/plum_prod'
-  when: running_on_server
-  changed_when: false
+- name: install or upgrade geoserver if necessary
+  ansible.builtin.include_tasks:
+    file: upgrade_geoserver.yml
+  when: not current_geoserver_file.stat.exists

--- a/roles/geoserver/tasks/main.yml
+++ b/roles/geoserver/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
-- name: check geoserver_version
-  ansible.builtin.stat:
-    path: /var/lib/tomcat8/webapps/{{ geoserver_version }}/{{ geoserver_file }}
+- name: download geoserver war file
+  ansible.builtin.get_url:
+    url: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
+    dest: /var/lib/tomcat8/webapps/{{ geoserver_file }}
   register: current_geoserver_file
 
 - name: install or upgrade geoserver if necessary
   ansible.builtin.include_tasks:
     file: upgrade_geoserver.yml
-  when: not current_geoserver_file.stat.exists
+  when: current_geoserver_file.changed

--- a/roles/geoserver/tasks/upgrade_geoserver.yml
+++ b/roles/geoserver/tasks/upgrade_geoserver.yml
@@ -1,4 +1,9 @@
 ---
+# - name: download geoserver war file
+#   ansible.builtin.get_url:
+#     url: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
+#     dest: /var/lib/tomcat8/webapps/{{ geoserver_file }}
+
 # do we need to stop the tomcat server?
 # or is restarting afterwards enough?
 - name: stop tomcat server

--- a/roles/geoserver/tasks/upgrade_geoserver.yml
+++ b/roles/geoserver/tasks/upgrade_geoserver.yml
@@ -1,0 +1,53 @@
+---
+# do we need to stop the tomcat server?
+# or is restarting afterwards enough?
+- name: stop tomcat server
+  service:
+    name: tomcat8
+    state: stopped
+
+- name: unarchive war file
+  unarchive:
+    src: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
+    dest: /var/lib/tomcat8/webapps
+    remote_src: true
+  notify:
+    - restart tomcat
+
+- name: Configure postgresql repository key
+  apt_key:
+    url: "{{ postgresql_apt_key_url }}"
+
+- name: Configure postgresql repository
+  apt_repository:
+    repo: "{{ postgresql_apt_repo }}"
+
+- name: add postgresql repository
+  apt_repository:
+    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main'
+    state: present
+
+# are these versions going to change in future?
+- name: install postgis software
+  apt:
+    name: ["postgresql-10-postgis-2.4", "postgis", "postgresql-10-pgrouting"]
+    state: present
+  notify:
+    - restart postgresql
+
+- name: Create symlinks
+  file:
+    src: '{{ item.src }}'
+    dest: '{{ item.link }}'
+    owner: '{{ deploy_user }}'
+    group: '{{ deploy_user }}'
+    state: 'link'
+    force: true
+  with_items:
+    - src: '/srv/shares/plum_geo_data'
+      link: '/var/lib/tomcat8/webapps/geoserver/data/plum_geo_data'
+    - src: '/srv/shares/figgy_geo_data'
+      link: '/var/lib/tomcat8/webapps/geoserver/data/figgy_geo_data'
+    - src: '/mnt/libimages2/data/jp2s/plum_prod'
+      link: '/var/lib/tomcat8/webapps/geoserver/data/plum_prod'
+  when: running_on_server

--- a/roles/geoserver/tasks/upgrade_geoserver.yml
+++ b/roles/geoserver/tasks/upgrade_geoserver.yml
@@ -11,9 +11,13 @@
     name: tomcat8
     state: stopped
 
+# using this task, the zip file is not preserved, and we end up 
+# with unversioned files in /var/lib/tomcat8
+# need some way (download separately? touch a file?) to preserve the 
+# version so we can check it
 - name: unarchive war file
   unarchive:
-    src: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
+    src: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_zip }}"
     dest: /var/lib/tomcat8/webapps
     remote_src: true
   notify:

--- a/roles/geoserver/tasks/upgrade_geoserver.yml
+++ b/roles/geoserver/tasks/upgrade_geoserver.yml
@@ -1,8 +1,8 @@
 ---
-# - name: download geoserver war file
-#   ansible.builtin.get_url:
-#     url: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_file }}"
-#     dest: /var/lib/tomcat8/webapps/{{ geoserver_file }}
+- name: download geoserver war file
+  ansible.builtin.get_url:
+    url: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_zip }}"
+    dest: /opt/{{ geoserver_zip }}
 
 # do we need to stop the tomcat server?
 # or is restarting afterwards enough?
@@ -11,13 +11,9 @@
     name: tomcat8
     state: stopped
 
-# using this task, the zip file is not preserved, and we end up 
-# with unversioned files in /var/lib/tomcat8
-# need some way (download separately? touch a file?) to preserve the 
-# version so we can check it
 - name: unarchive war file
   unarchive:
-    src: "{{ geoserver_url }}/{{ geoserver_version }}/{{ geoserver_zip }}"
+    src: /opt/{{ geoserver_zip }}
     dest: /var/lib/tomcat8/webapps
     remote_src: true
   notify:


### PR DESCRIPTION
Closes #214.

Makes the download step explicit.
Checks the version of the download.
Moves the install tasks into a separate tasks file.
Skips the install tasks unless the playbook downloads a different version of geoserver.

I'm making this a draft PR because I'm not sure which tasks were destructive. But this PR will address the obvious challenges I see in the role and playbook.