### PR TITLE
the ruby_s role occasionally fails idempotence

### DIFF
--- a/roles/ruby_s/molecule/default/converge.yml
+++ b/roles/ruby_s/molecule/default/converge.yml
@@ -6,10 +6,9 @@
   become: true
   pre_tasks:
     - name: update cache
-      apt:
+      ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: 600
   tasks:
-    - name: "Include ruby"
-      include_role:
+    - name: "Include ruby_s"
+      ansible.builtin.include_role:
         name: ruby_s


### PR DESCRIPTION
the role will occasionally run longer than the alloted 10 minutes and
will subsequently fail idempotence.

I am unable to find the pattern for this and certainly not on CI.

Connected to #3455.
