### PR TITLE
allow PHP*-xml version for OJS to change

### DIFF
--- a/roles/ojs/tasks/install_prerequisites.yml
+++ b/roles/ojs/tasks/install_prerequisites.yml
@@ -11,7 +11,7 @@
 
 - name: ojs | install php xml libraries
   apt:
-    name: ["php7.4-xml"]
+    name: ["php{{ php_version }}-xml"]
     state: present
 
 - name: ojs | install php postgres drivers


### PR DESCRIPTION
With `php7.4-xml` hard-coded, the OJS role fails idempotency.

Since the default version of PHP for all other related modules is already 8.1, this PR updates the XML package to match (and also to handle future upgrades).

Related to #3490, where the failure first showed up.

Co-authored-by: Max Kadel <maxkadel@users.noreply.github.com>