### PR TITLE
updates rapid7 after testing on sandbox vms

### DIFF
--- a/inventory/by_environment/sandbox
+++ b/inventory/by_environment/sandbox
@@ -1,3 +1,3 @@
 [sandbox]
-sandbox-acozine
-sandbox-vkarasic
+sandbox-acozine.lib.princeton.edu
+sandbox-vkarasic.lib.princeton.edu

--- a/playbooks/rapid7_install.yml
+++ b/playbooks/rapid7_install.yml
@@ -22,16 +22,3 @@
 
   - name: Execute Rapid 7 install script
     ansible.builtin.shell: sudo /opt/rapid7/Rapid7_agent_installer.sh install_start --token {{ vault_Rapid7_token }} --attributes="library"
-
-  # - name: Set Rapid 7 service to restart on reboot
-  #   module:
-  #     param: "{{ if_param_starts_with_var }}"
-  #     param2: 2048
-  #     param3: RSA
-  #
-  # - name: Confirm that Rapid 7 agent is running
-  #   module:
-  #     param: "{{ if_param_starts_with_var }}"
-  #     param2: 2048
-  #     param3: RSA
-  #

--- a/playbooks/rapid7_install.yml
+++ b/playbooks/rapid7_install.yml
@@ -25,10 +25,6 @@
       path: /opt/rapid7/ir_agent
     register: rapid7_status
 
-  - name: What is in rapid7_status
-    ansible.builtin.debug:
-      var: rapid7_status
-
   - name: Execute Rapid7 install script
     ansible.builtin.shell: sudo /opt/rapid7/Rapid7_agent_installer.sh install_start --token {{ vault_Rapid7_token }} --attributes="library"
     when: rapid7_status.stat.isdir == false

--- a/playbooks/rapid7_install.yml
+++ b/playbooks/rapid7_install.yml
@@ -31,4 +31,4 @@
 
   - name: Execute Rapid7 install script
     ansible.builtin.shell: sudo /opt/rapid7/Rapid7_agent_installer.sh install_start --token {{ vault_Rapid7_token }} --attributes="library"
-    when: rapid7_status.todo
+    when: rapid7_status.stat.isdir == false

--- a/playbooks/rapid7_install.yml
+++ b/playbooks/rapid7_install.yml
@@ -1,17 +1,17 @@
 ---
-# installs the Rapid 7 agent
+# installs the Rapid7 agent
 # By default this runs on all staging machines. To run on other machines, pass the group on which you want to install the agent at the command line
 # Example:
 # ansible-playbook -e runtime_env=qa playbooks/rapid7_install.yml
 #
 #
-- name: Install Rapid 7 agent
+- name: Install Rapid7 agent
   hosts: "{{ runtime_env | default('staging') }}"
   vars_files:
     - ../group_vars/all/vault.yml
 
   tasks:
-  - name: Copy Rapid 7 install script to box
+  - name: Copy Rapid7 install script to box
     ansible.builtin.copy:
       src: ../bin/Rapid7_agent_installer.sh
       dest: /opt/rapid7/
@@ -20,5 +20,15 @@
       mode: '0744'
     become: true
 
-  - name: Execute Rapid 7 install script
+  - name: Check if Rapid7 is installed
+    ansible.builtin.stat:
+      path: /opt/rapid7/ir_agent
+    register: rapid7_status
+
+  - name: What is in rapid7_status
+    ansible.builtin.debug:
+      var: rapid7_status
+
+  - name: Execute Rapid7 install script
     ansible.builtin.shell: sudo /opt/rapid7/Rapid7_agent_installer.sh install_start --token {{ vault_Rapid7_token }} --attributes="library"
+    when: rapid7_status.todo


### PR DESCRIPTION
We installed Rapid7 on a sandbox machine and tried rebooting it, and the Rapid7 agent restarted successfully. Removing the dummy tasks in the playbook. 