### PR TITLE
Ealapps cron jobs

### DIFF
--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -94,4 +94,3 @@
     minute: "0"
     hour: "1"
     job: "cd /var/www/ealapps/current/newtitles; php newtitles.cron.php > files/newtitles.cron.xml 2> /dev/null"
-    

--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -81,18 +81,18 @@
 
 - name: ealapps | add hishi cron job
   ansible.builtin.cron:
-    name: hishi
-    weekday: 1-5
-    minute: 0
-    hour: 1
+    name: "generate hishi.json"
+    weekday: "1-5"
+    minute: "0"
+    hour: "1"
     job: "cd /var/www/ealapps/current/hishi; php hishiDownload.php > hishi.json 2> /dev/null"
 
 - name: ealapps | add newtitles cron job
   ansible.builtin.cron:
-    name: hishi
-    weekday: 1-5
-    minute: 0
-    hour: 1
+    name: "generate newtitles.cron.xml"
+    weekday: "1-5"
+    minute: "0"
+    hour: "1"
     job: "cd /var/www/ealapps/current/newtitles; php newtitles.cron.php > files/newtitles.cron.xml 2> /dev/null"
 
 

--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -94,6 +94,4 @@
     minute: "0"
     hour: "1"
     job: "cd /var/www/ealapps/current/newtitles; php newtitles.cron.php > files/newtitles.cron.xml 2> /dev/null"
-
-
-
+    

--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -78,3 +78,22 @@
   become: true
   register: apache2_disable
   changed_when: '"disabled." in apache2_disable.stdout'
+
+- name: ealapps | add hishi cron job
+  ansible.builtin.cron:
+    name: hishi
+    weekday: 1-5
+    minute: 0
+    hour: 1
+    job: "cd /var/www/ealapps/current/hishi; php hishiDownload.php > hishi.json 2> /dev/null"
+
+- name: ealapps | add newtitles cron job
+  ansible.builtin.cron:
+    name: hishi
+    weekday: 1-5
+    minute: 0
+    hour: 1
+    job: "cd /var/www/ealapps/current/newtitles; php newtitles.cron.php > files/newtitles.cron.xml 2> /dev/null"
+
+
+

--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -85,7 +85,8 @@
     weekday: "1-5"
     minute: "0"
     hour: "1"
-    job: "cd /var/www/ealapps/current/hishi; php hishiDownload.php > hishi.json 2> /dev/null"
+    user: deploy
+    job: "php /var/www/ealapps/current/hishi/hishiDownload.php > /var/www/ealapps/shared/hishi/hishi.json 2> /dev/null"
 
 - name: ealapps | add newtitles cron job
   ansible.builtin.cron:
@@ -93,4 +94,5 @@
     weekday: "1-5"
     minute: "0"
     hour: "1"
-    job: "cd /var/www/ealapps/current/newtitles; php newtitles.cron.php > files/newtitles.cron.xml 2> /dev/null"
+    user: deploy
+    job: "php /var/www/ealapps/current/newtitles/newtitles.cron.php >  /var/www/ealapps/shared/newtitles/files/newtitles.cron.xml 2> /dev/null"


### PR DESCRIPTION
Uses the ansible.builtin.cron module to create cron jobs for ealapps.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html

All tests passed.  I want to confirm that the files were generated correctly before finalizing this (will do so first thing on Thu 12/8).