### PR TITLE
[ealapps] i3537: send mail to mailcatcher instead of sendmail on staging

### DIFF
--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -115,3 +115,10 @@
     hour: "1"
     user: deploy
     job: "php /var/www/ealapps/current/newtitles/newtitles.cron.php >  /var/www/ealapps/shared/newtitles/files/newtitles.cron.xml 2> /dev/null"
+
+- name: ealapps | enable mailcatcher in php.ini
+  ansible.builtin.lineinfile:
+    dest: "/etc/php/{{ php_version }}/apache2/php.ini"
+    regexp: ";?sendmail_path"
+    line: "sendmail_path = /usr/local/bin/catchmail"
+  when: runtime_env | default('staging') == "staging"


### PR DESCRIPTION
closes #3537 

Sibling PR: https://github.com/PrincetonUniversityLibrary/ealapps/pull/16

I ran this on staging 12/15, using a `--start-at-task` so I didn't clobber the apache config change from #3543 