### PR TITLE
Cache python environment (including pip dependencies) in github actions

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -109,9 +109,14 @@ jobs:
           for i in 1 2 3 4 5; do git clone https://github.com/pulibrary/princeton_ansible.git . && break || sleep 15; done
           git checkout ${{ github.sha }}
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: cache python environment
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This shaves a solid 90 seconds off of each job run (except the very first one to run with a given python version or requirements.txt, of course).  Hopefully this will translate into more available runners on busy days with a lot of PRs. 🤞 