### PR TITLE
[ealapps] Add required php modules

### DIFF
--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -51,10 +51,13 @@
     state: present
   notify: restart apache2
   loop:
+    - libapache2-mod-php{{ php_version }}
     - php{{ php_version }}-gd
     - php{{ php_version }}-intl
     - php{{ php_version }}-ldap
     - php{{ php_version }}-mbstring
+    - php{{ php_version }}-mysql
+    - php{{ php_version }}-xml
     - sendmail
 
 - name: ealapp | Make repos git safe


### PR DESCRIPTION
- These were on staging, but not in the role, and were required for composer to install correctly on production

Ran on production and was able to use Capistrano to deploy