### PR TITLE
also remove the config that refers to lib-prod cert and key

### DIFF
--- a/roles/nginxplus/files/conf/http/library-prod.conf
+++ b/roles/nginxplus/files/conf/http/library-prod.conf
@@ -51,19 +51,6 @@ server {
 
 server {
     listen 443 ssl http2;
-    server_name lib-prod.princeton.edu;
-    rewrite ^/(.*)$ https://library.princeton.edu/$1 permanent;
-
-    client_max_body_size 8m;
-
-    ssl_certificate            /etc/nginx/conf.d/ssl/certs/lib-prod_princeton_edu_chained.pem;
-    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/lib-prod_princeton_edu_priv.key;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
-}
-
-server {
-    listen 443 ssl http2;
     server_name library.princeton.edu;
 
     client_max_body_size 8m;


### PR DESCRIPTION
Follow up to #3568.

Removes all reference to `lib-prod.princeton.edu`. 