### PR TITLE
Expand nginx server hash table

### DIFF
--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -436,3 +436,8 @@ nginx_stream_template:
             port: 8080
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
+
+# manage the hash table that stores server names for fast lookup
+# increase the size first, when that stops working, increase the number of hash buckets in the table
+nginx_server_names_hash_bucket_size: 64
+nginx_server_names_hash_max_size: 512

--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -440,4 +440,4 @@ nginx_stream_template:
 # manage the hash table that stores server names for fast lookup
 # increase the size first, when that stops working, increase the number of hash buckets in the table
 nginx_server_names_hash_bucket_size: 64
-nginx_server_names_hash_max_size: 512
+nginx_server_names_hash_max_size: 1024

--- a/roles/nginxplus/templates/nginx.conf.j2
+++ b/roles/nginxplus/templates/nginx.conf.j2
@@ -47,6 +47,8 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    server_names_hash_max_size {{ nginx_server_names_hash_max_size }}
+    server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }}
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Closes #2556.

Supersedes #2648.

We've seen some failures of playbooks with the error:
```
nginx: [warn] could not build optimal server_names_hash, you should increase either server_names_hash_max_size: 512 or server_names_hash_bucket_size: 64; ignoring server_names_hash_bucket_size
```
This PR overrides the [default setting](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) of `512` for  the `server_names_hash_max_size`, making the  stated setting `1024`, which should still be well within the capabilities of the nginxplus servers.
