### PR TITLE
Configure sitemap cacheing in nginx for orangelight

### DIFF
--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -156,7 +156,7 @@ nginx_main_template:
   http_enable: true
   http_settings:
     keepalive_timeout: 65
-    cache: false
+    cache: true
     rate_limit: false
     keyval: false
   stream_enable: false

--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -31,7 +31,12 @@ server {
     listen 443 ssl http2;
     server_name pulsearch.princeton.edu;
     rewrite ^/(.*)$ https://catalog.princeton.edu/$1 permanent;
-
+    # proxy_cache section should match nginx.conf settings, currently:
+    # proxy_cache_path /tmp/cache keys_zone=one:10m;
+    proxy_cache one;
+        location /sitemap {
+            proxy_pass http://localhost:8000;
+            }
     ssl_certificate            /etc/nginx/conf.d/ssl/certs/catalog_princeton_edu_chained.pem;
     ssl_certificate_key        /etc/nginx/conf.d/ssl/private/catalog_princeton_edu_priv.key;
     ssl_session_cache          shared:SSL:1m;


### PR DESCRIPTION
Closes #3436.

WIP. Configures cacheing for the sitemap for the catalog/orangelight.
