### PR TITLE
removes campus_access directory from bibdata build

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -67,8 +67,6 @@ rails_app_vars:
     value: '/opt/bibdata/shared/hathi/output'
   - name: BIBDATA_ACCESS_DIRECTORY
     value: '/mnt/dms-smbserve/bi-library-hr/prod'
-  - name: CAMPUS_ACCESS_DIRECTORY
-    value: '/data/bibdata_files/campus_access_files/'
   - name: SCSB_S3_USER_NAME
     value: '{{ scsb_s3_user_name }}'
   - name: SCSB_S3_ACCESS_KEY

--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -61,8 +61,6 @@ rails_app_vars:
     value: '/opt/bibdata/shared/hathi/output'
   - name: BIBDATA_ACCESS_DIRECTORY
     value: '/mnt/dms-smbserve/bi-library-hr/prod'
-  - name: CAMPUS_ACCESS_DIRECTORY
-    value: '/data/bibdata_files/campus_access_files/'
   - name: SCSB_S3_USER_NAME
     value: '{{ scsb_s3_user_name }}'
   - name: SCSB_S3_ACCESS_KEY

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -66,8 +66,6 @@ rails_app_vars:
     value: '/opt/bibdata/shared/hathi/output'
   - name: BIBDATA_ACCESS_DIRECTORY
     value: '/mnt/dms-smbserve/bi-library-hr/prod'
-  - name: CAMPUS_ACCESS_DIRECTORY
-    value: '/data/bibdata_files/campus_access_files/'
   - name: SCSB_S3_USER_NAME
     value: '{{ scsb_s3_user_name }}'
   - name: SCSB_S3_ACCESS_KEY

--- a/roles/bibdata/tasks/mounts.yml
+++ b/roles/bibdata/tasks/mounts.yml
@@ -73,6 +73,5 @@
     mode: 0755
   when: running_on_server
   with_items:
-    - '{{ bibdata_data_dir }}/campus_access_files'
     - '{{ bibdata_data_dir }}/scsb_update_files'
     - '{{ bibdata_data_dir }}/figgy_ark_cache'


### PR DESCRIPTION
Closes #3174.

Removes unused `campus_access` directory from the bibdata tasks and variables.

Running the playbook with this change will not remove the directory from existing infrastructure, but it will stop checking it and will not recreate it if/when it's removed.
