### PR TITLE
removes unused 'solr_version' variable

### DIFF
--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -4,7 +4,6 @@ running_on_server: true
 
 # Apache Solr
 oawaiver_solr_core: "oawaiver-production"
-solr_version: "8.2.0"
 solr_cores:
   - "{{ oawaiver_solr_core }}"
 solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -10,7 +10,6 @@ pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
 postgresql_is_local: false
-solr_version: "8.2.0"
 solr_cores:
   - "{{ pulfalight_solr_core }}"
 solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -8,7 +8,6 @@ pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
 postgres_port: "5432"
-solr_version: "8.2.0"
 solr_cores:
   - "{{ pulfalight_solr_core }}"
 solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"

--- a/roles/pulfalight/molecule/default/converge.yml
+++ b/roles/pulfalight/molecule/default/converge.yml
@@ -4,7 +4,6 @@
   vars:
     - running_on_server: false
     - node_identifier: 1
-    - solr_version: "8.2.0"
     - solr_cores:
         - "pulfalight-staging"
     - solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"

--- a/roles/pulfalight/vars/main.yml
+++ b/roles/pulfalight/vars/main.yml
@@ -1,6 +1,5 @@
 ---
 # vars file for roles/pulfalight
-solr_version: "8.4.1"
 install_ruby_from_source: true
 desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"


### PR DESCRIPTION
Closes #2708.

Grepping through the repo turned up these places where `solr_version` was being set (often incorrectly) but no place where it was being used (in other words, no instances of `{{ solr_version }}`). 

This PR removes the unused variables.