### PR TITLE
add the number of servers this runs

### DIFF
--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -7,7 +7,7 @@
 - name: update the Operating System apt packages 
   hosts: "{{ runtime_env | default('staging') }}"
   remote_user: pulsys
-  serial: 2
+  serial: 3
   become: true
 
   pre_tasks:


### PR DESCRIPTION
this will bump up the time it takes to run all the updates with a
minimal disruptive penalty.
An odd number is also preferable because occasionally the playbook fails
when paired servers are included.
