### PR TITLE
Nginx playbook should fail if run without '--limit'

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -1,5 +1,6 @@
 ---
-# best practice is to run on a single host with '--limit' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml`
+# you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml`
+# to update the second load-balancer, switch which adc# host is currently active, then run the playbook on the second (formerly active, now inactive) host
 # to update configuration for existing sites, run with '-t update_conf' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml -t update_conf`
 # to replace SSL certificates and keys, run with `-t SSL`
 
@@ -10,6 +11,13 @@
   become: true
   vars_files:
     - ../group_vars/nginxplus/main.yml
+
+  tasks:
+  - name: stop playbook if you didn't use --limit
+    fail:
+      msg: "you must use -l or --limit"
+    when: ansible_limit is not defined
+    run_once: true
 
   # updates existing load balancer
   roles:

--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -12,7 +12,7 @@
   vars_files:
     - ../group_vars/nginxplus/main.yml
 
-  tasks:
+  pre_tasks:
   - name: stop playbook if you didn't use --limit
     fail:
       msg: "you must use -l or --limit"


### PR DESCRIPTION
Partial fix for #3319.

Adds a failure task at the beginning of the nginx playbook.

I didn't add it to the larger `nginx_production_rebuild` playbook, and I'm not sure if we want to add it there. That playbook rebuilds the load-balancing infrastructure from scratch.