### PR TITLE
use pulsys for the ealapps playbook

### DIFF
--- a/playbooks/ealapps.yml
+++ b/playbooks/ealapps.yml
@@ -1,11 +1,11 @@
 ---
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
-# to use `pulsys` pass `-u pulsys`
+# to use a different connection user, pass `-e ansible_user=my_user`
 
 - name: build the ealapps
   hosts: ealapps_{{ runtime_env | default('staging') }}
-  remote_user: tventimi
+  remote_user: pulsys
   become: true
   vars_files:
     - ../group_vars/ealapps/{{ runtime_env | default('staging') }}.yml


### PR DESCRIPTION
Closes #3573.

Brings the ealapps playbook into line with our other playbooks by connecting as the `pulsys` user.

Includes a comment showing how to override the connection user if necessary.