### PR TITLE
Updating the host to be the load balanced host pdc-describe-prod

### DIFF
--- a/group_vars/pdc_discovery/production.yml
+++ b/group_vars/pdc_discovery/production.yml
@@ -10,7 +10,7 @@ pdc_discovery_db_user: '{{vault_pdc_discovery_production_db_user}}'
 pdc_discovery_db_password: '{{vault_pdc_discovery_production_db_password}}'
 rails_app_env: "production"
 
-pdc_discovery_host_name: 'pdc-discovery-prod1.princeton.edu'
+pdc_discovery_host_name: 'pdc-discovery-prod.princeton.edu'
 pdc_discovery_honeybadger_key: '{{vault_pdc_discovery_honeybadger_key}}'
 
 solr_url: "http://lib-solr8-prod.princeton.edu:8983/solr/pdc-discovery-production"


### PR DESCRIPTION
Currently it is pointing at pdc-describe-prod1 which is the physical host.  This is causing URLs generated by the application to be incorrect and unreachable

fixes https://github.com/pulibrary/pdc_describe/issues/768