### PR TITLE
add TLS blocks for various cdh names

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_web.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_web.conf
@@ -51,11 +51,31 @@ server {
     listen 443 ssl;
     server_name digitalhumanities.princeton.edu;
 
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
     location / {
         return 301 https://cdh.princeton.edu$request_uri;
     }
 
 }
+
+server {
+    listen 443 ssl;
+    server_name hc3.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        return 301 https://cdh.princeton.edu$request_uri;
+    }
+}
+
 server {
     listen 443 ssl;
     server_name cdh.princeton.edu;

--- a/roles/nginxplus/files/conf/http/cdh_test_derrida.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_derrida.conf
@@ -12,6 +12,15 @@ upstream test_derrida {
 
 server {
     listen 80;
+    server_name cdh-test-derrida.princeton.edu;
+
+    location / {
+        return 301 https://test-derrida.cdh.princeton.edu$request_uri;
+    }
+}
+
+server {
+    listen 80;
     server_name test-derrida.cdh.princeton.edu;
 
     location / {
@@ -20,14 +29,18 @@ server {
 }
 
 server {
-    listen 80;
+    listen 443 ssl;
     server_name cdh-test-derrida.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/cdh-test-derrida_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/cdh-test-derrida_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
 
     location / {
         return 301 https://test-derrida.cdh.princeton.edu$request_uri;
     }
 }
-
 
 server {
     listen 443 ssl;

--- a/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
@@ -12,15 +12,6 @@ upstream test_geniza {
 
 server {
     listen 80;
-    server_name test-geniza.cdh.princeton.edu;
-
-    location / {
-        return 301 https://$server_name$request_uri;
-    }
-}
-
-server {
-    listen 80;
     server_name cdh-test-geniza.princeton.edu;
 
     location / {
@@ -28,6 +19,14 @@ server {
     }
 }
 
+server {
+    listen 80;
+    server_name test-geniza.cdh.princeton.edu;
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
 
 server {
     listen 443 ssl;

--- a/roles/nginxplus/files/conf/http/cdh_test_prosody.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prosody.conf
@@ -39,6 +39,34 @@ server {
 
 server {
     listen 443 ssl;
+    server_name cdh-test-prosody.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/test-prosody_cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/test-prosody_cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        return 301 https://test-prosody.cdh.princeton.edu$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name test-ppa.cdh.princeton.edu;
+
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/test-prosody_cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/test-prosody_cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        return 301 https://test-prosody.cdh.princeton.edu$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
     server_name test-prosody.cdh.princeton.edu;
 
     client_max_body_size 50M;

--- a/roles/nginxplus/files/conf/http/cdh_test_web.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_web.conf
@@ -23,6 +23,11 @@ server {
     listen 443 ssl;
     server_name cdh-test-web.princeton.edu;
 
+    ssl_certificate            /etc/nginx/conf.d/ssl/certs/test-web_cdh_princeton_edu_chained.pem;
+    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/test-web_cdh_princeton_edu_priv.key;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
     location / {
         return 301 https://test-web.cdh.princeton.edu$request_uri;
     }


### PR DESCRIPTION
the current config only allows routing for HTTP and not HTTPS
