### PR TITLE
More slack message updates

### DIFF
--- a/playbooks/pdc_describe.yml
+++ b/playbooks/pdc_describe.yml
@@ -22,8 +22,8 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts
       when: not ansible_check_mode

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -21,8 +21,8 @@
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts
       when: not ansible_check_mode

--- a/playbooks/repec.yml
+++ b/playbooks/repec.yml
@@ -1,7 +1,8 @@
 ---
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
-- hosts: repec_{{ runtime_env | default('staging') }}
+- name: build the Research Papers in Economics project
+  hosts: repec_{{ runtime_env | default('staging') }}
   remote_user: pulsys
   become: true
   vars_files:
@@ -18,8 +19,9 @@
       service:
         name: nginx
         state: restarted
+
     - name: tell everyone on slack you ran an ansible playbook
-      slack:
+      community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: #server-alerts


### PR DESCRIPTION
Partial fix for #2852.

Updates the slack messages in the `pdc_describe` and `pdc_discovery` playbooks.

Also updates the slack message and play name in the `repec` playbook.