### PR TITLE
[libwww] Move Database list redirects for libguides into Production.

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -4,6 +4,9 @@
     rewrite ^/hours(.*)$ https://libcal.princeton.edu/hours redirect;
     rewrite ^/AssignedSpaceApplication(.*)$ https://lockers-and-study-spaces.princeton.edu/ redirect;
     rewrite ^/AssignedSpaces https://lockers-and-study-spaces.princeton.edu/ redirect;
+    rewrite ^/research/databases https://libguides.princeton.edu/az.php redirect;
+    rewrite ^/research/databases/subjects https://libguides.princeton.edu/az.php redirect;
+    rewrite ^/resource/(\d+)$ https://libguides.princeton.edu/resource/$1 redirect;
 
     location /mudd-dbs {
         proxy_pass https://lib-mudd-prod.princeton.edu/;

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -3,9 +3,6 @@
     rewrite ^/research-data(.*)$ https://researchdata-staging.princeton.edu redirect;
     rewrite ^/AssignedSpaceApplication(.*)$ https://lockers-and-study-spaces-staging.princeton.edu/ redirect;
     rewrite ^/AssignedSpaces https://lockers-and-study-spaces-staging.princeton.edu/ redirect;
-    rewrite ^/research/databases https://libguides.princeton.edu/az.php redirect;
-    rewrite ^/research/databases/subjects https://libguides.princeton.edu/az.php redirect;
-    rewrite ^/resource/(\d+)$ https://libguides.princeton.edu/resource/$1 redirect;
 
     location /mudd-dbs {
         proxy_pass https://lib-mudd-staging.princeton.edu/;


### PR DESCRIPTION
Testing in staging, this PR moves the new redirect rules for prod. It also removes them for staging to at the point of go live staff can still refer to the old list for a period of time to help resolve any outstanding discrepancies that remain post migration. 