### PR TITLE
[ansible operations] add pulmirror vm

### DIFF
--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -45,6 +45,7 @@ prosody_production
 pulfalight_production
 pulfalight_production_workers
 pulmap_production
+pulmirror_production
 recap_production
 redis_production
 repec_production


### PR DESCRIPTION
the pulmirror vm is not included in the patch tuesday group
this adds it

will close #3685 
