### PR TITLE
[README] Update for CRITICAL Outside collections you must mention role namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ In all the steps below substitute your role name for `your_new_role`
    export your_new_role=<fill in the role name here>
    cd roles
    molecule init role $your_new_role --driver-name docker
+   cd ..
    ```
 1. Set up to run from github actions `vi .github/workflows/molecule_tests.yml` add for your role at the end matrix of the roles
    ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ In all the steps below substitute your role name for `your_new_role`
 
    ```bash
    export your_new_role=<fill in the role name here>
-   molecule init role roles/$your_new_role --driver-name docker
+   cd roles
+   molecule init role $your_new_role --driver-name docker
    ```
 1. Set up to run from github actions `vi .github/workflows/molecule_tests.yml` add for your role at the end matrix of the roles
    ```


### PR DESCRIPTION
The old command now causes and error and will not work.

```
princeton_ansible) colec in ~/projects/princeton_ansible (tiger-data) > molecule init role roles/$your_new_role --driver-name docker
CRITICAL Outside collections you must mention role namespace like: molecule init role 'acme.myrole'. Be sure you use only lowercase characters and underlines. See https://galaxy.ansible.com/docs/contributing/creating_role.html
```
Must cd into roles and then run the init command
```
(princeton_ansible) colec in ~/projects/princeton_ansible (tiger-data) > cd roles
(princeton_ansible) colec in ~/projects/princeton_ansible/roles (tiger-data) > molecule init role $your_new_role --driver-name docker 
INFO     Initializing new role tigerdata...
```