### PR TITLE
[ansible] common role snapd

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -6,7 +6,14 @@
   loop:
     - ca-certificates
     - apt-transport-https
+
+- name: common | Add snapd
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: present
+  loop:
     - snapd
+  when: running_on_server
 
 - name: common | Install procs
   community.general.snap:

--- a/roles/ruby_s/molecule/default/converge.yml
+++ b/roles/ruby_s/molecule/default/converge.yml
@@ -8,6 +8,7 @@
     - name: update cache
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: 600
   tasks:
     - name: "Include ruby_s"
       ansible.builtin.include_role:


### PR DESCRIPTION
we need snapd installed on VMs and not containers
this is a fix to allow a new container to run for #3724
which fails to get a new container
