### PR TITLE
[ruby_s] add libyaml to common

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,6 +14,7 @@ common_packages:
   - jq
   - libcurl4
   - libssl-dev
+  - libyaml-dev
   - python3-apt
   - python3-pip
   - python-setuptools


### PR DESCRIPTION
libyaml is not present in jammy and makes the `ruby_s` role fail to
build
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
