### PR TITLE
[TLS nginxplus] renew certificates

### DIFF
--- a/roles/nginxplus/files/conf/http/pulfa_old.conf
+++ b/roles/nginxplus/files/conf/http/pulfa_old.conf
@@ -24,8 +24,8 @@ server {
     server_name pulfa.princeton.edu;
 
 
-    ssl_certificate            /etc/nginx/conf.d/ssl/certs/pulfa_princeton_edu_chained.pem;
-    ssl_certificate_key        /etc/nginx/conf.d/ssl/private/pulfa_princeton_edu_priv.key;
+    ssl_certificate            /etc/letsencrypt/pulfa/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/pulfa/privkey.pem;
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 


### PR DESCRIPTION
renews TLS for pulfa.princeton.edu using ACME
