### PR TITLE
Use 3.1.3 in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 python 3.11.1
-ruby 3.2.0
+ruby 3.1.3
 awscli 2.7.31


### PR DESCRIPTION
Use ruby 3.1.3 in tool-versions

`asdf list all ruby` indicates that 3.2.0 is a dev release `3.2.0-dev`