### PR TITLE
change slack channel for alerts from 'server-alerts' to 'ansible-alerts'

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -82,3 +82,4 @@ percona_xtra_cluster_host: 'maria-staging'
 running_on_server: true
 postgresql_is_cloud: false
 postgresql_is_local: false
+slack_alerts_channel: '#ansible-alerts'

--- a/playbooks/abid.yml
+++ b/playbooks/abid.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/abid.yml
+++ b/playbooks/abid.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/annotations.yml
+++ b/playbooks/annotations.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/annotations.yml
+++ b/playbooks/annotations.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/ansible_tower.yml
+++ b/playbooks/ansible_tower.yml
@@ -12,4 +12,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/ansible_tower.yml
+++ b/playbooks/ansible_tower.yml
@@ -12,4 +12,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/appdeploy.yml
+++ b/playbooks/appdeploy.yml
@@ -16,4 +16,4 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         token: "{{ vault_pul_slack_token }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/appdeploy.yml
+++ b/playbooks/appdeploy.yml
@@ -16,4 +16,4 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         token: "{{ vault_pul_slack_token }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -25,4 +25,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -25,4 +25,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/aws_ec2.yml
+++ b/playbooks/aws_ec2.yml
@@ -133,4 +133,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/aws_ec2.yml
+++ b/playbooks/aws_ec2.yml
@@ -133,4 +133,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/byzantine.yml
+++ b/playbooks/byzantine.yml
@@ -28,7 +28,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
 
     - name: post role reminders
       debug:

--- a/playbooks/byzantine.yml
+++ b/playbooks/byzantine.yml
@@ -28,7 +28,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
 
     - name: post role reminders
       debug:

--- a/playbooks/cantaloupe.yml
+++ b/playbooks/cantaloupe.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/cantaloupe.yml
+++ b/playbooks/cantaloupe.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/cicognara.yml
+++ b/playbooks/cicognara.yml
@@ -27,4 +27,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/cicognara.yml
+++ b/playbooks/cicognara.yml
@@ -27,4 +27,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/confluence_staging.yml
+++ b/playbooks/confluence_staging.yml
@@ -13,4 +13,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/confluence_staging.yml
+++ b/playbooks/confluence_staging.yml
@@ -13,4 +13,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -39,4 +39,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible deployed the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment"
-      channel: #ansible-alerts
+      channel: "{{ slack_alerts_channel }}"

--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -39,4 +39,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible deployed the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment"
-      channel: #server-alerts
+      channel: #ansible-alerts

--- a/playbooks/deploy_user.yml
+++ b/playbooks/deploy_user.yml
@@ -14,4 +14,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #ansible-alerts
+      channel: "{{ slack_alerts_channel }}"

--- a/playbooks/deploy_user.yml
+++ b/playbooks/deploy_user.yml
@@ -14,4 +14,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #server-alerts
+      channel: #ansible-alerts

--- a/playbooks/dpul.yml
+++ b/playbooks/dpul.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/dpul.yml
+++ b/playbooks/dpul.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/dss.yml
+++ b/playbooks/dss.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/dss.yml
+++ b/playbooks/dss.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/ealapps.yml
+++ b/playbooks/ealapps.yml
@@ -25,4 +25,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/ealapps.yml
+++ b/playbooks/ealapps.yml
@@ -25,4 +25,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -28,7 +28,7 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
     - ansible.builtin.debug:
         msg:
           - "****************************************************************"
@@ -70,4 +70,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -28,7 +28,7 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts
     - ansible.builtin.debug:
         msg:
           - "****************************************************************"
@@ -70,4 +70,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/figgy_staging.yml
+++ b/playbooks/figgy_staging.yml
@@ -27,4 +27,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/figgy_staging.yml
+++ b/playbooks/figgy_staging.yml
@@ -27,4 +27,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/figgy_toggle_readonly.yml
+++ b/playbooks/figgy_toggle_readonly.yml
@@ -31,4 +31,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} toggled read-only mode to {{figgy_read_only_mode}}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/figgy_toggle_readonly.yml
+++ b/playbooks/figgy_toggle_readonly.yml
@@ -31,4 +31,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} toggled read-only mode to {{figgy_read_only_mode}}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/friends_of_pul.yml
+++ b/playbooks/friends_of_pul.yml
@@ -26,7 +26,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
 
     - name: post role reminders
       debug:

--- a/playbooks/friends_of_pul.yml
+++ b/playbooks/friends_of_pul.yml
@@ -26,7 +26,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
 
     - name: post role reminders
       debug:

--- a/playbooks/geaccirc.yml
+++ b/playbooks/geaccirc.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/geaccirc.yml
+++ b/playbooks/geaccirc.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/geoserver_production.yml
+++ b/playbooks/geoserver_production.yml
@@ -17,4 +17,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/geoserver_production.yml
+++ b/playbooks/geoserver_production.yml
@@ -17,4 +17,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/globus_certs.yml
+++ b/playbooks/globus_certs.yml
@@ -22,4 +22,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/globus_certs.yml
+++ b/playbooks/globus_certs.yml
@@ -22,4 +22,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/imagecat_rails.yml
+++ b/playbooks/imagecat_rails.yml
@@ -26,5 +26,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
       when: not ansible_check_mode

--- a/playbooks/imagecat_rails.yml
+++ b/playbooks/imagecat_rails.yml
@@ -26,5 +26,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       when: not ansible_check_mode

--- a/playbooks/incommon_certbot.yml
+++ b/playbooks/incommon_certbot.yml
@@ -39,4 +39,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/incommon_certbot.yml
+++ b/playbooks/incommon_certbot.yml
@@ -39,4 +39,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/journal_ctl.yml
+++ b/playbooks/journal_ctl.yml
@@ -32,4 +32,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/journal_ctl.yml
+++ b/playbooks/journal_ctl.yml
@@ -32,4 +32,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/lae.yml
+++ b/playbooks/lae.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/lae.yml
+++ b/playbooks/lae.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/lib_jobs.yml
+++ b/playbooks/lib_jobs.yml
@@ -24,7 +24,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
 
     - name: post role reminders
       debug:

--- a/playbooks/lib_jobs.yml
+++ b/playbooks/lib_jobs.yml
@@ -24,7 +24,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
 
     - name: post role reminders
       debug:

--- a/playbooks/lib_sftp.yml
+++ b/playbooks/lib_sftp.yml
@@ -25,7 +25,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
     - name: post role reminders
       debug:
         msg: "{{ post_install.split('\n') }}"

--- a/playbooks/lib_sftp.yml
+++ b/playbooks/lib_sftp.yml
@@ -25,7 +25,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
     - name: post role reminders
       debug:
         msg: "{{ post_install.split('\n') }}"

--- a/playbooks/lib_smb_serve_production.yml
+++ b/playbooks/lib_smb_serve_production.yml
@@ -13,4 +13,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/lib_smb_serve_production.yml
+++ b/playbooks/lib_smb_serve_production.yml
@@ -13,4 +13,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/lib_svn.yml
+++ b/playbooks/lib_svn.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/lib_svn.yml
+++ b/playbooks/lib_svn.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/libruby.yml
+++ b/playbooks/libruby.yml
@@ -17,4 +17,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #server-alerts
+      channel: #ansible-alerts

--- a/playbooks/libruby.yml
+++ b/playbooks/libruby.yml
@@ -17,4 +17,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #ansible-alerts
+      channel: "{{ slack_alerts_channel }}"

--- a/playbooks/libstatic.yml
+++ b/playbooks/libstatic.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/libstatic.yml
+++ b/playbooks/libstatic.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/libwww.yml
+++ b/playbooks/libwww.yml
@@ -30,7 +30,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
 
     - name: post role reminders
       ansible.builtin.debug:

--- a/playbooks/libwww.yml
+++ b/playbooks/libwww.yml
@@ -30,7 +30,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
 
     - name: post role reminders
       ansible.builtin.debug:

--- a/playbooks/locator.yml
+++ b/playbooks/locator.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/locator.yml
+++ b/playbooks/locator.yml
@@ -18,4 +18,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/lockers_and_study_rooms.yml
+++ b/playbooks/lockers_and_study_rooms.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/lockers_and_study_rooms.yml
+++ b/playbooks/lockers_and_study_rooms.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/mudd.yml
+++ b/playbooks/mudd.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/mudd.yml
+++ b/playbooks/mudd.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/mysql.yml
+++ b/playbooks/mysql.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/mysql.yml
+++ b/playbooks/mysql.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/mysql_db_migration.yml
+++ b/playbooks/mysql_db_migration.yml
@@ -154,5 +154,5 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} backed up {{ item.name }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
       loop: "{{ mysql_databases | default([]) }}"

--- a/playbooks/mysql_db_migration.yml
+++ b/playbooks/mysql_db_migration.yml
@@ -154,5 +154,5 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} backed up {{ item.name }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       loop: "{{ mysql_databases | default([]) }}"

--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -41,5 +41,5 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
       tags: always

--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -41,5 +41,5 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       tags: always

--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -31,5 +31,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       tag: always

--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -31,5 +31,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
       tag: always

--- a/playbooks/oawaiver.yml
+++ b/playbooks/oawaiver.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/oawaiver.yml
+++ b/playbooks/oawaiver.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/ojs.yml
+++ b/playbooks/ojs.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/ojs.yml
+++ b/playbooks/ojs.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/openbooks.yml
+++ b/playbooks/openbooks.yml
@@ -16,4 +16,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/openbooks.yml
+++ b/playbooks/openbooks.yml
@@ -16,4 +16,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/orangelight_toggle_readonly.yml
+++ b/playbooks/orangelight_toggle_readonly.yml
@@ -32,4 +32,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} toggled read-only mode to {{ ol_read_only_mode }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/orangelight_toggle_readonly.yml
+++ b/playbooks/orangelight_toggle_readonly.yml
@@ -32,4 +32,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} toggled read-only mode to {{ ol_read_only_mode }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -123,4 +123,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -123,4 +123,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/pas.yml
+++ b/playbooks/pas.yml
@@ -20,4 +20,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/pas.yml
+++ b/playbooks/pas.yml
@@ -20,4 +20,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/pdc_describe.yml
+++ b/playbooks/pdc_describe.yml
@@ -25,5 +25,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       when: not ansible_check_mode

--- a/playbooks/pdc_describe.yml
+++ b/playbooks/pdc_describe.yml
@@ -25,5 +25,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
       when: not ansible_check_mode

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -24,5 +24,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       when: not ansible_check_mode

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -24,5 +24,5 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
       when: not ansible_check_mode

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -190,4 +190,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} backed up {{ application_db_name }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -190,4 +190,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} backed up {{ application_db_name }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/postgresql_production.yml
+++ b/playbooks/postgresql_production.yml
@@ -26,4 +26,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/postgresql_production.yml
+++ b/playbooks/postgresql_production.yml
@@ -26,4 +26,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/postgresql_staging.yml
+++ b/playbooks/postgresql_staging.yml
@@ -24,4 +24,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/postgresql_staging.yml
+++ b/playbooks/postgresql_staging.yml
@@ -24,4 +24,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/pulfalight.yml
+++ b/playbooks/pulfalight.yml
@@ -21,7 +21,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
 
 - name: build the pulfalight workers
   hosts: pulfalight_{{ runtime_env | default('production') }}_workers
@@ -43,4 +43,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/pulfalight.yml
+++ b/playbooks/pulfalight.yml
@@ -21,7 +21,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
 
 - name: build the pulfalight workers
   hosts: pulfalight_{{ runtime_env | default('production') }}_workers
@@ -43,4 +43,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/pulmap.yml
+++ b/playbooks/pulmap.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/pulmap.yml
+++ b/playbooks/pulmap.yml
@@ -19,4 +19,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/pulmirror.yml
+++ b/playbooks/pulmirror.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} updated packages"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/pulmirror.yml
+++ b/playbooks/pulmirror.yml
@@ -17,4 +17,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} updated packages"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/recap.yml
+++ b/playbooks/recap.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/recap.yml
+++ b/playbooks/recap.yml
@@ -21,4 +21,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/redis_production.yml
+++ b/playbooks/redis_production.yml
@@ -12,5 +12,5 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts
       delegate_to: localhost

--- a/playbooks/redis_production.yml
+++ b/playbooks/redis_production.yml
@@ -12,5 +12,5 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
       delegate_to: localhost

--- a/playbooks/remove_app_configs.yml
+++ b/playbooks/remove_app_configs.yml
@@ -16,4 +16,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #server-alerts
+      channel: #ansible-alerts

--- a/playbooks/remove_app_configs.yml
+++ b/playbooks/remove_app_configs.yml
@@ -16,4 +16,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #ansible-alerts
+      channel: "{{ slack_alerts_channel }}"

--- a/playbooks/remove_datadog.yml
+++ b/playbooks/remove_datadog.yml
@@ -32,4 +32,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #ansible-alerts
+      channel: "{{ slack_alerts_channel }}"

--- a/playbooks/remove_datadog.yml
+++ b/playbooks/remove_datadog.yml
@@ -32,4 +32,4 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #server-alerts
+      channel: #ansible-alerts

--- a/playbooks/repec.yml
+++ b/playbooks/repec.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/repec.yml
+++ b/playbooks/repec.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/researchdata.yml
+++ b/playbooks/researchdata.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/researchdata.yml
+++ b/playbooks/researchdata.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/sensu_agent.yml
+++ b/playbooks/sensu_agent.yml
@@ -22,7 +22,7 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #ansible-alerts
+      channel: "{{ slack_alerts_channel }}"
 
 # If we ever decide to move away from the script install, here are the install steps from the collection:
 #

--- a/playbooks/sensu_agent.yml
+++ b/playbooks/sensu_agent.yml
@@ -22,7 +22,7 @@
     community.general.slack:
       token: "{{ vault_pul_slack_token }}"
       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-      channel: #server-alerts
+      channel: #ansible-alerts
 
 # If we ever decide to move away from the script install, here are the install steps from the collection:
 #

--- a/playbooks/solr8cloud_production.yml
+++ b/playbooks/solr8cloud_production.yml
@@ -18,4 +18,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/solr8cloud_production.yml
+++ b/playbooks/solr8cloud_production.yml
@@ -18,4 +18,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/solrcloud_production.yml
+++ b/playbooks/solrcloud_production.yml
@@ -19,4 +19,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/solrcloud_production.yml
+++ b/playbooks/solrcloud_production.yml
@@ -19,4 +19,4 @@
       slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "{{ inventory_hostname }} completed"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/special_collections.yml
+++ b/playbooks/special_collections.yml
@@ -25,7 +25,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
 
     - name: post role reminders
       debug:

--- a/playbooks/special_collections.yml
+++ b/playbooks/special_collections.yml
@@ -25,7 +25,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
 
     - name: post role reminders
       debug:

--- a/playbooks/studio_processors.yml
+++ b/playbooks/studio_processors.yml
@@ -16,4 +16,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/studio_processors.yml
+++ b/playbooks/studio_processors.yml
@@ -16,4 +16,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/tigerdata.yml
+++ b/playbooks/tigerdata.yml
@@ -29,4 +29,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/tigerdata.yml
+++ b/playbooks/tigerdata.yml
@@ -29,4 +29,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/update_expired_certs.yml
+++ b/playbooks/update_expired_certs.yml
@@ -30,4 +30,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/update_expired_certs.yml
+++ b/playbooks/update_expired_certs.yml
@@ -30,4 +30,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/upgrade_apache.yml
+++ b/playbooks/upgrade_apache.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts

--- a/playbooks/upgrade_apache.yml
+++ b/playbooks/upgrade_apache.yml
@@ -23,4 +23,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/video_reserves.yml
+++ b/playbooks/video_reserves.yml
@@ -24,7 +24,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts
   
     - name: post role reminders
       debug:

--- a/playbooks/video_reserves.yml
+++ b/playbooks/video_reserves.yml
@@ -24,7 +24,7 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"
   
     - name: post role reminders
       debug:

--- a/playbooks/zookeeper.yml
+++ b/playbooks/zookeeper.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #ansible-alerts
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/zookeeper.yml
+++ b/playbooks/zookeeper.yml
@@ -24,4 +24,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: #server-alerts
+        channel: #ansible-alerts


### PR DESCRIPTION
We have a new channel for `sensu-alerts`, we no longer get alerts from netdata or anything else . . . so it might be nice to use `ansible-alerts` instead of `server-alerts` in Slack. This is more specific, more descriptive, and easier to understand if you're browsing Slack channels.

This PR updates all instances of alerts sent to `server-alerts` on the `main` branch. We probably have a couple more on branches/PRs.