### PR TITLE
make ddog environment tags parallel

### DIFF
--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -27,7 +27,7 @@ rails_app_env: "production"
 scsb_auth_key: "{{ vault_scsb_auth_key }}"
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:
-  tags: "application:orangelight, environment:alma_production, type:webserver"
+  tags: "application:orangelight, environment:production, type:webserver"
   apm_enabled: "true"
   log_enabled: true
   process_config:

--- a/group_vars/zookeeper/zookeeper_production.yml
+++ b/group_vars/zookeeper/zookeeper_production.yml
@@ -1,6 +1,6 @@
 datadog_api_key: "{{vault_datadog_key}}"
 datadog_config:
-  tags: "zookeeper, env:production, role:zookeeper"
+  tags: "zookeeper, environment:production, role:zookeeper"
   apm_enabled: "false"
   log_enabled: true
   process_config:


### PR DESCRIPTION
Currently most projects have a datadog tag for `environment: production`.

This PR changes the two outliers to follow this convention. Baby steps!
