### PR TITLE
Add TLS for datadog on ealapps

### DIFF
--- a/group_vars/ealapps/production.yml
+++ b/group_vars/ealapps/production.yml
@@ -34,6 +34,12 @@ datadog_config:
   apm_enabled: true
   process_enabled: true
 datadog_typed_checks:
+  - type: tls
+    configuration:
+      init_config:
+      instances:
+        - server: eal-apps-prod1.princeton.edu
+          port: 443
   - type: process
     configuration:
       init_config:


### PR DESCRIPTION
Ran successfully on prod and now see monitor here - https://app.datadoghq.com/monitors/65339664?from_ts=1681295019631&to_ts=1681309419631&eval_ts=1681305403550&q=host%3Aeal-apps-prod1