### PR TITLE
Make deploy_user playbook & role quicker

### DIFF
--- a/playbooks/deploy_user.yml
+++ b/playbooks/deploy_user.yml
@@ -1,10 +1,19 @@
 ---
-# Only run this playbook on all hosts in a maintenance window, because no one can deploy while the playbook is running.
-# If you are running it outside the maintenance window please run it on one box at a time using a limit flag.
-# For example: `ansible-playbook playbooks/deploy_user.yml --limit slavery-prod1.princeton.edu`
+# If you run the full deploy_user role
+# no-one can deploy until the playbook stops!
+# So only run the full playbook:
+#  - during a maintenance window on all hosts, or
+#  - with `serial: 2` uncommented, or
+#  - on one box at a time using a limit flag, for example:
+#    `ansible-playbook playbooks/deploy_user.yml --limit slavery-prod1.princeton.edu`
+#
+# To update keys only (much quicker and less disruptive)
+# run with the update_keys tag:
+#  `ansible-playbook playbooks/deploy_user.yml --tags update_keys`
+#
 - name: Add deploy user
   hosts: all
-  serial: 2
+  # serial: 2
   remote_user: pulsys
   become: true
   roles:

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -20,6 +20,7 @@
   register: deploy_user_keys_from_github
   changed_when: false
   run_once: true
+  tags: update_keys
 
 - name: deploy_user | create the .ssh directory
   ansible.builtin.file:
@@ -37,6 +38,7 @@
     owner: "{{ deploy_user }}"
     mode: '0600'
     backup: true
+  tags: update_keys
 
 - name: deploy_user | allow "authorized_key" files
   ansible.builtin.lineinfile: >

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ deploy_user }}"
     gid: "{{ deploy_user_uid }}"
 
-- name: deploy_user | create- system user
+- name: deploy_user | create system user
   ansible.builtin.user:
     name: "{{ deploy_user }}"
     uid: "{{ deploy_user_uid }}"
@@ -19,6 +19,7 @@
   loop: "{{ deploy_user_github_keys }}"
   register: deploy_user_keys_from_github
   changed_when: false
+  run_once: true
 
 - name: deploy_user | create the .ssh directory
   ansible.builtin.file:
@@ -52,10 +53,8 @@
               backrefs=yes
               regexp='^AllowUsers(.*?)( ?)({{ deploy_user }})?$'
               line="AllowUsers\1 {{ deploy_user }}"
-
   notify:
     - restart sshd
-
 
 - name: deploy_user | install deploy github key
   ansible.builtin.copy:


### PR DESCRIPTION
Because we want folks to rotate their SSH keys periodically, we want to make it easy to deploy new keys. This PR:
- Adds two refinements to the deploy_user role and playbook:
  - use `run_once` on the task that pulls keys from GitHub (which takes a long, long time)
  - adds a tag called `update_keys` to the two tasks in the `deploy_user` role - when we only need to update keys, this will make the process much quicker, because we won't be running all the other tasks (creating the deploy user, allowing the `authorized_keys` file, etc.) on existing/built VMs
- Updates the documentation in the playbook
- Comments out the `serial: 2` setting
  - when run with `serial`, Ansible runs any `run_once` tasks once per group, so with `serial: 2` we would get at most a 50% speed improvement; I hope that with this task set to `run_once`, the playbook will be much less disruptive; we should test to confirm