### PR TITLE
adds a slack message at the beginning of a deploy

### DIFF
--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -11,6 +11,13 @@
   vars:
     project_dir: /tmp/{{ repo_name }}
 #    github_key_path:
+  pre_tasks:
+  - name: let folks on slack know a deploy has begun
+    community.general.slack:
+      token: "{{ vault_pul_slack_token }}"
+      msg: "Tower has started a deploy of the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment."
+      channel: #server-alerts
+
   tasks:
     - name: update code repo
       ansible.builtin.git:


### PR DESCRIPTION
With this change, Ansible will send a notification to slack before it deploys code. 

If you see the "started a deploy" and there's no "has deployed" message, check Tower to see what failed.