### PR TITLE
Update install location for mailcatcher

### DIFF
--- a/group_vars/pdc_describe/staging.yml
+++ b/group_vars/pdc_describe/staging.yml
@@ -22,7 +22,7 @@ pdc_describe_production_aws_dspace_bucket: 'prds-dataspace'
 install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.0.0/gems/mailcatcher-0.8.2/bin/mailcatcher"
+mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.1.0/gems/mailcatcher-0.8.2/bin/mailcatcher"
 
 # Note that this MUST stay in the environment-specific playbook.
 # Moving any of these to common.yml will not work.


### PR DESCRIPTION
We upgraded to ruby 3.1.0 so we need to update the mailcatcher location to match

Fixes:
* https://github.com/pulibrary/pdc_describe/issues/1085