### PR TITLE
Updates deploy role to run in Tower

### DIFF
--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -39,6 +39,7 @@
     mode: '0600'
     backup: true
   become: true
+  become_user: deploy
   tags: update_keys
 
 - name: deploy_user | allow "authorized_key" files

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -30,7 +30,7 @@
     group: "{{ deploy_user }}"
     mode: 0700
 
-- name: deploy_user | build authorized keys file
+- name: deploy_user | build authorized keys file as deploy
   ansible.builtin.template:
     src: authorized_keys.j2
     dest: /home/{{ deploy_user }}/.ssh/authorized_keys

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -38,6 +38,7 @@
     owner: "{{ deploy_user }}"
     mode: '0600'
     backup: true
+  become: true
   tags: update_keys
 
 - name: deploy_user | allow "authorized_key" files


### PR DESCRIPTION
When running the `deploy_user.yml` playbook with the tag `update_keys` in Ansible Tower, the task that replaces the  deploy user's `authorized_keys` file failed with this error:
```
Failed to get information on remote file (/home/deploy/.ssh/authorized_keys): Permission denied
```
The Tower Template had Privilege Escalation turned on, but that was not enough.

Setting `become: true` on the task was not enough either.

Changing the task to run as the `deploy` user fixed the issue.