### PR TITLE
install activesupport on towerdeploy for dpul

### DIFF
--- a/roles/towerdeploy/tasks/main.yml
+++ b/roles/towerdeploy/tasks/main.yml
@@ -8,11 +8,12 @@
   failed_when: gemoutput.rc !=0
 
 - name: towerdeploy | install capistrano dependencies
-  ansible.builtin.command: gem install "{{ item }}" airbrussh
+  ansible.builtin.command: gem install "{{ item }}"
   register: capgemoutput
   changed_when: capgemoutput.rc != 0
   failed_when: capgemoutput.rc !=0
   loop:
+    - activesupport
     - airbrussh
     - capistrano-composer
     - capistrano-passenger


### PR DESCRIPTION
Closes #3824 

Add the `activesupport` gem to the list of gems we install on the new `appdeploy` machine for use by capistrano when deploying from Ansible Tower.
