### PR TITLE
Remove student ssh and sidekiq keys

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -28,8 +28,6 @@ deploy_user_github_keys:
   - https://github.com/rladdusaw.keys
   - https://github.com/sandbergja.keys
   - https://github.com/sdellis.keys
-  - https://github.com/taylor-yamashita.keys
-  - https://github.com/thanyabegum.keys
   - https://github.com/tpendragon.keys
   - https://github.com/tventimi.keys
   - https://github.com/VickieKarasic.keys
@@ -58,8 +56,6 @@ sidekiq_netids:
   - rl3667 # Robert-Anthony Lee-Faison
   - rl8282 # Ryan Laddusaw
   - shaune # Shaun Ellis
-  - taylory # Taylor Yamashita
-  - tbegum # Thanya Begum
   - tpend # Trey Pendragon
   - vk4273 # Vickie Karasic
 figgy_rabbit_host: 'figgy1.princeton.edu'


### PR DESCRIPTION
Students no longer working for PUL.