### PR TITLE
[nginxplus tls] improve our TLS scores

### DIFF
--- a/roles/nginxplus/templates/nginx.conf.j2
+++ b/roles/nginxplus/templates/nginx.conf.j2
@@ -55,6 +55,10 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/nginx/access.log  main;
+#  use intermediate Mozilla SSL configurator
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    add_header Strict-Transport-Security "max-age=63072000" always;
 
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
we will use backwards compatible best practices for TLS
adopted from Mozilla

closes #3832
