### PR TITLE
Add username to the slack mesages for code deploys

### DIFF
--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -15,7 +15,7 @@
   - name: let folks on slack know a deploy has begun
     community.general.slack:
       token: "{{ vault_tower_slack_token }}"
-      msg: "`{{ tower_user_first_name | default('A laptop') }}` is deploying the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment. If you don't see a 'success' message, check the #ansible-alerts channel for failure details."
+      msg: "{{ tower_user_first_name | default('A laptop') }} is deploying the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment. If you don't see a 'success' message, check the #ansible-alerts channel for failure details."
       channel: "{{ slack_alerts_channel }}"
 
   tasks:
@@ -45,5 +45,5 @@
   - name: let folks on slack know you deployed
     community.general.slack:
       token: "{{ vault_tower_slack_token }}"
-      msg: "`{{ tower_user_first_name | default('A laptop') }}` successfully deployed the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment"
+      msg: "{{ tower_user_first_name | default('A laptop') }} successfully deployed the `{{ branch_name | default('main') }}` branch of `{{ repo_name }}` to the {{ runtime_env | default('staging') }} environment"
       channel: "{{ slack_alerts_channel }}"


### PR DESCRIPTION
Updates the deploy_code playbook to include the Tower user name in its slack "starting" and "success" messages. If the playbook runs outside of Tower, the messages will say "A laptop" ran the playbook.

The [Job Template documentation](https://docs.ansible.com/ansible-tower/latest/html/userguide/job_templates.html) lists the variables that are added to a Tower job at runtime (scroll down, it's under `16.7 Launch a Job Template`). 