### PR TITLE
[aspace helpers] ship logs to datadog

### DIFF
--- a/group_vars/lib_jobs/production.yml
+++ b/group_vars/lib_jobs/production.yml
@@ -59,6 +59,14 @@ datadog_checks:
         path: /opt/lib-jobs/current/log/production.log
         service: lib-jobs
         source: ruby
+      - type: file
+        path: /opt/aspace_helpers/current/reports/aspace2alma/log_out.txt
+        service: lib-jobs
+        source: ruby
+      - type: file
+        path: /opt/aspace_helpers/current/reports/aspace2alma/log_err.txt
+        service: lib-jobs
+        source: ruby
   nginx:
     init_config:
     logs:


### PR DESCRIPTION
point to ruby generated logs for datadog
This closes #3670
