### PR TITLE
[patch Tuesday] split openbsd playbook

### DIFF
--- a/playbooks/bsd_updates.yml
+++ b/playbooks/bsd_updates.yml
@@ -1,0 +1,100 @@
+---
+- name: update the BSD System packages
+  hosts: "{{ runtime_env | default('staging') }}"
+  remote_user: pulsys
+  become: true
+  become_method: doas
+  become_user: pulsys
+  environment:
+    USER: pulsys
+    HOME: /home/pulsys
+
+  pre_tasks:
+
+    - name: test for python on new VM
+      ansible.builtin.raw: test -e /usr/bin/python
+      changed_when: false
+      failed_when: false
+      register: check_python
+      become: true
+      become_method: doas
+      become_user: pulsys
+      environment:
+        USER: pulsys
+        HOME: /home/pulsys
+
+    - name: Install Python  # this has to be raw in the event python is not installed
+      ansible.builtin.raw: "pkg_add python%3.9"
+      become: true
+      become_method: doas
+      become_user: pulsys
+      environment:
+        USER: pulsys
+        HOME: /home/pulsys
+      when:
+        - check_python.rc != 0
+
+  tasks:
+
+    - name: openbsd | Upgrade to latest snapshot
+      community.general.sysupgrade:
+        snapshot: true
+        installurl: https://cloudflare.cdn.openbsd.org/pub/OpenBSD
+      register: sysupgrade
+      become: true
+      become_method: doas
+      become_user: root
+      environment:
+        USER: root
+        HOME: /root
+
+    - name: openbsd | Reboot to apply upgrade if needed
+      ansible.builtin.reboot:
+        msg: "Reboot initiated by Ansible because of sysupgrade updates."
+        connect_timeout: 5
+        reboot_timeout: 1200
+        pre_reboot_delay: 0
+        post_reboot_delay: 15
+        test_command: whoami
+      become: true
+      become_method: doas
+      become_user: root
+      environment:
+        USER: root
+        HOME: /root
+      when: 
+        - sysupgrade.changed
+
+    - name: openbsd | Install a base set of software packages.
+      community.general.openbsd_pkg:
+        name:
+          - zsh
+          - curl
+          - git
+          - htop
+          - rsync--
+          - vim--no_x11-lua
+        state: present
+      become: true
+      become_method: doas
+      become_user: root
+      environment:
+        USER: root
+        HOME: /root
+
+    - name: openbsd | update base set of software packages.
+      community.general.openbsd_pkg:
+        name: '*'
+        state: latest
+      become: true
+      become_method: doas
+      become_user: root
+      environment:
+        USER: root
+        HOME: /root
+
+    - name: tell everyone on slack you ran an ansible playbook
+      community.general.slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -4,65 +4,13 @@
 # to run in production, pass '-e runtime_env=production'
 # remember that the loadbalancing machines are not included
 # and will need to be manually updated
-- name: update the Operating System packages 
+- name: update the Operating System packages
   hosts: "{{ runtime_env | default('staging') }}"
   remote_user: pulsys
   serial: 3
   become: true
 
-  pre_tasks:
-    - name: test for python on new VM
-      ansible.builtin.raw: test -e /usr/bin/python
-      changed_when: false
-      failed_when: false
-      register: check_python
-      when: ansible_os_family == "OpenBSD"
-
-    - name: Install Python  # this has to be raw in the event python is not installed
-      ansible.builtin.raw: "pkg_add python%3.9"
-      when:
-        - ansible_os_family == "OpenBSD"
-        - check_python.rc != 0
-
   tasks:
-
-    - name: openbsd | Upgrade to latest snapshot
-      community.general.sysupgrade:
-        snapshot: true
-        installurl: https://cloudflare.cdn.openbsd.org/pub/OpenBSD
-      register: sysupgrade
-      when: ansible_os_family == "OpenBSD"
-
-    - name: openbsd | Reboot to apply upgrade if needed
-      ansible.builtin.reboot:
-        msg: "Reboot initiated by Ansible because of sysupgrade updates."
-        connect_timeout: 5
-        reboot_timeout: 600
-        pre_reboot_delay: 0
-        post_reboot_delay: 15
-        test_command: whoami
-      when: 
-        - ansible_os_family == "OpenBSD"
-        - sysupgrade.changed
-
-    - name: openbsd | Install a base set of software packages.
-      community.general.openbsd_pkg:
-        name:
-          - zsh
-          - curl
-          - git
-          - htop
-          - rsync--
-          - vim--no_x11-lua
-        state: present
-      when: ansible_os_family == "OpenBSD"
-
-    - name: openbsd | update base set of software packages.
-      community.general.openbsd_pkg:
-        name: '*'
-        state: latest
-      when: ansible_os_family == "OpenBSD"
-
     - name: Ubuntu | refresh keys
       ansible.builtin.command: /usr/bin/apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
       become: true


### PR DESCRIPTION
doas replaced sudo from OpenBSD base. doas does not propagate
the environment variables from the original session. Ansible has a way
to specify environment variables per task. This workaround allows us to
automatically update our BSD servers
