### PR TITLE
[Figgy] Cache HEAD requests separately from GET requests.

### DIFF
--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -47,6 +47,9 @@ server {
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
+        proxy_cache_convert_head off;
+        proxy_cache_methods GET HEAD;
+        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
         health_check interval=10 fails=3 passes=2;
     }
 

--- a/roles/nginxplus/files/conf/http/figgy-staging.conf
+++ b/roles/nginxplus/files/conf/http/figgy-staging.conf
@@ -46,6 +46,9 @@ server {
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
+        proxy_cache_convert_head off;
+        proxy_cache_methods GET HEAD;
+        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
         health_check interval=10 fails=3 passes=2;
     }
     #


### PR DESCRIPTION
The load balancer was converting HEAD requests to GET requests, resulting in Uppy not being able to do resumable uploads for Figgy (it uses a HEAD request to see the state of the previous upload.)

Pulled from https://serverfault.com/questions/530763/nginx-proxy-cache-key-and-head-get-request and tested.