### PR TITLE
Updates keys list for deploy and pulsys users

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -32,7 +32,6 @@ deploy_user_github_keys:
   - https://github.com/tventimi.keys
   - https://github.com/VickieKarasic.keys
 deploy_user_local_keys:
-      - { name: 'heaven', key: "{{ lookup('file', '../keys/heaven.pub') }}" }
       - { name: 'TowerDeployKey', key: "{{ lookup('file', '../keys/TowerDeployKey.pub') }}" }
       - { name: 'CodeDeployKey', key: "{{ lookup('file', '../keys/CodeDeployKey.pub') }}" }
 sidekiq_netids:

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -90,7 +90,6 @@ library_github_keys:
   - https://github.com/rladdusaw.keys
   - https://github.com/sandbergja.keys
   - https://github.com/sdellis.keys
-  - https://github.com/taylor-yamashita.keys
   - https://github.com/tpendragon.keys
   - https://github.com/Twade968.keys
 ops_github_keys:


### PR DESCRIPTION
Removes the key for `heaven`, which is now retired.
Removes the key for Taylor.
