### PR TITLE
adds filtering for Datadog APM logs

### DIFF
--- a/group_vars/approvals/production.yml
+++ b/group_vars/approvals/production.yml
@@ -37,6 +37,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       approvals|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   tls:
     init_config:

--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -150,6 +150,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       bibdata|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -141,7 +141,7 @@ postgresql_is_local: false
 
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:
-  tags: "application:bibdata, environment:production, type:webserver"
+  tags: "application:bibdata, environment:staging, type:webserver"
   apm_enabled: "true"
   log_enabled: true
   process_config:
@@ -149,6 +149,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       bibdata|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/cicognara/production.yml
+++ b/group_vars/cicognara/production.yml
@@ -78,6 +78,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       cicognara|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -95,6 +95,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       dpul|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -187,6 +187,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       figgy|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 figgy_datadog_nginx_check:
 figgy_datadog_ruby_check:
   init_config:

--- a/group_vars/geaccirc/production.yml
+++ b/group_vars/geaccirc/production.yml
@@ -17,6 +17,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       geaccirc|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   tls:
     init_config:

--- a/group_vars/lae/production.yml
+++ b/group_vars/lae/production.yml
@@ -81,6 +81,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       approvals|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   tls:
     init_config:

--- a/group_vars/lib_jobs/production.yml
+++ b/group_vars/lib_jobs/production.yml
@@ -51,6 +51,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       lib-jobs|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/lockers_and_study_spaces/production.yml
+++ b/group_vars/lockers_and_study_spaces/production.yml
@@ -40,6 +40,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       lockers-and-study-spaces|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_typed_checks:
   - type: tls
     configuration:

--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -102,6 +102,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       oawaiver|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   tls:
     init_config:

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -35,6 +35,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       orangelight|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -34,6 +34,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       orangelight|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -34,6 +34,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       orangelight|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -104,6 +104,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       pulfalight|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   tls:
     init_config:

--- a/group_vars/pulmap/production.yml
+++ b/group_vars/pulmap/production.yml
@@ -88,6 +88,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       pulmap|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   ruby:
     init_config:

--- a/group_vars/repec/production.yml
+++ b/group_vars/repec/production.yml
@@ -36,6 +36,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       repec|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_checks:
   tls:
     init_config:

--- a/group_vars/tigerdata/production.yml
+++ b/group_vars/tigerdata/production.yml
@@ -23,6 +23,8 @@ datadog_config:
   apm_config:
     analyzed_spans:
       tigerdata|rack.request: 1
+    filter_tags:
+      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
 datadog_typed_checks:
   - type: tls
     configuration:


### PR DESCRIPTION
Building on @bess's great work in #3922 and #3921.

This change filters out:
- health checks from the load balancers to VMs
- sidekiq "got any jobs" checks
from the logging for Application Performance Monitoring on Datadog for all applications that are configured to use it.
