### PR TITLE
Add heaven key back

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -90,7 +90,6 @@ library_github_keys:
   - https://github.com/rladdusaw.keys
   - https://github.com/sandbergja.keys
   - https://github.com/sdellis.keys
-  - https://github.com/taylor-yamashita.keys
   - https://github.com/tpendragon.keys
   - https://github.com/Twade968.keys
 ops_github_keys:

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -32,6 +32,7 @@ deploy_user_github_keys:
   - https://github.com/tventimi.keys
   - https://github.com/VickieKarasic.keys
 deploy_user_local_keys:
+      - { name: 'heaven', key: "{{ lookup('file', '../keys/heaven.pub') }}" }
       - { name: 'TowerDeployKey', key: "{{ lookup('file', '../keys/TowerDeployKey.pub') }}" }
       - { name: 'CodeDeployKey', key: "{{ lookup('file', '../keys/CodeDeployKey.pub') }}" }
 sidekiq_netids:
@@ -89,6 +90,7 @@ library_github_keys:
   - https://github.com/rladdusaw.keys
   - https://github.com/sandbergja.keys
   - https://github.com/sdellis.keys
+  - https://github.com/taylor-yamashita.keys
   - https://github.com/tpendragon.keys
   - https://github.com/Twade968.keys
 ops_github_keys:


### PR DESCRIPTION
Deploying via ansible tower still depends on the heaven key.  We should remove the heaven key eventually, but we're re-adding it now so that we can keep deploying.

Previously, if the deploy_user role had been run on a box to remove the heaven key, appdeploy could no longer ssh into the box to deploy.  This affected lib-jobs production, bibdata production, pdc_describe, and possibly figgy.

To get your app deployable again after this is merged: `ansible-playbook playbooks/deploy_user.yml -e runtime_env="[your_env]" --limit=[your_group_of_servers]`