### PR TITLE
[byzantine] add nfs mounts

### DIFF
--- a/roles/byzantine/tasks/main.yml
+++ b/roles/byzantine/tasks/main.yml
@@ -35,3 +35,27 @@
     block: |
       Alias /byzantine {{ drupal_docroot }}/current
   notify: restart apache
+
+- name: byzantine | Create  drupal7 directory production
+  ansible.posix.mount:
+    src: "{{ nfs_server_production }}:/var/nfs/drupal7"
+    path: "/mnt/nfs/drupal7"
+    state: mounted
+    fstype: nfs
+    opts: rw,sync,hard
+  when:
+    - running_on_server
+    - "'production' in inventory_hostname"
+  become: true
+
+- name: byzantine | Create drupal7 directory staging
+  ansible.posix.mount:
+    src: "{{ nfs_server_staging }}:/var/nfs/drupal7"
+    path: "/mnt/nfs/drupal7"
+    state: mounted
+    fstype: nfs
+    opts: rw,sync,hard
+  when:
+    - running_on_server
+    - "'staging' in inventory_hostname"
+  become: true


### PR DESCRIPTION
the byzantine vms did not have NFS mounts added
Co-authored-by: Max Kadel <maxkadel@users.noreply.github.com>
