### PR TITLE
make python version general again

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -112,7 +112,7 @@ jobs:
         env:
         AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
         with:
-          python-version: "3.11.1"
+          python-version: "3.11"
       - name: cache python environment
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Our CI system has stopped running on every push. Not sure this is hte problem, but it's a recent change, so we're trying this fix first.