### PR TITLE
[pdc-globus] use elastic IP

### DIFF
--- a/inventory/by_cloud/aws
+++ b/inventory/by_cloud/aws
@@ -1,6 +1,6 @@
 [pdc_production]
 pdc-globus-prod-precuration ansible_host=50.19.54.13
-pdc-globus-prod-postcuration ansible_host=3.80.94.204
+pdc-globus-prod-postcuration ansible_host=44.197.15.236
 [pdc_staging]
 pdc-globus-staging-precuration ansible_host=52.91.159.136
 pdc-globus-staging-postcuration ansible_host=18.207.151.182


### PR DESCRIPTION
if a Globus VM goes down it will get a new IP address from AWS. We are
  providing with an Elastic one to prevent the inability to connect
