### PR TITLE
[orangelight] Use rails_app role not blacklight_app

### DIFF
--- a/roles/orangelight/meta/main.yml
+++ b/roles/orangelight/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: orangelight
   company: Princeton University Library
-  description: orangelight a role for maintaing the blacklight based catalog
+  description: orangelight a role for maintaining the blacklight based catalog
   author: pulibrary
 
   license: MIT
@@ -17,4 +17,4 @@ dependencies:
   - role: 'redis'
   - role: 'sneakers_worker'
   - role: 'extra_path'
-  - role: 'blacklight_app'
+  - role: 'rails_app'


### PR DESCRIPTION
- This allows us to skip the creation of a cron job that was causing issues.
- In order for it to take full effect, you need to ssh onto each box and delete the cron job manually

```
ssh deploy@one-of-the-servers
crontab -e
# Use nano or vim to delete the blacklight:delete_old_searches cron job and save
# to verify the lines have been deleted:
crontab -l
```

Connected to #4039 
Connected to https://github.com/pulibrary/orangelight/issues/3610 
