### PR TITLE
[Bibdata] Add datadog nginx status check

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -147,31 +147,35 @@ datadog_config:
     filter_tags:
       reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
     ignore_resources: ["sidekiq.heartbeat", "sidekiq.job_fetch", "sidekiq.scheduled_push"]
+datadog_typed_checks:
+  - type: process
+    configuration:
+      init_config:
+      instances:
+        - name: bibdata
+          service: bibdata
+          search_string:
+            - nginx
+  - type: nginx
+    configuration:
+      init_config:
+      instances:
+        - nginx_status_url: http://localhost:80/nginx_status/
+      logs:
+        - type: file
+          path: /var/log/nginx/access.log
+          source: nginx
+        - type: file
+          path: /var/log/nginx/error.log
+          source: nginx
+        - type: file
+          path: /opt/bibdata/current/log/production.log
+          source: rails
+        - type: file
+          path: /opt/bibdata/current/log/traject-error.log
+          service: traject
+          source: ruby
 datadog_checks:
-  ruby:
-    init_config:
-    logs:
-      - type: file
-        path: /opt/bibdata/current/log/production.log
-        service: bibdata
-        source: ruby
-      - type: file
-        path: /opt/bibdata/current/log/traject-error.log
-        service: traject
-        source: ruby
-  nginx:
-    init_config:
-    logs:
-      - type: file
-        path: /var/log/nginx/access.log
-        service: bibdata
-        source: nginx
-        sourcecategory: http_web_access
-      - type: file
-        path: /var/log/nginx/error.log
-        service: bibdata
-        source: nginx
-        sourcecategory: http_web_access
   tls:
     init_config:
     instances:


### PR DESCRIPTION
Ran this on 14 July, and bibdata machines started showing up on the nginx dashboard in datadog.