### PR TITLE
[orangelight] Enhance nginx monitoring via datadog

### DIFF
--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -38,24 +38,27 @@ datadog_config:
       orangelight|rack.request: 1
     filter_tags:
       reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
-datadog_checks:
-  ruby:
-    init_config:
-    logs:
-      - type: file
-        path: /opt/orangelight/current/log/production.log
-        service: orangelight
-        source: ruby
-  nginx:
-    init_config:
-    logs:
-      - type: file
-        path: /var/log/nginx/access.log
-        service: orangelight
-        source: nginx
-        sourcecategory: http_web_access
-      - type: file
-        path: /var/log/nginx/error.log
-        service: orangelight
-        source: nginx
-        sourcecategory: http_web_access
+datadog_typed_checks:
+  - type: process
+    configuration:
+      init_config:
+      instances:
+        - name: orangelight
+          service: orangelight
+          search_string:
+            - nginx
+  - type: nginx
+    configuration:
+      init_config:
+      instances:
+        - nginx_status_url: http://localhost:80/nginx_status/
+      logs:
+        - type: file
+          path: /var/log/nginx/access.log
+          source: nginx
+        - type: file
+          path: /var/log/nginx/error.log
+          source: nginx
+        - type: file
+          path: /opt/orangelight/current/log/production.log
+          source: rails


### PR DESCRIPTION
Use typed checks to make sure datadog uses nginx status page