### PR TITLE
[solr] change our upstream algorithm

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-solr8-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8-prod.conf
@@ -3,6 +3,7 @@
 proxy_cache_path /data/nginx/lib-solr8-prod/NGINX_cache/ keys_zone=lib-solr8-prodcache:10m;
 
 upstream lib-solr8-prod {
+    least_time header 'inflight';
     zone lib-solr8-prod 128k;
     server lib-solr-prod4.princeton.edu:8983 resolve;
     server lib-solr-prod5.princeton.edu:8983 resolve;

--- a/roles/nginxplus/files/conf/http/lib-solr8-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8-staging.conf
@@ -3,6 +3,7 @@
 proxy_cache_path /data/nginx/lib-solr8-staging/NGINX_cache/ keys_zone=lib-solr8-stagingcache:10m;
 
 upstream lib-solr8-staging {
+    least_time header 'inflight';
     zone lib-solr8-staging 64k;
     server lib-solr-staging4.princeton.edu:8983 resolve;
     server lib-solr-staging5.princeton.edu:8983 resolve;

--- a/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
@@ -3,6 +3,7 @@
 proxy_cache_path /data/nginx/lib-solr9-prod/NGINX_cache/ keys_zone=lib-solr9-prodcache:10m;
 
 upstream lib-solr9-prod {
+    least_time header 'inflight';
     zone lib-solr9-prod 128k;
     server lib-solr-prod1.princeton.edu:8983 resolve;
     server lib-solr-prod2.princeton.edu:8983 resolve;

--- a/roles/nginxplus/files/conf/http/lib-solr9-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-staging.conf
@@ -3,6 +3,7 @@
 proxy_cache_path /data/nginx/lib-solr9-staging/NGINX_cache/ keys_zone=lib-solr9-stagingcache:10m;
 
 upstream lib-solr9-staging {
+    least_time header 'inflight';
     zone lib-solr9-staging 64k;
     server lib-solr-staging1.princeton.edu:8983 resolve;
     server lib-solr-staging2.princeton.edu:8983 resolve;


### PR DESCRIPTION
the loadbalancer keeps favoring one of our boxes because we've been
defaulting on round robin. we will use the least_time instead

load balancing method where a request is passed to the server with the least average response time and least number of active connections, taking into account weights of servers
incomplete requests are also taken into account with the inflight
parameter
