### PR TITLE
Update solr configs

### DIFF
--- a/group_vars/solr8cloud/production.yml
+++ b/group_vars/solr8cloud/production.yml
@@ -4,6 +4,8 @@ install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
 bundler_version: "2.3.18"
 solr_heap_setting: '20g'
+# more granular option would be:
+# solr_java_memory: '-Xms16g -Xmx20g'
 solr_cloud_download_version: 8.4.1
 solr_log4j_path: '/solr/log4j2.xml'
 lib_zk1_host_name: lib-zk1

--- a/group_vars/solr8cloud/staging.yml
+++ b/group_vars/solr8cloud/staging.yml
@@ -4,6 +4,8 @@ install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
 bundler_version: "2.3.18"
 solr_heap_setting: '20g'
+# more granular option would be:
+# solr_java_memory: '-Xms16g -Xmx20g'
 solr_cloud_download_version: 8.4.1
 solr_log4j_path: '/solr/log4j2.xml'
 lib_zk1_host_name: lib-zk-staging1

--- a/group_vars/solr9cloud/production.yml
+++ b/group_vars/solr9cloud/production.yml
@@ -6,6 +6,8 @@ desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"
 bundler_version: "2.3.18"
 solr_heap_setting: '20g'
+# more granular option would be:
+# solr_java_memory: '-Xms16g -Xmx20g'
 solr_cloud_download_version: 9.2.0
 solr_log4j_path: '/solr/log4j2.xml'
 lib_zk4_host_name: lib-zk4

--- a/group_vars/solr9cloud/staging.yml
+++ b/group_vars/solr9cloud/staging.yml
@@ -6,6 +6,8 @@ desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"
 bundler_version: "2.3.18"
 solr_heap_setting: '20g'
+# more granular option would be:
+# solr_java_memory: '-Xms16g -Xmx20g'
 solr_cloud_download_version: 9.2.0
 solr_log4j_path: '/solr/log4j2.xml'
 lib_zk4_host_name: lib-zk-staging4

--- a/group_vars/solrcloud/solrcloud_production.yml
+++ b/group_vars/solrcloud/solrcloud_production.yml
@@ -13,6 +13,8 @@ lib_zk2_host: '{{ vault_lib_zk2_host }}'
 lib_zk3_host: '{{ vault_lib_zk3_host }}'
 solr_znode: solr7
 solr_heap_setting: '20g'
+# more granular option would be:
+# solr_java_memory: '-Xms16g -Xmx20g'
 datadog_config:
   tags: "solrcloud, environment:production, role:solr"
   apm_enabled: false

--- a/group_vars/solrcloud/solrcloud_staging.yml
+++ b/group_vars/solrcloud/solrcloud_staging.yml
@@ -2,6 +2,8 @@
 ruby_version_override: "ruby2.6"
 bundler_version: "2.1.4"
 solr_heap_setting: '20g'
+# more granular option would be:
+# solr_java_memory: '-Xms16g -Xmx20g'
 solr_cloud_download_version: 7.7.2
 solr_log4j_path: '/solr/log4j2.xml'
 lib_solr1_host: '{{ vault_lib_solr_staging1_host }}'

--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -24,24 +24,30 @@ solr_jmx_enabled: 'true'
 solr_jmx_port: 1099
 solr_host: '{{ inventory_hostname }}'
 
-# JVM
-solr_gc_tune: "-XX:NewRatio=3 \
--XX:SurvivorRatio=4 \
--XX:TargetSurvivorRatio=90 \
--XX:MaxTenuringThreshold=8 \
--XX:+UseConcMarkSweepGC \
--XX:+UseParNewGC \
--XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 \
--XX:+CMSScavengeBeforeRemark \
--XX:PretenureSizeThreshold=64m \
--XX:+UseCMSInitiatingOccupancyOnly \
--XX:CMSInitiatingOccupancyFraction=50 \
--XX:CMSMaxAbortablePrecleanTime=6000 \
--XX:+CMSParallelRemarkEnabled \
--XX:+ParallelRefProcEnabled"
+# garbage collection settings
+solr_gc_tune: " \
+-XX:+UseG1GC \
+-XX:+ParallelRefProcEnabled \
+-XX:G1HeapRegionSize=8m \
+-XX:MaxGCPauseMillis=200 \
+-XX:+UseLargePages \
+-XX:+AggressiveOpts \
+"
+gc_log_settings: " \
+-verbose:gc \
+-XX:+PrintHeapAtGC \
+-XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps \
+-XX:+PrintGCTimeStamps \
+-XX:+PrintTenuringDistribution \
+-XX:+PrintGCApplicationStoppedTime\
+"
 
 solr_stack_size: 256k
-solr_heap: "{{ solr_heap_setting | default('72g') }}"
+solr_heap: "{{ solr_heap_setting | default('20g') }}"
+# Consider configuring the min and max separately:
+# solr_java_memory: '-Xms16g -Xmx20g'
+# ^^^ would require changes to both scripts in the templates dir
 solr_jetty_threads_min: 10
 solr_jetty_threads_max: 10000
 solr_jetty_threads_idle_timeout: 30000

--- a/roles/solrcloud/templates/jammy_solr.in.sh.j2
+++ b/roles/solrcloud/templates/jammy_solr.in.sh.j2
@@ -1,9 +1,12 @@
 # Increase Java Heap as needed to support your indexing / query needs
 SOLR_HEAP='{{ solr_heap }}'
+# for more specific memory settings, use SOLR_JAVA_MEM and get rid of SOLR_HEAP
+# SOLR_JAVA_MEM={{ solr_java_memory }}
 # Enable verbose GC logging
-GC_LOG_OPTS="-verbose:gc -XX:+PrintGCDetails"
-# These GC settings have shown to work well for a number of common Solr workloads
-GC_TUNE='-XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:PretenureSizeThreshold=64m -XX:+ParallelRefProcEnabled'
+GC_LOG_OPTS={{ gc_log_settings }}
+GC_TUNE='{{ solr_gc_tune }}'
+# possible new GC_TUNE settings for Jammy:
+# GC_TUNE='-XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:PretenureSizeThreshold=64m -XX:+ParallelRefProcEnabled'
 # Set the ZooKeeper connection string if using an external ZooKeeper ensemble
 ZK_HOST='{{ solr_zk_host }}'
 # Set the ZooKeeper client timeout (for SolrCloud mode)

--- a/roles/solrcloud/templates/solr.in.sh.j2
+++ b/roles/solrcloud/templates/solr.in.sh.j2
@@ -23,13 +23,11 @@ SOLR_HEAP='{{ solr_heap }}'
 
 # Expert: If you want finer control over memory options, specify them directly
 # Comment out SOLR_HEAP if you are using this though, that takes precedence
-#SOLR_JAVA_MEM="-Xms512m -Xmx512m"
+# SOLR_JAVA_MEM={{ solr_java_memory }}
 
 # Enable verbose GC logging
-GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
--XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
-
-# These GC settings have shown to work well for a number of common Solr workloads
+GC_LOG_OPTS={{ gc_log_settings }}
+# GC settings tested July 2023
 GC_TUNE='{{ solr_gc_tune }}'
 
 # Set the ZooKeeper connection string if using an external ZooKeeper ensemble


### PR DESCRIPTION
Following our most recent challenges with our Solr infrastructure, this PR updates our garbage collection settings and sets the stage for more granular control of the heap memory.

The new GC settings have already been implemented and tested.

The heap changes suggested in these comments have not been implemented or tested at all. If we do pursue optimizing heap memory management, we will have to update both scripts (solr.in.sh and jammy_solr.in.sh) as well as the group variables files.
