### PR TITLE
[Catalog] increase burst for catalog rate limit

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -69,7 +69,7 @@ server {
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
-        limit_req zone=catalog-prod-ratelimit burst=20 nodelay;
+        limit_req zone=catalog-prod-ratelimit burst=80 nodelay;
         health_check interval=10 fails=2 passes=1 uri=/catalog/991234563506421;
         include /etc/nginx/conf.d/templates/deny_bad_actors.conf;
     }

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -41,7 +41,7 @@ server {
 
     location / {
 #        app_protect_enable on;
-        limit_req zone=catalog-staging-ratelimit burst=20 nodelay;
+        limit_req zone=catalog-staging-ratelimit burst=80 nodelay;
         app_protect_security_log_enable on;
         proxy_pass http://catalog-staging;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
When a human user visits the catalog using a web browser, it causes a burst of ~16 requests for all the images, javascript, etc.  To reduce the chance that bursts like this would cause nginx to block a human user, let's increase the burst setting, but keep the rate limit in place to block traffic that is consistently making many requests/second.

We ran this on 19 July, 2023.