### PR TITLE
[lib_jobs] Do not log SVN secrets

### DIFF
--- a/roles/lib_svn/tasks/main.yml
+++ b/roles/lib_svn/tasks/main.yml
@@ -141,6 +141,7 @@
     group: "{{ item.group }}"
     mode: "{{ item.mode | default('u+rw,g+r') }}"
   with_items: "{{ svn_credentials }}"
+  no_log: true
 
 - name: lib_svn | setup virtual host
   ansible.builtin.template:


### PR DESCRIPTION
Previously the task was outputting each user's secret to the console, this makes it so that it does not log those secrets. 