### PR TITLE
Add headers to help troubleshooting error pages

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/errors.conf
+++ b/roles/nginxplus/files/conf/http/templates/errors.conf
@@ -1,3 +1,4 @@
+add_header "X-troubleshooting" "errors.conf";
 error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 426 428 429 431 451 500 501 502 503 504 505 506 507 508 510 511 /error.html;
 
     location = /error.html {

--- a/roles/nginxplus/files/conf/http/templates/staging-maintenance.conf
+++ b/roles/nginxplus/files/conf/http/templates/staging-maintenance.conf
@@ -1,3 +1,4 @@
+add_header "X-troubleshooting" "staging-maintenance.conf";
 error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 425 426 428 429 431 451 500 501 502 503 504 505 506 507 508 510 511 = @maintenance;
 
 location @maintenance {


### PR DESCRIPTION
Also, we had a lot of luck using this curl command to get status code and headers, courtesy of @rlskoeser : `curl -I https://abid-staging.princeton.edu`