### PR TITLE
allow CDH to access load balancers

### DIFF
--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -17,6 +17,8 @@ cdh-test-web1.princeton.edu
 lib-postgres-prod3.princeton.edu
 lib-solr-prod1.princeton.edu
 lib-solr-prod4.princeton.edu
+lib-adc1.princeton.edu
+lib-adc2.princeton.edu
 [cdh_shared_staging]
 lib-postgres-staging3.princeton.edu
 lib-solr-staging1.princeton.edu


### PR DESCRIPTION
Working on #2227, we discovered that the CDH folks don't have access to the load balancers. This is a shared resource, so they should be able to access it.
