### PR TITLE
[orangelight] Add env for redis_db

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -89,6 +89,8 @@ rails_app_vars:
     value: "{{ ol_rabbit_server }}"
   - name: OL_READ_ONLY_MODE
     value: '{{ol_read_only_mode}}'
+  - name: OL_REDIS_DB
+    value: '7'
   - name: OL_REDIS_HOST
     value: "{{ ol_redis_host }}"
   - name: OL_SECRET_KEY_BASE


### PR DESCRIPTION
Closes #4055 

Connected to https://github.com/pulibrary/orangelight/issues/3629