### PR TITLE
[nginx] Update DACS nginx error handling

### DIFF
--- a/roles/nginxplus/files/conf/http/approvals-prod.conf
+++ b/roles/nginxplus/files/conf/http/approvals-prod.conf
@@ -32,9 +32,11 @@ server {
         proxy_pass http://approvals-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache approvals-prodcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/approvals-staging.conf
+++ b/roles/nginxplus/files/conf/http/approvals-staging.conf
@@ -35,6 +35,8 @@ server {
         proxy_pass http://approvals-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache approvals-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -42,6 +44,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/byzantine-tsp_prod.conf
+++ b/roles/nginxplus/files/conf/http/byzantine-tsp_prod.conf
@@ -32,9 +32,11 @@ server {
         proxy_pass http://byzantine-tsp-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache byzantine-prodcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/byzantine-tsp_staging.conf
+++ b/roles/nginxplus/files/conf/http/byzantine-tsp_staging.conf
@@ -32,9 +32,11 @@ server {
         proxy_pass http://byzantine-tsp-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache byzantine-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -42,11 +42,13 @@ server {
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2 uri=/catalog/1234567;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all
         deny all;
     }
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 }

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -53,6 +53,8 @@ server {
         proxy_buffer_size          128k;
         proxy_buffers              4 256k;
         proxy_busy_buffers_size    256k;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -62,6 +64,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/library-prod.conf
+++ b/roles/nginxplus/files/conf/http/library-prod.conf
@@ -84,6 +84,8 @@ server {
 
     location / {
         proxy_pass http://library-prod;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check uri=/health interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
     }
@@ -109,7 +111,7 @@ server {
         proxy_read_timeout         2h;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
     include /etc/nginx/conf.d/templates/libwww-proxy-pass-prod.conf;
 

--- a/roles/nginxplus/files/conf/http/library-staging.conf
+++ b/roles/nginxplus/files/conf/http/library-staging.conf
@@ -37,6 +37,8 @@ server {
 #        app_protect_security_log_enable on;
         proxy_pass http://library-staging;
         proxy_cache library-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check uri=/health interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
         # allow princeton network
@@ -66,7 +68,7 @@ server {
         proxy_read_timeout         2h;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
     include /etc/nginx/conf.d/templates/libwww-proxy-pass-staging.conf;
 

--- a/roles/nginxplus/files/conf/http/locator-prod.conf
+++ b/roles/nginxplus/files/conf/http/locator-prod.conf
@@ -38,9 +38,11 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/locator-staging.conf
+++ b/roles/nginxplus/files/conf/http/locator-staging.conf
@@ -40,6 +40,8 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -47,6 +49,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
@@ -32,9 +32,11 @@ server {
         proxy_pass http://lockers-and-study-spaces-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache lockers-and-study-spacescache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
@@ -34,9 +34,11 @@ server {
         proxy_pass http://lockers-and-study-spaces-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache lockers-and-study-spaces-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/recap-prod.conf
+++ b/roles/nginxplus/files/conf/http/recap-prod.conf
@@ -37,12 +37,14 @@ server {
     location / {
         proxy_pass http://recap-prod;
         proxy_cache recap-prodcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check uri=/health interval=10 fails=3 passes=2 jitter=5;
         proxy_set_header Host $http_host;
         allow all;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }
 server {

--- a/roles/nginxplus/files/conf/http/recap-staging.conf
+++ b/roles/nginxplus/files/conf/http/recap-staging.conf
@@ -35,6 +35,8 @@ server {
         app_protect_security_log_enable on;
         proxy_pass http://recap-staging;
         proxy_cache recap-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check uri=/health interval=10 fails=3 passes=2 jitter=5;
         proxy_set_header Host $http_host;
         # allow princeton network
@@ -43,6 +45,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/repec-prod.conf
+++ b/roles/nginxplus/files/conf/http/repec-prod.conf
@@ -33,9 +33,11 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache repec-prodcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/repec-staging.conf
+++ b/roles/nginxplus/files/conf/http/repec-staging.conf
@@ -35,6 +35,8 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache repec-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -42,6 +44,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/researchdata_prod.conf
+++ b/roles/nginxplus/files/conf/http/researchdata_prod.conf
@@ -42,12 +42,14 @@ server {
 
     location / {
         proxy_pass http://researchdata_prod;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check uri=/health interval=10 fails=3 passes=2;
         proxy_set_header Host $host;
         proxy_cache researchdata_prodcache;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 }
 
 server {

--- a/roles/nginxplus/files/conf/http/researchdata_staging.conf
+++ b/roles/nginxplus/files/conf/http/researchdata_staging.conf
@@ -36,6 +36,8 @@ server {
         app_protect_security_log_enable on;
         proxy_pass http://researchdata-staging;
         proxy_cache researchdata-stagingcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         proxy_set_header Host $host;
         # allow princeton network
@@ -44,6 +46,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/slavery-prod.conf
+++ b/roles/nginxplus/files/conf/http/slavery-prod.conf
@@ -36,8 +36,10 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 }

--- a/roles/nginxplus/files/conf/http/slavery-staging.conf
+++ b/roles/nginxplus/files/conf/http/slavery-staging.conf
@@ -39,6 +39,8 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
         # health_check interval=10 fails=3 passes=2 uri=/talkback/get-in-touch;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -46,6 +48,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/videoreserves_prod.conf
+++ b/roles/nginxplus/files/conf/http/videoreserves_prod.conf
@@ -39,6 +39,8 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
 #        health_check interval=10 fails=3 passes=2 uri=/talkback/get-in-touch;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -46,6 +48,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/videoreserves_staging.conf
+++ b/roles/nginxplus/files/conf/http/videoreserves_staging.conf
@@ -39,6 +39,8 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
 #        health_check interval=10 fails=3 passes=2 uri=/talkback/get-in-touch;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
@@ -46,6 +48,6 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/staging-maintenance.conf;
+    include /etc/nginx/conf.d/templates/errors.conf;
 
 }


### PR DESCRIPTION
Updates nginx config for DACS sites - allows errors to be passed through load balancer for monitoring, etc. 

Has not been run on load balancer yet (as of 8/11/2023)