### PR TITLE
increase serial number to allow playbook to get through inventory

### DIFF
--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -7,7 +7,7 @@
 - name: update the Operating System packages
   hosts: "{{ runtime_env | default('staging') }}"
   remote_user: pulsys
-  serial: 3
+  serial: "{{ concurrent_vms | default('5') }}"
   become: true
 
   tasks:


### PR DESCRIPTION
The Patch Tuesday job in Tower has been failing on several VMs. With the `serial` set to `3`, three unreachable or failing VMs will make the entire playbook fail and some VMs will not get updates at all.

This PR creates a variable called `concurrent_vms` for the `serial` value and sets a default of `5`. In Tower, we can set the template to `Prompt on launch` for that variable value when we need to override it.