### PR TITLE
[Nginx] set 'always' tag on nginx validation

### DIFF
--- a/roles/nginxplus/tasks/validate.yml
+++ b/roles/nginxplus/tasks/validate.yml
@@ -3,3 +3,4 @@
   command: /usr/sbin/nginx -t
   changed_when: false
   become: true
+  tags: always


### PR DESCRIPTION
Closes #2749.

Sets the 'always' tag on the config validation task. This task gets included in the role run when the target is our load balancers (nginxplus). It should run whether or not we pass `-t update_config`. If it fails, the handler to reload the config (which runs at the end of the role) shouldn't run, and the hard restart at the end of the playbook shouldn't run either.

Not sure what the `command` module will consider to be a failure, though. We may need to add a `failed_when` condition to control that. Let's test this by putting some bad config on a branch and trying to upload it to the inactive LB using the playbook before we merge.