### PR TITLE
[nginx] add config stanza for logo

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/errors.conf
+++ b/roles/nginxplus/files/conf/http/templates/errors.conf
@@ -13,3 +13,8 @@ error_page 429 /ratelimit.html;
         internal;
         root /var/local/www/default;
     }
+
+    location = /pul-logo-new.svg {
+        ssi on;
+        root /var/local/www/default;
+    }


### PR DESCRIPTION
Closes #4134.

No idea how the old config actually worked. But this seems to do the trick.

Keeps the `error` and `ratelimit` locations private, but adds a non-private location stanza for the image.