### PR TITLE
[libsftp] pause the system-ldap playbook

### DIFF
--- a/roles/system_ldap/tasks/main.yml
+++ b/roles/system_ldap/tasks/main.yml
@@ -35,6 +35,12 @@
     line: '# AllowUsers pulsys'
   notify: restart sshd
 
+- name: pause to configure LDAP connection
+  ansible.builtin.pause:
+    prompt: "Follow https://github.com/pulibrary/princeton_ansible/blob/main/roles/system_ldap/README.md to configure the LDAP connection"
+    seconds: None
+    minutes: None
+
 - name: system_ldap | configure pam to enable mkhomedir
   ansible.builtin.shell: realm permit "{{ ad_user | default('almasftp@pu.win.princeton.edu') }}"
   become: true


### PR DESCRIPTION
Closes #3774.

Needs testing, but this should pause the playbook that builds the libsftp box while the manual steps from the README are run, then resume once the user acknowledges the message.