### PR TITLE
[Figgy] figgy does not use kakadu any more

### DIFF
--- a/roles/figgy/meta/main.yml
+++ b/roles/figgy/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
         - 18.04
 dependencies:
   - role: "redis"
-  - role: "kakadu"
   - role: "mediainfo"
   - role: "vips"
   - role: "imagemagick"


### PR DESCRIPTION
Removes the figgy dependency on the kakadu role.

Kakadu is still referenced in these locations:
- 'all' group vars (in `extra_path`)
- 'cantaloupe' group vars
- the cantaloupe playbook
- the `task/main.yml` file in the sidekiq workers role