### PR TITLE
Block Bytespider from the catalog.

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -74,6 +74,9 @@ server {
         limit_req zone=catalog-prod-ratelimit burst=80 nodelay;
         limit_req_status 429;
         health_check interval=10 fails=2 passes=1 uri=/catalog/991234563506421;
+        if ($http_user_agent ~ (Bytespider) ) {
+          return 403;
+        }
     }
 
    include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
They're eating up our Alma calls.

This is deployed.