### PR TITLE
[inventory] adds group for LBs

### DIFF
--- a/inventory/all_projects/_orphans
+++ b/inventory/all_projects/_orphans
@@ -3,6 +3,9 @@
 geoserv1.princeton.edu
 [issue_tracker]
 issuetracker-prod1.princeton.edu
+[load_balancers]
+lib-adc1.princeton.edu
+lib-adc2.princeton.edu
 [monitor_backends]
 lib-monitor1.princeton.edu
 sensu-testing-staging-1.princeton.edu # the "punching bag" VM

--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -29,7 +29,6 @@ libstatic_production
 lib_fs_production
 lib_svn_production
 libwww_production
-load_balancers
 loadtest_production
 locator_production
 lockers_and_study_spaces_production

--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -29,6 +29,7 @@ libstatic_production
 lib_fs_production
 lib_svn_production
 libwww_production
+load_balancers
 loadtest_production
 locator_production
 lockers_and_study_spaces_production


### PR DESCRIPTION
The pulsys user playbook was not running on the load balancers. I suspect neither was the apt update playbook.

Root cause was that those playbooks run by environment, as defined by the files in `inventory/by_environment`, like `inventory/by_environment/production.yml`. The load balancers were not in the production group. 

This PR adds a group for the load balancers in the `_orphans` file and adds the `load_balancers` group to 'production' meta-group.