### PR TITLE
[datacommons] remove health checks

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/datacommons-describe.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-describe.conf
@@ -7,5 +7,4 @@ location /describe/ {
     proxy_cache pdc-discovery-prodcache;
     # handle errors using errors.conf
     proxy_intercept_errors on;
-    health_check uri=/describe interval=10 fails=3 passes=2;
 }

--- a/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
@@ -7,5 +7,4 @@ location /discovery/ {
     proxy_cache pdc-discovery-prodcache;
     # handle errors using errors.conf
     proxy_intercept_errors on;
-    health_check uri=/discovery interval=10 fails=3 passes=2;
 }


### PR DESCRIPTION
these make the `nginx -t` fail
created an issue here https://github.com/pulibrary/princeton_ansible/issues/4200
