### PR TITLE
block .ris and .endnote on catalog prod

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -57,14 +57,6 @@ server {
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;    
 
-    location ~ ^.*\.ris {
-       return 403;
-    }
-
-    location ~ ^.*\.endnote {
-       return 403;
-    }
-
     location / {
         proxy_pass http://catalog-prod;
         proxy_set_header X-Forwarded-Host $host;
@@ -84,6 +76,34 @@ server {
         health_check interval=10 fails=2 passes=1 uri=/catalog/991234563506421;
         if ($http_user_agent ~ (Bytespider) ) {
           return 403;
+        }
+        location ~ ^.*\.endnote {
+          if ($http_referer = "") {
+           return 403;
+          }
+          proxy_pass http://catalog-prod;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_connect_timeout      2h;
+          proxy_send_timeout         2h;
+          proxy_read_timeout         2h;
+          proxy_max_temp_file_size 0;
+          limit_req zone=catalog-prod-ratelimit burst=80 nodelay;
+          limit_req_status 429;
+        }
+        location ~ ^.*\.ris {
+          if ($http_referer = "") {
+           return 403;
+          }
+          proxy_pass http://catalog-prod;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_connect_timeout      2h;
+          proxy_send_timeout         2h;
+          proxy_read_timeout         2h;
+          proxy_max_temp_file_size 0;
+          limit_req zone=catalog-prod-ratelimit burst=80 nodelay;
+          limit_req_status 429;
         }
     }
 

--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -55,7 +55,19 @@ server {
     ssl_certificate            /etc/nginx/conf.d/ssl/certs/catalog_princeton_edu_chained.pem;
     ssl_certificate_key        /etc/nginx/conf.d/ssl/private/catalog_princeton_edu_priv.key;
     ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
+    ssl_prefer_server_ciphers  on;    
+
+    location ~ ^.*\.ris {
+      if ($http_referer = "") {
+       return 403;
+      }
+    }
+
+    location ~ ^.*\.endnote {
+      if ($http_referer = "") {
+       return 403;
+      }
+    }
 
     location / {
         proxy_pass http://catalog-prod;

--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -58,15 +58,11 @@ server {
     ssl_prefer_server_ciphers  on;    
 
     location ~ ^.*\.ris {
-      if ($http_referer = "") {
        return 403;
-      }
     }
 
     location ~ ^.*\.endnote {
-      if ($http_referer = "") {
        return 403;
-      }
     }
 
     location / {

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -65,11 +65,13 @@ server {
           if ($http_referer = "") {
            return 403;
           }
+          return $upstream_status;
         }
         location ~ ^.*\.ris {
           if ($http_referer = "") {
            return 403;
           }
+          return $upstream_status;
         }
         # block all
         deny all;

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -39,19 +39,6 @@ server {
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 
-
-    location ~ ^.*\.ris {
-      if ($http_referer = "") {
-       return 403;
-      }
-    }
-
-    location ~ ^.*\.endnote {
-      if ($http_referer = "") {
-       return 403;
-      }
-    }
-
     location / {
 #        app_protect_enable on;
         limit_req zone=catalog-staging-ratelimit burst=80 nodelay;
@@ -73,9 +60,20 @@ server {
         include /etc/nginx/conf.d/templates/restrict.conf;
         # allow rapid7 network
         include /etc/nginx/conf.d/templates/rapid7.conf;
+        # limit downloads, exclude bots
+        location ~ ^.*\.endnote {
+          if ($http_referer = "") {
+           return 403;
+          }
+        }
+        location ~ ^.*\.ris {
+          if ($http_referer = "") {
+           return 403;
+          }
+        }
         # block all
         deny all;
-    }
+   }
 
 
     include /etc/nginx/conf.d/templates/errors.conf;

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -65,13 +65,25 @@ server {
           if ($http_referer = "") {
            return 403;
           }
-          return $upstream_status;
+          limit_req zone=catalog-staging-ratelimit burst=80 nodelay;
+          proxy_pass http://catalog-staging;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_connect_timeout      2h;
+          proxy_send_timeout         2h;
+          proxy_read_timeout         2h;
+          proxy_max_temp_file_size 0;
         }
         location ~ ^.*\.ris {
           if ($http_referer = "") {
            return 403;
           }
-          return $upstream_status;
+          limit_req zone=catalog-staging-ratelimit burst=80 nodelay;
+          proxy_pass http://catalog-staging;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_connect_timeout      2h;
+          proxy_send_timeout         2h;
+          proxy_read_timeout         2h;
+          proxy_max_temp_file_size 0;
         }
         # block all
         deny all;


### PR DESCRIPTION
Part of today's incident response. We still need to allow referred traffic to .ris and .endpoint resources to go through. Implementing this to preserve our Alma API quote in the meantime.

Related to #4203.

Co-authored-by: Anna Headley hackartisan@users.noreply.github.com
Co-authored-by: Bess Sadler bess@users.noreply.github.com
Co-authored-by: Carolyn Cole carolyncole@users.noreply.github.com
Co-authored-by: Esmé Cowles escowles@users.noreply.github.com
Co-authored-by: Francis Kayiwa <kayiwa@users.noreply.github.com>
Co-authored-by: Kevin Reiss kevinreiss@users.noreply.github.com
Co-authored-by: Mark Zelesky mzelesky@users.noreply.github.com
Co-authored-by: Max Kadel maxkadel@users.noreply.github.com
Co-authored-by: regineheberlein regineheberlein@users.noreply.github.com
Co-authored-by: Robert-Anthony Lee-Faison leefaisonr@users.noreply.github.com
Co-authored-by: Trey Pendragon tpendragon@users.noreply.github.com