### PR TITLE
Add CORS exceptions for PDC* when url doesn't match

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/datacommons-describe.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-describe.conf
@@ -1,6 +1,7 @@
 # https://datacommons.princeton.edu/describe should point to
 # https://pdc-describe-prod.princeton.edu/describe/
 location /describe/ {
+    add_header 'Access-Control-Allow-Origin' "$http_origin" always;
     add_header 'Access-Control-Allow-Origin' 'https://pdc-describe-prod.princeton.edu' always;
     proxy_pass https://pdc-describe-prod.princeton.edu/describe/;
     proxy_set_header X-Forwarded-Host $host;

--- a/roles/nginxplus/files/conf/http/templates/datacommons-describe.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-describe.conf
@@ -1,6 +1,7 @@
 # https://datacommons.princeton.edu/describe should point to
 # https://pdc-describe-prod.princeton.edu/describe/
 location /describe/ {
+    add_header 'Access-Control-Allow-Origin' 'https://pdc-describe-prod.princeton.edu' always;
     proxy_pass https://pdc-describe-prod.princeton.edu/describe/;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
@@ -3,6 +3,7 @@
 location /discovery/ {
     add_header 'Access-Control-Allow-Origin' "$http_origin" always;
     add_header 'Access-Control-Allow-Origin' 'https://pdc-discovery-prod.princeton.edu' always;
+    add_header 'Access-Control-Allow-Origin' '*' always;
     proxy_pass https://pdc-discovery-prod.princeton.edu/discovery/;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
@@ -1,6 +1,7 @@
 # https://datacommons.princeton.edu/discovery should point to
 # https://pdc-discovery-prod.princeton.edu/discovery/
 location /discovery/ {
+    add_header 'Access-Control-Allow-Origin' "$http_origin" always;
     add_header 'Access-Control-Allow-Origin' 'https://pdc-discovery-prod.princeton.edu' always;
     proxy_pass https://pdc-discovery-prod.princeton.edu/discovery/;
     proxy_set_header X-Forwarded-Host $host;

--- a/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
+++ b/roles/nginxplus/files/conf/http/templates/datacommons-discovery.conf
@@ -1,6 +1,7 @@
 # https://datacommons.princeton.edu/discovery should point to
 # https://pdc-discovery-prod.princeton.edu/discovery/
 location /discovery/ {
+    add_header 'Access-Control-Allow-Origin' 'https://pdc-discovery-prod.princeton.edu' always;
     proxy_pass https://pdc-discovery-prod.princeton.edu/discovery/;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
https://datacommons.princeton.edu/discovery should always accept resources from https://pdc-discovery-prod.princeton.edu

https://datacommons.princeton.edu/describe should always accept resources from https://pdc-describe-prod.princeton.edu

Ref https://github.com/pulibrary/pdc_discovery/issues/498