### PR TITLE
Ensuring that the Datadog logs for NGINX on TigerData hosts specify that these are associated with the `tigerdata` service

### DIFF
--- a/group_vars/tigerdata/production.yml
+++ b/group_vars/tigerdata/production.yml
@@ -50,12 +50,15 @@ datadog_typed_checks:
         - type: file
           path: /var/log/nginx/access.log
           source: nginx
+          service: tigerdata
         - type: file
           path: /var/log/nginx/error.log
           source: nginx
+          service: tigerdata
         - type: file
           path: /opt/tigerdata/current/log/production.log
           source: rails
+          service: tigerdata
 
 # This is needed to override what is specified in common.yml
 rails_app_vars:


### PR DESCRIPTION
This follows the changes proposed during the Datadog Book Club session held on 09/08/2023:

Co-authored-by: [Bess Sadler](mailto:bess@users.noreply.github.com)
Co-authored-by: [Alicia Cozine](mailto:acozine@users.noreply.github.com)
Co-authored-by: [Anna Headley](mailto:hackartisan@users.noreply.github.com)
Co-authored-by: [Max Kadel](mailto:maxkadel@users.noreply.github.com)