### PR TITLE
update slack alerts for lib-smb and geoserver playbooks

### DIFF
--- a/playbooks/geoserver_production.yml
+++ b/playbooks/geoserver_production.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: geoserver
+- name: build or update geoserver system
+  hosts: geoserver
   remote_user: pulsys
   become: true
   vars_files:
@@ -16,5 +17,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: "{{ slack_alerts_channel }}"

--- a/playbooks/lib_smb_serve_production.yml
+++ b/playbooks/lib_smb_serve_production.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: smb_serve
+- name: build or update the Samba shares
+  hosts: smb_serve
   remote_user: pulsys
   become: true
   vars_files:
@@ -12,5 +13,5 @@
     - name: tell everyone on slack you ran an ansible playbook
       slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "{{ inventory_hostname }} completed"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: "{{ slack_alerts_channel }}"


### PR DESCRIPTION
Closes #2852.

These are the last playbooks that still sent `{{ inventory_hostname }} completed` to slack.
