### PR TITLE
Add deploy user to allsearch boxes

### DIFF
--- a/inventory/all_projects/allsearch
+++ b/inventory/all_projects/allsearch
@@ -1,0 +1,4 @@
+[allsearch_api_staging]
+allsearch-api-staging1.princeton.edu
+[allsearch_api_production]
+allsearch-api-prod1.princeton.edu

--- a/playbooks/allsearch_api.yml
+++ b/playbooks/allsearch_api.yml
@@ -1,0 +1,18 @@
+---
+# by default this playbook runs in the staging environment
+# to run in production, pass '-e runtime_env=production'
+- name: build the Allsearch backend
+  hosts: allsearch_api_{{ runtime_env | default('staging') }}
+  remote_user: pulsys
+  become: true
+  roles:
+    - role: roles/deploy_user
+    - role: datadog
+      when: runtime_env | default('staging') == "production"
+
+  post_tasks:
+    - name: tell everyone on slack you ran an ansible playbook
+      community.general.slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
+        channel: "{{ slack_alerts_channel }}"


### PR DESCRIPTION
Adds a very minimal playbook for allsearch (all it does is run common and add a deploy user), hopefully it's a good starting point for future work.

I ran this on staging on 14 September.