### PR TITLE
[Postgresql] Move postgresql common role to playbook.

### DIFF
--- a/playbooks/cicognara.yml
+++ b/playbooks/cicognara.yml
@@ -14,7 +14,7 @@
     - role: roles/ruby
     - role: roles/deploy_user
     - role: roles/passenger
-    - role: roles/postgresql
+    - { role: 'roles/postgresql', tags: 'postgresql' }
     - role: roles/openjdk
     - role: roles/solrcloud
     - role: roles/blacklight_app

--- a/playbooks/postgresql.yml
+++ b/playbooks/postgresql.yml
@@ -12,6 +12,7 @@
     - ../host_vars/lib-postgres-staging2.princeton.edu.yml
     - ../group_vars/postgresql/vault.yml
   roles:
+    - role: roles/common
     - role: ../roles/postgresql
     - role: roles/datadog
       when: runtime_env | default('staging') == "production"

--- a/playbooks/pulfalight.yml
+++ b/playbooks/pulfalight.yml
@@ -11,7 +11,7 @@
     - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/pulfalight/vault.yml
   roles:
-    - role: roles/postgresql
+    - { role: 'roles/postgresql', tags: 'postgresql' }
     - role: roles/openjdk
     - role: roles/pulfalight
     - role: roles/datadog
@@ -32,7 +32,7 @@
     - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/pulfalight/vault.yml
   roles:
-    - role: roles/postgresql
+    - { role: 'roles/postgresql', tags: 'postgresql' }
     - role: roles/openjdk
     - role: roles/sidekiq_worker
     - role: roles/pulfalight

--- a/roles/postgresql/meta/main.yml
+++ b/roles/postgresql/meta/main.yml
@@ -14,4 +14,3 @@ galaxy_info:
       versions:
         - 18.04
 dependencies:
-  - role: common

--- a/roles/rails_app/meta/main.yml
+++ b/roles/rails_app/meta/main.yml
@@ -18,5 +18,5 @@ dependencies:
   - role: 'bind9'
   - role: 'deploy_user'
   - role: 'passenger'
-  - role: 'postgresql'
+  - { role: 'postgresql', tags: 'postgresql' }
   - role: 'nodejs'


### PR DESCRIPTION
It's both a "set a server up" playbook and a "apps include this" playbook - for "set a server up" it should be in the playbook, for "apps include this" common not being a dependency will allow us to optimize setting up required databases.

This also tags the postgresql role includes with "postgresql." By tagging postgresql we can run playbooks and just have it set up access/databases/users. This is useful for migrations. (see step 3 here: https://github.com/pulibrary/pulfalight/issues/1319)