### PR TITLE
[cdh] add cdh vms to nfs

### DIFF
--- a/group_vars/nfsserver/staging.yml
+++ b/group_vars/nfsserver/staging.yml
@@ -2,6 +2,8 @@
 # servers
 byzantine_tsp_staging1: "128.112.204.93"
 byzantine_tsp_staging2: "128.112.203.151"
+cdh_test_prosody1: "128.112.204.82"
+cdh_test_prosody2: "128.112.201.147"
 fpul_staging1: "128.112.204.18"
 fpul_staging2: "128.112.203.121"
 lib_jobs_staging1: "128.112.203.209"
@@ -17,10 +19,27 @@ recap_www_staging2: "128.112.203.131"
 slavery_staging1: "128.112.202.236"
 slavery_staging2: "128.112.203.152"
 # mounts
+cdh_fileshare_mount: "/var/nfs/cdh"
 drupal7_fileshare_mount: "/var/nfs/drupal7"
 open_marc_records_mount: "/var/nfs/open_marc_records"
 pas_fileshare_mount: "/var/nfs/pas"
 nfsserver_exports:
+  - share: "{{ cdh_fileshare_mount }}"
+    hosts:
+      - name: "{{ cdh_test_prosody1 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_test_prosody2 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
   - share: "{{ drupal7_fileshare_mount }}"
     hosts:
       - name: "{{ byzantine_tsp_staging1 }}"

--- a/group_vars/nfsserver/staging.yml
+++ b/group_vars/nfsserver/staging.yml
@@ -2,8 +2,14 @@
 # servers
 byzantine_tsp_staging1: "128.112.204.93"
 byzantine_tsp_staging2: "128.112.203.151"
+cdh_test_geniza1: "128.112.203.244"
+cdh_test_geniza2: "128.112.202.28"
 cdh_test_prosody1: "128.112.204.82"
 cdh_test_prosody2: "128.112.201.147"
+cdh_test_shxco1: "128.112.201.56"
+cdh_test_shxco2: "128.112.202.215"
+cdh_test_web1: "128.112.204.3"
+cdh_test_web2: "128.112.201.117"
 fpul_staging1: "128.112.204.18"
 fpul_staging2: "128.112.203.121"
 lib_jobs_staging1: "128.112.203.209"
@@ -26,6 +32,20 @@ pas_fileshare_mount: "/var/nfs/pas"
 nfsserver_exports:
   - share: "{{ cdh_fileshare_mount }}"
     hosts:
+      - name: "{{ cdh_test_geniza1 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_test_geniza2 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
       - name: "{{ cdh_test_prosody1 }}"
         options:
           - rw
@@ -34,6 +54,34 @@ nfsserver_exports:
           - no_root_squash
           - no_wdelay
       - name: "{{ cdh_test_prosody2 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_test_shxco1 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_test_shxco2 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_test_web1 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_test_web2 }}"
         options:
           - rw
           - sync

--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -26,6 +26,7 @@ lib-solr-prod4.princeton.edu
 lib-adc1.princeton.edu
 lib-adc2.princeton.edu
 [cdh_shared_staging]
+lib-fs-staging.princeton.edu
 lib-postgres-staging3.princeton.edu
 lib-solr-staging1.princeton.edu
 lib-solr-staging4.princeton.edu

--- a/roles/nfsserver/defaults/main.yml
+++ b/roles/nfsserver/defaults/main.yml
@@ -11,6 +11,7 @@
 #           - no_subtree_check
 #           - nohide
 nfsserver_exports: []
+cdh_fileshare_mount: "/var/nfs/cdh"
 drupal7_fileshare_mount: "/var/nfs/drupal7"
 open_marc_records_mount: "/var/nfs/open_marc_records"
 pas_fileshare_mount: "/var/nfs/pas"

--- a/roles/nfsserver/tasks/main.yml
+++ b/roles/nfsserver/tasks/main.yml
@@ -10,6 +10,7 @@
     group: "{{ deploy_user }}"
     mode: "0755"
   loop:
+    - "{{ cdh_fileshare_mount }}"
     - "{{ drupal7_fileshare_mount }}"
     - "{{ pas_fileshare_mount }}"
     - "{{ open_marc_records_mount }}"


### PR DESCRIPTION
- add lib-fs-staging access for CDH folks Co-authored-by: Rebecca Sutton Koeser <rlskoeser@users.noreply.github.com>
- add prosody test machine to have nfs access
- add all the cdh test servers to the nfs exports Co-authored-by: Rebecca Sutton Koeser <rlskoeser@users.noreply.github.com>
