### PR TITLE
[DPUL] Remove inaccurate dependencies from dpul

### DIFF
--- a/roles/dpul/meta/main.yml
+++ b/roles/dpul/meta/main.yml
@@ -14,15 +14,11 @@ galaxy_info:
       versions:
         - bionic
 dependencies:
-  - role: deploy_user
-  - role: passenger
   - role: redis
-  - role: postgresql
   - role: nodejs
   - role: openjdk
   - role: imagemagick
   - role: rails_app
   - role: shared_data
-  - role: solrcloud
   - role: sidekiq_worker
   - role: sneakers_worker


### PR DESCRIPTION
solrcloud shouldn't be there at all, and the rest are covered by
rails_app.
