### PR TITLE
[allsearch-api] Rate limit requests / sec

### DIFF
--- a/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
@@ -1,6 +1,14 @@
 # Ansible managed
 proxy_cache_path /data/nginx/allsearch-api/NGINX_cache/ keys_zone=allsearch-apicache:10m;
 
+map $limit $external_traffic {
+    0 "";
+    1 $binary_remote_addr;
+}
+
+# zone: 10mb can hold 160K IP addresses in memory
+limit_req_zone $external_traffic zone=allsearch-api-prod-ratelimit:10m rate=10r/s;
+
 upstream allsearch-api {
     zone allsearch-api 128k;
     least_conn;
@@ -37,6 +45,7 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         proxy_set_header Host $host;
+        limit_req zone=allsearch-api-prod-ratelimit burst=20 nodelay;
         proxy_cache allsearch-apicache;
     }
 

--- a/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
@@ -1,6 +1,14 @@
 # Ansible managed
 proxy_cache_path /data/nginx/allsearch-api-staging/NGINX_cache/ keys_zone=allsearch-api-stagingcache:10m;
 
+map $limit $external_traffic {
+    0 "";
+    1 $binary_remote_addr;
+}
+
+# zone: 10mb can hold 160K IP addresses in memory
+limit_req_zone $external_traffic zone=allsearch-api-staging-ratelimit:10m rate=10r/s;
+
 upstream allsearch-api-staging {
     zone allsearch-api-staging 64k;
     least_conn;
@@ -39,6 +47,7 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         proxy_set_header Host $host;
+        limit_req zone=allsearch-api-staging-ratelimit burst=20 nodelay;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
Closes https://github.com/pulibrary/allsearch_api/issues/45

Based on #4072 - using a lower burst rate, because this application does not download a bunch of assets when first loading the page, as the Catalog does.