### PR TITLE
i4329: Load balancer error page should use absolute path to image file

### DIFF
--- a/roles/nginxplus/files/cdh-error.html
+++ b/roles/nginxplus/files/cdh-error.html
@@ -85,7 +85,7 @@
         </p>
         <p>
         <a href="https://library.princeton.edu">
-          <img src="pul-logo-new.svg" alt="Princeton University Library"/>
+          <img src="/pul-logo-new.svg" alt="Princeton University Library"/>
         </a>
         </p>
         <p>

--- a/roles/nginxplus/files/cdh-forbidden.html
+++ b/roles/nginxplus/files/cdh-forbidden.html
@@ -78,7 +78,7 @@
         </p>
         <p>
         <a href="https://library.princeton.edu">
-          <img src="pul-logo-new.svg" alt="Princeton University Library"/>
+          <img src="/pul-logo-new.svg" alt="Princeton University Library"/>
         </a>
         </p>
         <p>

--- a/roles/nginxplus/files/error.html
+++ b/roles/nginxplus/files/error.html
@@ -86,7 +86,7 @@
           <a href="https://catalog.princeton.edu">Try the Library Catalog</a>
         </p>
         <a href="https://library.princeton.edu"
-          ><img src="pul-logo-new.svg" alt="Princeton University Library"
+          ><img src="/pul-logo-new.svg" alt="Princeton University Library"
         /></a>
       </div>
     </main>

--- a/roles/nginxplus/files/index.html
+++ b/roles/nginxplus/files/index.html
@@ -78,7 +78,7 @@
           <a href="https://catalog.princeton.edu">Go to the Library Catalog</a>
         </p>
         <a href="https://library.princeton.edu"
-          ><img src="pul-logo-new.svg" alt="Princeton University Library"
+          ><img src="/pul-logo-new.svg" alt="Princeton University Library"
         /></a>
       </div>
     </main>

--- a/roles/nginxplus/files/ratelimit.html
+++ b/roles/nginxplus/files/ratelimit.html
@@ -79,7 +79,7 @@
           <a href="mailto:lsupport@princeton.edu?subject=Rate limiting">Contact Library Support</a>
         </p>
         <a href="https://library.princeton.edu">
-          <img src="pul-logo-new.svg" alt="Princeton University Library"/>
+          <img src="/pul-logo-new.svg" alt="Princeton University Library"/>
         </a>
       </div>
     </main>


### PR DESCRIPTION
closes #4329 

The image file can always be found at /pul-logo-new.svg, but the error page might appear at a path like /my/error/is/here.html.  Using an absolute path to refer to the image means that the application layer doesn't have to try to scramble to find an image at /my/error/is/pul-logo-new.svg, sparing us some Honeybadger noise.