### PR TITLE
do not restart nginx when creating new certs

### DIFF
--- a/playbooks/incommon_certbot.yml
+++ b/playbooks/incommon_certbot.yml
@@ -7,8 +7,6 @@
   remote_user: pulsys
   become: true
 
-
-
   pre_tasks:
   - name: stop playbook if you didn't use --limit
     ansible.builtin.fail:
@@ -28,12 +26,6 @@
 
     - name: update acme certificates for {{ domain_name }}
       ansible.builtin.command: /usr/bin/certbot certonly --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ domain_name }}.princeton.edu --cert-name {{ domain_name }}
-
-    - name: nginxplus | restart nginx for realsies
-      service:
-        name: nginx
-        state: restarted
-      tags: always
 
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:

--- a/playbooks/incommon_certbot_multi.yml
+++ b/playbooks/incommon_certbot_multi.yml
@@ -27,12 +27,6 @@
     - name: update acme certificates for {{ domain_name }}
       ansible.builtin.command: /usr/bin/certbot certonly --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ domain_name }}.princeton.edu --domain {{ add_san_name }}.princeton.edu --cert-name {{ domain_name }}
 
-    - name: nginxplus | restart nginx for realsies
-      service:
-        name: nginx
-        state: restarted
-      tags: always
-
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"


### PR DESCRIPTION
Adding a cert is necessary but not sufficient for adding or updating a site on the load balancer. To avoid unexpected behavior, we should not restart nginx when we add the cert - we should only restart nginx when we deploy the new/updated config that uses the cert.
