### PR TITLE
[recap] Set config_sync_directory to a real directory

### DIFF
--- a/roles/recap_www/templates/settings.php.j2
+++ b/roles/recap_www/templates/settings.php.j2
@@ -15,7 +15,7 @@ $databases = array (
   ),
 );
 
-$settings['config_sync_directory'] = 'sites/default/files/config_GgqhGGKbNejSwVp5O02ojVx_r8RgogdoGvKO59yK4B0qosdaXejr4KDlieRiWNW7zfXdDYsxKw';
+$settings['config_sync_directory'] = 'sites/default/config';
 
 $settings['hash_salt'] = 'GgqhGGKbNejSwVp5O02ojVx_r8RgogdoGvKO59yK4B0qosdaXejr4KDlieRiWNW7zfXdDYsxKw';
 


### PR DESCRIPTION
Part of https://github.com/pulibrary/recap/issues/199

Sibling PR: https://github.com/pulibrary/recap/pull/257

I ran this on staging on 2 October, 2023