### PR TITLE
Get postgresql logs onto Datadog

### DIFF
--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -45,3 +45,8 @@ datadog_typed_checks:
           source: postgresql
           sourcecategory: postgresql_logs
           tags: "postgresql, env:prod, role:postgresql"
+          log_processing_rules:
+            - type: exclude_at_match
+              name: exclude_log_level_LOG
+              pattern: \"error_severity\":\"LOG\"
+

--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -33,14 +33,14 @@ datadog_typed_checks:
     configuration:
       init_config:
       instances:
-        - dbm: true
-          host: localhost
+        - host: localhost
+          dbm: true
           port: 5432
           username: datadog
           password: "{{ vault_datadog_db_password }}"
       logs:
         - type: file
-          path: /var/lib/postgresql/{{ postgres_version }}/main/pg_log/postgresql-%Y-%m-%d_%H%M%S.json
+          path: /var/lib/postgresql/{{ postgres_version }}/main/pg_log/pg.json
           service: database
           source: postgresql
           sourcecategory: postgresql_logs

--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -40,7 +40,7 @@ datadog_typed_checks:
           password: "{{ vault_datadog_db_password }}"
       logs:
         - type: file
-          path: /var/lib/postgresql/{{ postgres_version }}/main/pg_log/*.csv
+          path: /var/lib/postgresql/{{ postgres_version }}/main/pg_log/postgresql-%Y-%m-%d_%H%M%S.json
           service: database
           source: postgresql
           sourcecategory: postgresql_logs

--- a/roles/postgresql/templates/postgresql.conf.j2
+++ b/roles/postgresql/templates/postgresql.conf.j2
@@ -96,31 +96,28 @@ effective_cache_size = {{ cache_size }}
 
 # - Where to Log -
 
-log_destination = 'jsonlog' # Valid values are combinations of
-
-# This is used when logging to stderr:
-logging_collector = on  # Enable capturing of stderr, jsonlog,
+logging_collector = on   # Enable capturing of stderr, jsonlog,
 					# and csvlog into log files. Required
 					# to be on for csvlogs and jsonlogs.
 					# (change requires restart)
+log_destination = 'jsonlog'
 
 # These are only used if logging_collector is on:
-log_directory = 'pg_log' # directory where log files are written,
-					# can be absolute or relative to PGDATA
-log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log' # log file name pattern,
-					# can include strftime() escapes
-#log_file_mode = 0600			# creation mode for log files,
-					# begin with 0 to use octal notation
-#log_rotation_age = 1d			# Automatic rotation of logfiles will
-					# happen after that time.  0 disables.
-log_rotation_age = 1d # Automatic rotation of logfiles will
-log_rotation_size = 1GB # Automatic rotation of logfiles will
+log_directory = 'pg_log' # relative to PGDATA (/var/lib/postgresql/15/main/pg_log/)
+log_filename = 'pg.log'  # can include strftime() escapes, but daily rotation is enough
+log_statement = 'all'
+log_file_mode = 0644     # allow Datadog to read log files
+log_rotation_age = 1d		 # Automatic daily logfile rotation. 0 disables.
+log_rotation_size = 1GB  # Automatic rotation of large logfiles.
 log_checkpoints = on
 log_connections = on
 log_disconnections = on
-log_line_prefix = '%m [%p] %q%u@%d ' # special values:
-log_lock_waits = on # log lock waits deadlock_timeout
-log_temp_files = 0 # log temporary files equal or larger
+
+# prefix recommended for Datadog:
+log_line_prefix= '%m [%p] %d %a %u %h %c '
+# log_line_prefix = '%m [%p] %q%u@%d '
+log_lock_waits = on      # log lock waits deadlock_timeout
+log_temp_files = 0       # log temporary files equal or larger
 log_timezone = 'localtime'
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4357.

Updates the postgresql configuration:
- simplifies the log file name
- explicitly logs all statements
- updates the log file mode so the datadog user can read it
- uses log entry prefix recommended in datadog docs

Updates the production group vars for postgres to match the new config. We hope this will enable the datadog service.
