### PR TITLE
Add connection upgrade headers to CDH sandbox proxy location

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_test_sandbox.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_sandbox.conf
@@ -38,6 +38,8 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;


### PR DESCRIPTION
I have an app running on the sandbox that apparently requires connection upgrade headers when proxied by nginx. I have these settings in the nginx config on the sandbox server and when I access that server via ssh port forwarding the app works; when I disable these, I get an error about a web socket connection. When it is working in sandbox nginx and I access it through the load balancer it does not work. I'm hoping this configuration will allow it to work through lib-adc.