### PR TITLE
update service and sourcecategory for pgsql in datadog

### DIFF
--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -41,9 +41,9 @@ datadog_typed_checks:
       logs:
         - type: file
           path: /var/lib/postgresql/{{ postgres_version }}/main/pg_log/pg.json
-          service: database
+          service: postgres_cluster
           source: postgresql
-          sourcecategory: postgresql_logs
+          sourcecategory: database
           tags: "postgresql, env:prod, role:postgresql"
           log_processing_rules:
             - type: exclude_at_match


### PR DESCRIPTION
We had these two datadog config params backwards. This PR resets them to do what we want for our postgres logs:

- `service` can be any string; this is what shows up in Datadog UI as a way to filter the logs view - we set it to `postgres_cluster`, which is more descriptive than `database`
- `sourcecategory` is the type of log - we set this to `database`, which is more accurate than `postgresql_logs`