### PR TITLE
notify when nginx playbooks start, with tags

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -19,6 +19,13 @@
     when: ansible_limit is not defined
     run_once: true
 
+  - name: tell slack the playbook is starting
+    slack:
+      token: "{{ vault_pul_slack_token }}"
+      msg: "Ansible is now running `{{ ansible_play_name }}` with the `{{ ansible_run_tags }}` tag on {{ inventory_hostname }}"
+      channel: "{{ slack_alerts_channel }}"
+    tags: always
+
   # updates existing load balancer
   roles:
     - role: ../roles/nginxplus

--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -1,11 +1,25 @@
 ---
-- name: rebuild nginx with datadog
+- name: rebuild nginx server
   hosts: nginxplus_production # default to staging when we get a staging environment going
   remote_user: pulsys
   strategy: free
   become: true
   vars_files:
     - ../group_vars/nginxplus/main.yml
+
+  pre_tasks:
+  - name: stop playbook if you didn't use --limit
+    fail:
+      msg: "you must use -l or --limit"
+    when: ansible_limit is not defined
+    run_once: true
+
+  - name: tell slack the playbook is starting
+    slack:
+      token: "{{ vault_pul_slack_token }}"
+      msg: "Ansible is now running `{{ ansible_play_name }}` with the `{{ ansible_run_tags }}` tag on {{ inventory_hostname }}"
+      channel: "{{ slack_alerts_channel }}"
+    tags: always
 
 # rebuilds the load balancer from scratch
   roles:
@@ -24,7 +38,7 @@
       service: 
         name: nginx
         state: restarted
-      tag: always
+      tags: always
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
@@ -32,4 +46,4 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: "{{ slack_alerts_channel }}"
-      tag: always
+      tags: always


### PR DESCRIPTION
Closes #4381.

If no tag is passed at runtime, the output of the notification will say:

Ansible is now running `update loadbalancer configuration` with the `all` tag on lib-adc2.

Are there other playbooks we want to add this functionality to?