### PR TITLE
Make running the nginx playbook safer

### DIFF
--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -35,7 +35,9 @@ nginx_http_upload_dest: /etc/nginx/conf.d/
 # Pass -e nginx_cleanup_config=true to remove all existing NGINX configuration files before uploading current versions.
 # Use a list of paths you wish to remove.
 nginx_cleanup_config: false
-nginx_cleanup_config_path: "{{nginx_http_upload_dest}}"
+# task complains that nginx_cleanup_config_path is undefined with this setting
+# nginx_cleanup_config_path: "{{nginx_http_upload_dest}}"
+nginx_cleanup_config_path: /etc/nginx/conf.d/
 # Upload SSL certificates and keys.
 nginx_ssl_upload_enable: true
 nginx_ssl_crt_upload_src: ssl/*.pem

--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -32,9 +32,9 @@ nginx_server_names_hash_max_size: 1024
 nginx_http_upload_enable: true
 nginx_http_upload_src: conf/http/*.conf
 nginx_http_upload_dest: /etc/nginx/conf.d/
-# Remove previously existing NGINX configuration files.
+# Pass -e nginx_cleanup_config=true to remove all existing NGINX configuration files before uploading current versions.
 # Use a list of paths you wish to remove.
-nginx_cleanup_config: true
+nginx_cleanup_config: false
 nginx_cleanup_config_path: "{{nginx_http_upload_dest}}"
 # Upload SSL certificates and keys.
 nginx_ssl_upload_enable: true

--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -32,12 +32,12 @@ nginx_server_names_hash_max_size: 1024
 nginx_http_upload_enable: true
 nginx_http_upload_src: conf/http/*.conf
 nginx_http_upload_dest: /etc/nginx/conf.d/
-# Pass -e nginx_cleanup_config=true to remove all existing NGINX configuration files before uploading current versions.
-# Use a list of paths you wish to remove.
-nginx_cleanup_config: false
-# task complains that nginx_cleanup_config_path is undefined with this setting
-# nginx_cleanup_config_path: "{{nginx_http_upload_dest}}"
-nginx_cleanup_config_path: /etc/nginx/conf.d/
+# By default we leave all existing config untouched.
+# Set nginx_cleanup_config=true to remove
+# existing NGINX config files before uploading
+# nginx_cleanup_config: true
+# Pass the directory to clear as nginx_cleanup_config_path
+nginx_cleanup_config_path: "{{nginx_http_upload_dest}}"
 # Upload SSL certificates and keys.
 nginx_ssl_upload_enable: true
 nginx_ssl_crt_upload_src: ssl/*.pem

--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -1,11 +1,19 @@
 ---
+# variables for building nginxplus on our load balancers
 deploy_user_uid: 1003
 slack_alerts_channel:
   - '#infrastructure'
   - '#ansible-alerts'
 nginx_type: plus
+nginx_delete_license: false
+# enable rest API
 nginx_rest_api_enable: true
 nginx_rest_api_write: true
+nginx_rest_api_src: api.conf.j2
+nginx_rest_api_location: /etc/nginx/conf.d/api.conf
+nginx_rest_api_port: 8080
+nginx_rest_api_dashboard: true
+# modules to install
 nginx_modules:
   waf: true
   geoip: true
@@ -14,30 +22,31 @@ nginx_modules:
   image_filter: true
   rtmp: true
   xslt: true
-nginx_status_enable: false
-nginx_status_port: 8080
-nginx_rest_api_src: api.conf.j2
-nginx_rest_api_location: /etc/nginx/conf.d/api.conf
-nginx_rest_api_port: 8080
-nginx_rest_api_dashboard: true
-nginx_delete_license: false
+# the hash table stores server names for fast lookup
+# see PR 3578 on princeton_ansible
+# increase the size first
+# when that stops working, increase the hash buckets
+nginx_server_names_hash_bucket_size: 64
+nginx_server_names_hash_max_size: 1024
+# Upload HTTP NGINX static configuration files.
 nginx_http_upload_enable: true
 nginx_http_upload_src: conf/http/*.conf
 nginx_http_upload_dest: /etc/nginx/conf.d/
-nginx_stream_upload_enable: true
-nginx_stream_upload_src: conf/stream/*.conf
-nginx_stream_upload_dest: /etc/nginx/conf.d/stream/
+# Remove previously existing NGINX configuration files.
+# Use a list of paths you wish to remove.
 nginx_cleanup_config: true
-nginx_cleanup_config_path:
-  - /etc/nginx/conf.d
+nginx_cleanup_config_path: "{{nginx_http_upload_dest}}"
+# Upload SSL certificates and keys.
 nginx_ssl_upload_enable: true
 nginx_ssl_crt_upload_src: ssl/*.pem
 nginx_ssl_crt_upload_dest: /etc/nginx/conf.d/ssl/certs/
 nginx_ssl_key_upload_src: ssl/*.key
 nginx_ssl_key_upload_dest: /etc/nginx/conf.d/ssl/private/
+# add "template" files (partial configs)
 nginx_template_upload_enable: true
 nginx_template_upload_src: conf/http/templates/*.conf
 nginx_template_upload_dest: /etc/nginx/conf.d/templates/
+# configure datadog log collection
 datadog_api_key: "{{vault_datadog_key}}"
 datadog_config:
   tags: "{{nginxplus_tags}}"
@@ -64,146 +73,3 @@ datadog_checks:
         service: adc
         source: adc
         sourcecategory: http_web_access
-nginx_stream_template_enable: false
-nginx_stream_template:
-  default:
-    template_file: stream/default.conf.j2
-    conf_file_name: default.conf
-    conf_file_location: /etc/nginx/conf.d/stream/
-    network_streams:
-      default:
-        listen_address: localhost
-        listen_port: 80
-        udp_enable: false
-        proxy_pass: backend
-        proxy_timeout: 3s
-        proxy_connect_timeout: 1s
-        proxy_protocol: false
-        proxy_ssl:
-          cert: /etc/ssl/certs/proxy_default.crt
-          key: /etc/ssl/private/proxy_default.key
-          trusted_cert: /etc/ssl/certs/proxy_ca.crt
-          server_name: false
-          name: server_name
-          protocols: TLSv1 TLSv1.1 TLSv1.2
-          ciphers: HIGH:!aNULL:!MD5
-          verify: false
-          verify_depth: 1
-          session_reuse: true
-        health_check_plus: false
-    upstreams:
-      upstream1:
-        name: backend
-        lb_method: least_conn
-        zone_name: backend
-        zone_size: 64k
-        sticky_cookie: false
-        servers:
-          server1:
-            address: localhost
-            port: 8080
-            weight: 1
-            health_check: max_fails=1 fail_timeout=10s
-nginx_http_template_enable: false
-nginx_http_template:
-  default:
-    template_file: http/default.conf.j2
-    conf_file_name: default.conf
-    conf_file_location: /etc/nginx/conf.d/
-    port: 8081
-    server_name: localhost
-    error_page: /usr/share/nginx/html
-    root: /usr/share/nginx/html
-    https_redirect: false
-    autoindex: false
-    ssl:
-      cert: /etc/ssl/certs/default.crt
-      key: /etc/ssl/private/default.key
-      protocols: TLSv1 TLSv1.1 TLSv1.2
-      ciphers: HIGH:!aNULL:!MD5
-      session_cache: none
-      session_timeout: 5m
-    web_server:
-      locations:
-        default:
-          location: /home
-          html_file_location: /usr/share/nginx/html
-          html_file_name: index.html
-          autoindex: false
-          auth_basic: null
-          auth_basic_file: null
-      http_demo_conf: false
-    reverse_proxy:
-      proxy_cache_path:
-        - path: /var/cache/nginx/proxy/backend
-          keys_zone:
-            name: backend_proxy_cache
-            size: 10m
-          levels: "1:2"
-          max_size: 10g
-          inactive: 60m
-          use_temp_path: true
-      proxy_temp_path:
-        path: /var/cache/nginx/proxy/temp
-      proxy_cache_lock: true
-      proxy_cache_min_uses: 5
-      proxy_cache_revalidate: true
-      proxy_cache_use_stale:
-        - error
-        - timeout
-      proxy_ignore_headers:
-        - Expires
-      locations:
-        backend:
-          location: /
-          proxy_connect_timeout: null
-          proxy_pass: http://backend
-          proxy_read_timeout: null
-          proxy_ssl:
-            cert: /etc/ssl/certs/proxy_default.crt
-            key: /etc/ssl/private/proxy_default.key
-            trusted_cert: /etc/ssl/certs/proxy_ca.crt
-            server_name: false
-            name: server_name
-            protocols: TLSv1 TLSv1.1 TLSv1.2
-            ciphers: HIGH:!aNULL:!MD5
-            verify: false
-            verify_depth: 1
-            session_reuse: true
-          proxy_temp_path:
-            path: /var/cache/nginx/proxy/backend/temp
-          proxy_cache_lock: false
-          proxy_cache_min_uses: 3
-          proxy_cache_revalidate: false
-          proxy_cache_use_stale:
-            - http_403
-            - http_404
-          proxy_ignore_headers:
-            - Vary
-            - Cache-Control
-          proxy_redirect: false
-          websocket: false
-          auth_basic: null
-          auth_basic_file: null
-      health_check_plus: false
-    proxy_cache:
-      proxy_cache_path:
-        path: /var/cache/nginx
-        keys_zone:
-          name: one
-          size: 10m
-      proxy_temp_path:
-        path: /var/cache/nginx/proxy
-    upstreams:
-      upstream1:
-        name: backend
-        lb_method: least_conn
-        zone_name: backend_mem_zone
-        zone_size: 64k
-        sticky_cookie: false
-        servers:
-          server1:
-            address: localhost
-            port: 8081
-            weight: 1
-            health_check: max_fails=1 fail_timeout=10s

--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -2,7 +2,9 @@
 # you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml`
 # to update the second load-balancer, switch which adc# host is currently active, then run the playbook on the second (formerly active, now inactive) host
 # to update configuration for existing sites, run with '-t update_conf' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml -t update_conf`
-# to replace SSL certificates and keys, run with `-t SSL`
+# to replace SSL certificates and keys, run with '-t SSL'
+# if you want to remove obsolete config files, you must pass '-e nginx_cleanup_config=true'
+# note that this will delete the entire config directory
 
 - name: update loadbalancer configuration
   hosts: nginxplus_production # default to staging when we get a staging environment going

--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -103,6 +103,9 @@ nginx_main_upload_dest: /etc/nginx/
 nginx_html_upload_enable: false
 nginx_html_upload_src: www/*
 nginx_html_upload_dest: /usr/share/nginx/html
+# delete old config if needed
+nginx_cleanup_config: false
+nginx_cleanup_config_path: /etc/nginx/conf.d/
 # Enable creating dynamic templated NGINX HTML demo websites.
 nginx_html_demo_template_enable: false
 nginx_html_demo_template:

--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -82,6 +82,10 @@ nginx_modules:
 nginx_amplify_enable: false
 nginx_amplify_api_key: null
 
+# add template files for library production and staging
+# defaults set this to false for testing
+nginx_template_upload_enable: false
+
 # Install NGINX Controller.
 # Use your NGINX Controller API key and NGINX Controller API endpoint.
 # Requires NGINX Plus and write access to the NGINX Plus REST API.
@@ -96,17 +100,25 @@ nginx_controller_api_endpoint: null
 nginx_unit_enable: false
 nginx_unit_modules: null
 # Upload the main NGINX configuration file.
+# Set to false for testing
 nginx_main_upload_enable: false
-nginx_main_upload_src: conf/nginx.conf
-nginx_main_upload_dest: /etc/nginx/
+# Upload HTTP NGINX configuration files.
+# Set to false for testing
+nginx_http_upload_enable: false
 # Upload HTML files.
+# Set to false for testing
 nginx_html_upload_enable: false
 nginx_html_upload_src: www/*
 nginx_html_upload_dest: /usr/share/nginx/html
 # delete old config if needed
+# Set to false for testing
 nginx_cleanup_config: false
 nginx_cleanup_config_path: /etc/nginx/conf.d/
+# Upload SSL certificates and keys.
+# Set to false for testing
+nginx_ssl_upload_enable: false
 # Enable creating dynamic templated NGINX HTML demo websites.
+# Set to false for testing
 nginx_html_demo_template_enable: false
 nginx_html_demo_template:
   default:
@@ -117,6 +129,7 @@ nginx_html_demo_template:
 
 # Enable creating dynamic templated NGINX configuration files.
 # Defaults are the values found in a fresh NGINX installation.
+# Set to false for testing
 nginx_main_template_enable: false
 nginx_main_template:
   template_file: nginx.conf.j2
@@ -142,6 +155,7 @@ nginx_main_template:
 # Enable creating dynamic templated NGINX HTTP configuration files.
 # Defaults will not produce a valid configuration. Instead they are meant to showcase
 # the options available for templating. Each key represents a new configuration file.
+# Set to false for testing
 nginx_http_template_enable: false
 nginx_http_template:
   default:
@@ -373,7 +387,7 @@ nginx_rest_api_dashboard: false
 # Upload Stream NGINX configuration files.
 # was set to 'true' in the group_vars for nginxplus
 # but we do not have any files in conf/stream/
-# nginx_stream_upload_enable: true
+nginx_stream_upload_enable: false
 nginx_stream_template_enable: false
 nginx_stream_upload_src: conf/stream/*.conf
 nginx_stream_upload_dest: /etc/nginx/conf.d/stream/

--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -95,44 +95,14 @@ nginx_controller_api_endpoint: null
 # Default is false.
 nginx_unit_enable: false
 nginx_unit_modules: null
-
-# Remove previously existing NGINX configuration files.
-# Use a list of paths you wish to remove.
-# Default is false.
-nginx_cleanup_config: false
-nginx_cleanup_config_path:
-  - /etc/nginx/conf.d
-
-# add template files for library production and staging
-nginx_template_upload_enable: false
-nginx_template_upload_src: conf/http/templates/*.conf
-nginx_template_upload_dest: /etc/nginx/conf.d/templates/
-# Enable uploading NGINX configuration files to your system.
-# Default for uploading files is false.
-# Default location of files is the files folder within the NGINX Ansible role.
 # Upload the main NGINX configuration file.
 nginx_main_upload_enable: false
 nginx_main_upload_src: conf/nginx.conf
 nginx_main_upload_dest: /etc/nginx/
-# Upload HTTP NGINX configuration files.
-nginx_http_upload_enable: false
-nginx_http_upload_src: conf/http/*.conf
-nginx_http_upload_dest: /etc/nginx/conf.d/
-# Upload Stream NGINX configuration files.
-nginx_stream_upload_enable: false
-nginx_stream_upload_src: conf/stream/*.conf
-nginx_stream_upload_dest: /etc/nginx/conf.d/
 # Upload HTML files.
 nginx_html_upload_enable: false
 nginx_html_upload_src: www/*
 nginx_html_upload_dest: /usr/share/nginx/html
-# Upload SSL certificates and keys.
-nginx_ssl_upload_enable: false
-nginx_ssl_crt_upload_src: ssl/*.crt
-nginx_ssl_crt_upload_dest: /etc/ssl/certs/
-nginx_ssl_key_upload_src: ssl/*.key
-nginx_ssl_key_upload_dest: /etc/ssl/private/
-
 # Enable creating dynamic templated NGINX HTML demo websites.
 nginx_html_demo_template_enable: false
 nginx_html_demo_template:
@@ -397,7 +367,13 @@ nginx_rest_api_dashboard: false
 # Enable creating dynamic templated NGINX stream configuration files.
 # Defaults will not produce a valid configuration. Instead they are meant to showcase
 # the options available for templating. Each key represents a new configuration file.
+# Upload Stream NGINX configuration files.
+# was set to 'true' in the group_vars for nginxplus
+# but we do not have any files in conf/stream/
+# nginx_stream_upload_enable: true
 nginx_stream_template_enable: false
+nginx_stream_upload_src: conf/stream/*.conf
+nginx_stream_upload_dest: /etc/nginx/conf.d/stream/
 nginx_stream_template:
   default:
     template_file: stream/default.conf.j2
@@ -417,6 +393,8 @@ nginx_stream_template:
           cert: /etc/ssl/certs/proxy_default.crt
           key: /etc/ssl/private/proxy_default.key
           trusted_cert: /etc/ssl/certs/proxy_ca.crt
+          server_name: false
+          name: server_name
           protocols: TLSv1 TLSv1.1 TLSv1.2
           ciphers: HIGH:!aNULL:!MD5
           verify: false
@@ -436,8 +414,3 @@ nginx_stream_template:
             port: 8080
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
-
-# manage the hash table that stores server names for fast lookup
-# increase the size first, when that stops working, increase the number of hash buckets in the table
-nginx_server_names_hash_bucket_size: 64
-nginx_server_names_hash_max_size: 1024


### PR DESCRIPTION
We are working to move most configs over to a template instead of static configs. In the meantime, however, we can make running the nginxplus playbook safer by only running the 'cleanup' tasks when we absolutely need to.

This PR also tries to organize the variables for the nginx role a little better:
- eliminates duplication (identical vars set to identical settings in group_vars and role defaults/main.yml) - hoping to save us from some vars-precedence issues in future
- puts vars in active use into the group_vars
- removes vars that are not in active use from the group_vars so we know which vars we are using and why