### PR TITLE
[allsearch_frontend] prefix envvar with VITE_

### DIFF
--- a/roles/allsearch_frontend/templates/env.j2
+++ b/roles/allsearch_frontend/templates/env.j2
@@ -1,5 +1,8 @@
 # NOTE: Variables in this file may be exposed via requests made through the browser
 # For more information see https://github.com/pulibrary/allsearch_frontend/issues/28
-ALLSEARCH_API_URL='{{ allsearch_api_url |default('https://allsearch-api-staging.princeton.edu') }}'
+#
+# If you need the variable to be available to the client after it has been compiled
+# (i.e. at runtime), make sure to include the prefix VITE_
+VITE_ALLSEARCH_API_URL='{{ allsearch_api_url |default('https://allsearch-api-staging.princeton.edu') }}'
 VITE_HONEYBADGER_API_KEY='{{ vault_allsearch_frontend_honeybadger_api_key | default('this-is-visible-on-requests') }}'
 VITE_HONEYBADGER_ENV='{{ allsearch_frontend_environment | default('set-environment') }}'


### PR DESCRIPTION
This makes it available to the client

Helps with https://github.com/pulibrary/allsearch_frontend/issues/88

Sibling PR: https://github.com/pulibrary/allsearch_frontend/pull/89