### PR TITLE
[allsearch] add second vm

### DIFF
--- a/roles/nginxplus/files/conf/http/allsearch_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch_staging.conf
@@ -13,6 +13,7 @@ upstream allsearch-staging {
     zone allsearch-staging 64k;
     least_conn;
     server allsearch-staging1.princeton.edu resolve;
+    server allsearch-staging2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_allsearch-stagingcookie
           lookup=$cookie_allsearch-stagingcookie


### PR DESCRIPTION
the second vm was missing on the loadbalancer. This adds it
Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: Kim Leaman <kelea99@users.noreply.github.com>
Co-authored-by: regineheberlein <regineheberlein@users.noreply.github.com>
Co-authored-by: Ryan Laddusaw <rladdusaw@users.noreply.github.com>
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
