### PR TITLE
[imagecat] move from windows host

### DIFF
--- a/roles/nginxplus/files/conf/http/imagecat_prod.conf
+++ b/roles/nginxplus/files/conf/http/imagecat_prod.conf
@@ -12,7 +12,7 @@ upstream imagecat_prod {
 
 server {
     listen 80;
-    server_name imagecat-prod.princeton.edu;
+    server_name imagecat.princeton.edu;
 
     location / {
         return 301 https://$server_name$request_uri;
@@ -22,10 +22,10 @@ server {
 server {
     listen 443 ssl;
     http2 on;
-    server_name imagecat-prod.princeton.edu;
+    server_name imagecat.princeton.edu;
 
-    ssl_certificate            /etc/letsencrypt/live/imagecat-prod/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/imagecat-prod/privkey.pem;
+    ssl_certificate            /etc/letsencrypt/live/imagecat/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/imagecat/privkey.pem;
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 


### PR DESCRIPTION
change the name to imagecat.princeton.edu
point to ACME generated certs

remember to revoke imagecat-prod
Co-authored-by: Anna Headley <hackartisan@users.noreply.github.com>
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>

this will close https://github.com/pulibrary/imagecat-rails/issues/25
