### PR TITLE
install older datadog-agent on postgres to support pg checks

### DIFF
--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -26,6 +26,8 @@ postgres_port: 5432
 postgres_admin_user: "{{ postgresadmin }}"
 
 datadog_api_key: "{{ vault_datadog_key }}"
+datadog_agent_version: "1:6.46.0-1"
+datadog_agent_allow_downgrade: true
 datadog_config:
   log_enabled: true
 datadog_typed_checks:


### PR DESCRIPTION
Partial fix for #4369.

Using datadog-agent 6.46 lets the postgresql check succeed.

```
    postgres (13.7.0)
    -----------------
      Instance ID: postgres:e38e16b591127b8f [WARNING]
      Configuration Source: file:/etc/datadog-agent/conf.d/postgres.d/conf.yaml
      Total Runs: 2
      Metric Samples: Last Run: 135,013, Total: 135,791
      Events: Last Run: 0, Total: 0
      Database Monitoring Activity Samples: Last Run: 2, Total: 2
      Database Monitoring Metadata Samples: Last Run: 134,014, Total: 134,017
      Database Monitoring Query Samples: Last Run: 3, Total: 3
      Service Checks: Last Run: 1, Total: 2
      Average Execution Time : 79ms
      Last Execution Date : 2023-10-20 18:51:08 UTC (1697827868000)
      Last Successful Execution Date : 2023-10-20 18:51:08 UTC (1697827868000)
      metadata:
        resolved_hostname: lib-postgres-prod1
        version.major: 15
        version.minor: 4
        version.patch: 0
        version.raw: 15.4 (Ubuntu 15.4-2.pgdg22.04+1)
        version.scheme: semver

      Warning: Unable to collect statement metrics because pg_stat_statements is not created in database 'postgres'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#pg-stat-statements-not-created for more details
code=pg-stat-statements-not-created dbname=postgres host=lib-postgres-prod1
```