### PR TITLE
Updating orcid-prod to also be know as orcid

### DIFF
--- a/playbooks/incommon_certbot.yml
+++ b/playbooks/incommon_certbot.yml
@@ -1,7 +1,8 @@
 ---
 # you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v -e domain_name=datacommons --limit lib-adc2.princeton.edu playbooks/incommon_certbot.yml`
-# in the event of SAN pass a variable like this
-#  -e add_san_name= "--domain pdc-discovery-prod.princeton.edu"
+# This playbook will need to be run on both load balancers sequentially
+# The domain_name will also be the location that will be utilized in the load balancer config `/etc/letsencrypt/live/datacommons/fullchain.pem;`
+# if a valid certificate already exists the existing certificate must be revoked prior to running this playbook for the playbook to change the system
 - name: add incommon acme for {{ domain_name }}
   hosts: nginxplus_production # default to staging when we get a staging environment going
   remote_user: pulsys

--- a/playbooks/incommon_certbot_multi.yml
+++ b/playbooks/incommon_certbot_multi.yml
@@ -1,5 +1,8 @@
 ---
 # you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v -e domain_name=findingaids-staging -e add_san_name="pulfalight-staging" --limit lib-adc2.princeton.edu playbooks/incommon_certbot_multi.yml`
+# This playbook will need to be run on both load balancers sequentially
+# The domain_name will also be the location that will be utilized in the load balancer config `/etc/letsencrypt/live/datacommons/fullchain.pem;`
+# if a valid certificate already exists the existing certificate must be revoked prior to running this playbook for the playbook to change the system
 - name: add incommon acme for {{ domain_name }}
   hosts: nginxplus_production # default to staging when we get a staging environment going
   remote_user: pulsys

--- a/playbooks/incommon_certbot_revoke.yml
+++ b/playbooks/incommon_certbot_revoke.yml
@@ -1,0 +1,35 @@
+---
+# you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v -e domain_name=orcid-prod --limit lib-adc2.princeton.edu playbooks/incommon_certbot_revoke.yml`
+# This playbook will need to be run on both load balancers sequentially
+- name: revoke incommon acme for {{ domain_name }}
+  hosts: nginxplus_production # default to staging when we get a staging environment going
+  remote_user: pulsys
+  become: true
+
+  pre_tasks:
+  - name: stop playbook if you didn't use --limit
+    ansible.builtin.fail:
+      msg: "you must use -l or --limit"
+    when: ansible_limit is not defined
+    run_once: true
+  vars_files:
+    - ../group_vars/all/vault.yml
+
+  tasks:
+    - name: install certbot software
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - certbot
+
+    - name: revoke acme certificates for {{ domain_name }}
+      ansible.builtin.command: /usr/bin/certbot revoke --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ domain_name }}.princeton.edu --cert-path /etc/letsencrypt/live/{{ domain_name }}/cert.pem
+      become_user: root
+      become: true
+
+    - name: tell everyone on slack you ran an ansible playbook
+      community.general.slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -1,10 +1,10 @@
 ---
-# you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml`
+# you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus.yml`
 # to update the second load-balancer, switch which adc# host is currently active, then run the playbook on the second (formerly active, now inactive) host
-# to update configuration for existing sites, run with '-t update_conf' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus_production.yml -t update_conf`
-# to replace SSL certificates and keys, run with '-t SSL'
+# to update configuration for existing sites, run with '-t update_conf' for example `ansible-playbook -v --limit lib-adc2.princeton.edu playbooks/nginxplus.yml -t update_conf`
 # if you want to remove obsolete config files, you must pass '-e nginx_cleanup_config=true'
 # note that this will delete the entire config directory
+# To find the active load-balancer ssh onto a machine and run `ip a |grep 146` the active one will display `inet 128.112.203.146/32 scope global eno1`
 
 - name: update loadbalancer configuration
   hosts: nginxplus_production # default to staging when we get a staging environment going

--- a/roles/nginxplus/files/conf/http/orcid_prod.conf
+++ b/roles/nginxplus/files/conf/http/orcid_prod.conf
@@ -23,12 +23,52 @@ server {
 }
 
 server {
+    listen 80;
+    server_name orcid.princeton.edu;
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+server {
     listen 443 ssl;
     http2 on;
     server_name orcid-prod.princeton.edu;
 
-    ssl_certificate            /etc/letsencrypt/live/orcid-prod/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/orcid-prod/privkey.pem;
+    ssl_certificate            /etc/letsencrypt/live/orcid/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/orcid/privkey.pem;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+    client_max_body_size       0;
+
+    location / {
+#        app_protect_enable on;
+#        app_protect_security_log_enable on;
+        proxy_pass http://orcid-prod;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_cache pdc-orcid-prodcache;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
+        health_check uri=/ interval=10 fails=3 passes=2;
+        # allow princeton network (during test period)
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
+    }
+
+    include /etc/nginx/conf.d/templates/errors.conf;
+
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name orcid.princeton.edu;
+
+    ssl_certificate            /etc/letsencrypt/live/orcid/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/orcid/privkey.pem;
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
     client_max_body_size       0;


### PR DESCRIPTION
Also adding more information into the playbook comments for certificates

Additionally revoked the existing certificate using the new playbook and ran
```
ansible-playbook -v -e domain_name=orcid -e add_san_name="orcid-prod" --limit lib-adc2.princeton.edu playbooks/incommon_certbot_multi.yml
ansible-playbook -v -e domain_name=orcid -e add_san_name="orcid-prod" --limit lib-adc1.princeton.edu playbooks/incommon_certbot_multi.yml
```
