### PR TITLE
[solr-prod9] stop traffic

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
@@ -6,7 +6,7 @@ upstream lib-solr9-prod {
     least_time header 'inflight';
     zone lib-solr9-prod 128k;
     server lib-solr-prod1.princeton.edu:8983 resolve;
-    server lib-solr-prod2.princeton.edu:8983 resolve;
+#    server lib-solr-prod2.princeton.edu:8983 resolve;
     server lib-solr-prod3.princeton.edu:8983 resolve;
     sticky learn
           create=$upstream_cookie_lib-solr9-prodcookie


### PR DESCRIPTION
solr-prod2 is connecting to the wrong zookeeper ensemble
we are commenting it out to prevent the loadbalancer from sending traffic to it

Co-authored-by: Anna Headley <hackartisan@users.noreply.github.com>
Co-authored-by: Hector Correa <hectorcorrea@users.noreply.github.com>
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
Co-authored-by: Rebecca Sutton Koeser <rlskoeser@users.noreply.github.com>
