### PR TITLE
Introduce and document consistent scheme for central redis db usage

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -90,9 +90,9 @@ rails_app_vars:
   - name: OL_READ_ONLY_MODE
     value: '{{ol_read_only_mode}}'
   - name: OL_REDIS_DB
-    value: '7'
+    value: "{{ central_redis_db }}"
   - name: OL_REDIS_HOST
-    value: "{{ ol_redis_host }}"
+    value: "{{ central_redis_host }}"
   - name: OL_SECRET_KEY_BASE
     value: "{{ ol_secret_key }}"
   - name: ORANGELIGHT_ADMIN_NETIDS

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -13,7 +13,8 @@ ol_rabbit_host: "figgy1.princeton.edu"
 ol_rabbit_password: "{{ vault_rabbit_production_password }}"
 ol_rabbit_user: "{{ vault_rabbit_production_user }}"
 ol_read_only_mode: 'false'
-ol_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_db: '7'
 ol_secret_key: "{{ vault_ol_secret_key }}"
 ol_smtp_host: "lib-ponyexpr.princeton.edu"
 ol_smtp_port: "25"

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -16,7 +16,8 @@ ol_rabbit_host: "figgy-staging2.princeton.edu"
 ol_rabbit_password: "{{ vault_rabbit_staging_password }}"
 ol_rabbit_user: "{{ vault_rabbit_staging_user }}"
 ol_read_only_mode: 'false'
-ol_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_db: '6'
 ol_secret_key: "{{ vault_ol_alma_qa_secret_key }}"
 ol_solr_url: http://lib-solr8-prod.princeton.edu:8983/solr/catalog-alma-production-rebuild
 passenger_app_env: "qa"

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -17,7 +17,7 @@ ol_rabbit_password: "{{ vault_rabbit_staging_password }}"
 ol_rabbit_user: "{{ vault_rabbit_staging_user }}"
 ol_read_only_mode: 'false'
 central_redis_host: 'lib-redis-prod1.princeton.edu'
-central_redis_db: '6'
+central_redis_db: '7'
 ol_secret_key: "{{ vault_ol_alma_qa_secret_key }}"
 ol_solr_url: http://lib-solr8-prod.princeton.edu:8983/solr/catalog-alma-production-rebuild
 passenger_app_env: "qa"

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -16,7 +16,8 @@ ol_rabbit_host: "figgy-staging2.princeton.edu"
 ol_rabbit_password: "{{ vault_rabbit_staging_password }}"
 ol_rabbit_user: "{{ vault_rabbit_staging_user }}"
 ol_read_only_mode: 'false'
-ol_redis_host: 'lib-redis-staging1.princeton.edu'
+central_redis_host: 'lib-redis-staging1.princeton.edu'
+central_redis_db: '6'
 ol_secret_key: "{{ vault_ol_staging_secret_key }}"
 ol_solr_url: http://lib-solr8-staging.princeton.edu:8983/solr/catalog-staging
 passenger_app_env: "staging"

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -17,7 +17,7 @@ ol_rabbit_password: "{{ vault_rabbit_staging_password }}"
 ol_rabbit_user: "{{ vault_rabbit_staging_user }}"
 ol_read_only_mode: 'false'
 central_redis_host: 'lib-redis-staging1.princeton.edu'
-central_redis_db: '6'
+central_redis_db: '7'
 ol_secret_key: "{{ vault_ol_staging_secret_key }}"
 ol_solr_url: http://lib-solr8-staging.princeton.edu:8983/solr/catalog-staging
 passenger_app_env: "staging"

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -51,6 +51,8 @@ subversion_pulfa_repo: '{{vault_subversion_pulfa_repo}}'
 subversion_pulfa_dir_path: '/var/opt/pulfa'
 subversion_pulfa_username: '{{vault_subversion_pulfa_username}}'
 subversion_pulfa_password: '{{vault_subversion_pulfa_password}}'
+central_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_db: '3'
 rails_app_vars:
   - name: PULFALIGHT_SECRET_KEY_BASE
     value: '{{vault_pulfalight_production_secret_key}}'
@@ -77,9 +79,9 @@ rails_app_vars:
   - name: ASPACE_PASSWORD
     value: '{{vault_pulfalight_aspace_production_password}}'
   - name: PULFALIGHT_REDIS_URL
-    value: 'lib-redis.princeton.edu'
+    value: '{{central_redis_host}}'
   - name: PULFALIGHT_REDIS_DB
-    value: '2'
+    value: '{{central_redis_db}}'
   - name: UNPUBLISHED_AUTH_TOKEN
     value: '{{vault_pulfalight_unpublished_auth_token}}'
   - name: FIGGY_AUTH_TOKEN

--- a/group_vars/pulfalight/qa.yml
+++ b/group_vars/pulfalight/qa.yml
@@ -50,6 +50,8 @@ subversion_pulfa_dir_path: '/var/opt/pulfa'
 subversion_pulfa_username: '{{vault_subversion_pulfa_username}}'
 subversion_pulfa_password: '{{vault_subversion_pulfa_password}}'
 # note we're not using FIGGY_AUTH_TOKEN in qa; there's no figgy it should talk to
+central_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_db: '4'
 rails_app_vars:
   - name: PULFALIGHT_SECRET_KEY_BASE
     value: '{{vault_pulfalight_qa_secret_key}}'
@@ -76,9 +78,9 @@ rails_app_vars:
   - name: ASPACE_PASSWORD
     value: '{{vault_pulfalight_aspace_qa_password}}'
   - name: PULFALIGHT_REDIS_URL
-    value: 'lib-redis-prod1.princeton.edu'
+    value: '{{central_redis_host}}'
   - name: PULFALIGHT_REDIS_DB
-    value: '4'
+    value: '{{central_redis_db}}'
   - name: UNPUBLISHED_AUTH_TOKEN
     value: '{{vault_pulfalight_unpublished_auth_token}}'
   - name: ADMIN_NETIDS

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -49,6 +49,8 @@ subversion_pulfa_repo: '{{vault_subversion_pulfa_repo}}'
 subversion_pulfa_dir_path: '/var/opt/pulfa'
 subversion_pulfa_username: '{{vault_subversion_pulfa_username}}'
 subversion_pulfa_password: '{{vault_subversion_pulfa_password}}'
+central_redis_host: 'lib-redis-staging1.princeton.edu'
+central_redis_db: '4'
 rails_app_vars:
   - name: PULFALIGHT_SECRET_KEY_BASE
     value: '{{vault_pulfalight_staging_secret_key}}'
@@ -75,9 +77,9 @@ rails_app_vars:
   - name: ASPACE_PASSWORD
     value: '{{vault_pulfalight_aspace_staging_password}}'
   - name: PULFALIGHT_REDIS_URL
-    value: 'lib-redis.princeton.edu'
+    value: '{{central_redis_host}}'
   - name: PULFALIGHT_REDIS_DB
-    value: '3'
+    value: '{{central_redis_db}}'
   - name: UNPUBLISHED_AUTH_TOKEN
     value: '{{vault_pulfalight_unpublished_auth_token}}'
   - name: FIGGY_AUTH_TOKEN

--- a/roles/redis/README.md
+++ b/roles/redis/README.md
@@ -1,7 +1,52 @@
-Role Name
+Redis Role
 =========
 
-This role install redis
+This role installs a redis server. If your application only needs to connect to
+the central redis instance, you don't need to run this role.
+
+### Connecting to the central redis
+
+To connect to the central redis instance, define a variable `central_redis_db` and
+give it a number between 1 and 15 that hasn't been used yet for the central host
+you're connecting to. Don't use database
+0, which is the default database in case one is not specified. To find an unused
+number, grep the group_vars directory for `central_redis_db` /
+`central_redis_host` pairs (example `ag` command below). Once you've
+identified a db number for your application you can set it to an environment
+variable that your application will access in its redis or sidekiq
+configuration.
+
+You also need to have your application install the redis-tools package.
+
+For good measure, add your app to the list below to help us track which
+applications are using the central redis hosts.
+
+Example configuration in a group_vars file:
+
+```
+rails_app_dependencies:
+  - redis-tools
+central_redis_host: 'lib-redis-prod1.princeton.edu'
+central_redis_db: '1'
+rails_app_vars:
+  - name: PULFALIGHT_REDIS_URL
+    value: '{{central_redis_host}}'
+  - name: PULFALIGHT_REDIS_DB
+    value: '{{central_redis_db}}'
+```
+
+With this configuration we can easily search for used host / db combinations
+with, e.g., `ag central_redis.*: group_vars`
+
+#### Apps using central redis
+- orangelight
+- pulfalight
+- libwww
+    - currently configured using a "prefix" strategy. This may mean it's using
+        database 0. Some relevant info:
+        - https://docs.spring.io/spring-data/redis/docs/1.8.0.RELEASE/api/org/springframework/data/redis/cache/RedisCachePrefix.html
+        - https://stackoverflow.com/questions/16819514/stats-of-elements-with-a-prefix-in-redis
+
 
 Requirements
 ------------


### PR DESCRIPTION
Note that orangelight QA and orangelight prod both are and have been pointing at db 7 on the central prod redis host.

closes #4294
closes #4046
advances pulibrary/pulfalight#1323
