### PR TITLE
[catalog-staging] use the default mailcatcher path

### DIFF
--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -3,7 +3,6 @@ alma_read_write_key: "{{ vault_alma_sandbox_read_write_key }}"
 install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
-mailcatcher_install_location: "/var/lib/gems/3.1.0/gems/mailcatcher-0.8.1/bin/mailcatcher"
 ol_bibdata_base: 'https://bibdata-staging.princeton.edu'
 ol_clancy_api_key: "{{ vault_clancy_api_key }}"
 ol_clancy_base_url: '{{ vault_clancy_api_base_url }}'


### PR DESCRIPTION
The mailcatcher service was not running on the catalog-staging boxes.  This is because it's looking for the mailcatcher binary at `/var/lib/gems/3.1.0/gems/mailcatcher-0.8.1/bin/mailcatcher`, when it is actually at the default location of `/usr/local/bin/mailcatcher`

I ran this on catalog-staging today, and confirmed that after `systemctl daemon-reload && service mailcatchter restart`, mailcatcher is running again.