### PR TITLE
allow catalog to use custom 404s

### DIFF
--- a/playbooks/nginxplus_production_rebuild.yml
+++ b/playbooks/nginxplus_production_rebuild.yml
@@ -18,7 +18,7 @@
     community.general.slack:
       token: "{{ vault_tower_slack_token }}"
       msg: "Ansible is now running `{{ ansible_play_name }}` with the `{{ ansible_run_tags }}` tag on {{ inventory_hostname }}"
-      channel: {{ item }}
+      channel: "{{ item }}"
     loop: "{{ slack_alerts_channel }}"
     tags: always
 
@@ -46,6 +46,6 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: {{ item }}
+        channel: "{{ item }}"
       loop: "{{ slack_alerts_channel }}"
       tags: always

--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -109,6 +109,6 @@ server {
         }
     }
 
-   include /etc/nginx/conf.d/templates/errors.conf;
+   include /etc/nginx/conf.d/templates/errors-without-404.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -52,5 +52,5 @@ server {
         # block all
         deny all;
     }
-    include /etc/nginx/conf.d/templates/errors.conf;
+    include /etc/nginx/conf.d/templates/errors-without-404.conf;
 }

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -91,6 +91,6 @@ server {
    }
 
 
-    include /etc/nginx/conf.d/templates/errors.conf;
+    include /etc/nginx/conf.d/templates/errors-without-404.conf;
 
 }

--- a/roles/nginxplus/files/conf/http/templates/errors-without-404.conf
+++ b/roles/nginxplus/files/conf/http/templates/errors-without-404.conf
@@ -1,0 +1,20 @@
+error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 426 428 431 451 500 501 502 503 504 505 506 507 508 510 511 /error.html;
+
+error_page 429 /ratelimit.html;
+
+    location = /error.html {
+        ssi on;
+        internal;
+        root /var/local/www/default;
+    }
+
+    location = /ratelimit.html {
+        ssi on;
+        internal;
+        root /var/local/www/default;
+    }
+
+    location = /pul-logo-new.svg {
+        ssi on;
+        root /var/local/www/default;
+    }


### PR DESCRIPTION
Closes https://github.com/pulibrary/orangelight/issues/3732.

Creates an error config page that handles most errors on the load balancer, but allows 404s to be handled by the underlying application.

Changes the catalog config to use this new error config page.

Other applications can now update their configs to use this as desired.