### PR TITLE
[ealapps] migrate db

### DIFF
--- a/group_vars/ealapps/staging.yml
+++ b/group_vars/ealapps/staging.yml
@@ -12,7 +12,7 @@ ealapp_domain_name: "eal-apps-staging.princeton.edu"
 ealapp_db_name: "ealapps_staging_db"
 ealapp_db_user: "ealapps_staging_db_user"
 ealapp_db_password: '{{ vault_ealapps_staging_user_password }}'
-mysql_host: "mysql-db-staging1.princeton.edu"
+mysql_host: "mysql-db-dev1.princeton.edu"
 
 mysql_root_password: "{{ vault_maria_mysql_root_password }}"
 mysql_databases:


### PR DESCRIPTION
migrate database to use mysql-dev1 
this is running mariadb-10.6 (mysql 8)

related to #4477
