### PR TITLE
Use Redis database #8 for Orangelight QA

### DIFF
--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -17,7 +17,7 @@ ol_rabbit_password: "{{ vault_rabbit_staging_password }}"
 ol_rabbit_user: "{{ vault_rabbit_staging_user }}"
 ol_read_only_mode: 'false'
 central_redis_host: 'lib-redis-prod1.princeton.edu'
-central_redis_db: '7'
+central_redis_db: '8'
 ol_secret_key: "{{ vault_ol_alma_qa_secret_key }}"
 ol_solr_url: http://lib-solr8-prod.princeton.edu:8983/solr/catalog-alma-production-rebuild
 passenger_app_env: "qa"


### PR DESCRIPTION
closes #4455 

Orangelight currently only uses redis for rack mini profiler, but this safeguards against future collisions should we use redis more extensively in Orangelight in the future.

I ran this on staging today, 27 November.