### PR TITLE
partially reverts PR #4067

### DIFF
--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -42,8 +42,13 @@ solr_gc_tune: "-XX:NewRatio=3 \
 -XX:+ParallelRefProcEnabled"
 
 # Enable verbose GC logging
-gc_log_settings: "-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
--XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
+gc_log_settings: "-verbose:gc \
+-XX:+PrintHeapAtGC \
+-XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps \
+-XX:+PrintGCTimeStamps \
+-XX:+PrintTenuringDistribution \
+-XX:+PrintGCApplicationStoppedTime"
 
 solr_stack_size: 256k
 solr_heap: "{{ solr_heap_setting | default('20g') }}"

--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -25,13 +25,25 @@ solr_jmx_port: 1099
 solr_host: '{{ inventory_hostname }}'
 
 # garbage collection settings
-solr_gc_tune: "-XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled
-"
+solr_gc_tune: "-XX:NewRatio=3 \
+-XX:SurvivorRatio=4 \
+-XX:TargetSurvivorRatio=90 \
+-XX:MaxTenuringThreshold=8 \
+-XX:+UseConcMarkSweepGC \
+-XX:+UseParNewGC \
+-XX:ConcGCThreads=4 \
+-XX:ParallelGCThreads=4 \
+-XX:+CMSScavengeBeforeRemark \
+-XX:PretenureSizeThreshold=64m \
+-XX:+UseCMSInitiatingOccupancyOnly \
+-XX:CMSInitiatingOccupancyFraction=50 \
+-XX:CMSMaxAbortablePrecleanTime=6000 \
+-XX:+CMSParallelRemarkEnabled \
+-XX:+ParallelRefProcEnabled"
 
 # Enable verbose GC logging
 gc_log_settings: "-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
 -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
-"
 
 solr_stack_size: 256k
 solr_heap: "{{ solr_heap_setting | default('20g') }}"

--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -25,22 +25,12 @@ solr_jmx_port: 1099
 solr_host: '{{ inventory_hostname }}'
 
 # garbage collection settings
-solr_gc_tune: " \
--XX:+UseG1GC \
--XX:+ParallelRefProcEnabled \
--XX:G1HeapRegionSize=8m \
--XX:MaxGCPauseMillis=200 \
--XX:+UseLargePages \
--XX:+AggressiveOpts \
+solr_gc_tune: "-XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled
 "
-gc_log_settings: " \
--verbose:gc \
--XX:+PrintHeapAtGC \
--XX:+PrintGCDetails \
--XX:+PrintGCDateStamps \
--XX:+PrintGCTimeStamps \
--XX:+PrintTenuringDistribution \
--XX:+PrintGCApplicationStoppedTime\
+
+# Enable verbose GC logging
+gc_log_settings: "-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
 "
 
 solr_stack_size: 256k

--- a/roles/solrcloud/templates/solr.in.sh.j2
+++ b/roles/solrcloud/templates/solr.in.sh.j2
@@ -27,7 +27,8 @@ SOLR_HEAP='{{ solr_heap }}'
 
 # Enable verbose GC logging
 GC_LOG_OPTS={{ gc_log_settings }}
-# GC settings tested July 2023
+
+# These GC settings have shown to work well for a number of common Solr workloads
 GC_TUNE='{{ solr_gc_tune }}'
 
 # Set the ZooKeeper connection string if using an external ZooKeeper ensemble


### PR DESCRIPTION
The changes from #4067 were never deployed to production. We are now seeing issues in Solr, and wondering if we should use the older configuration.

Closes #4483.