### PR TITLE
[ealapps] upgrade eal to jammy

### DIFF
--- a/group_vars/ealapps/staging.yml
+++ b/group_vars/ealapps/staging.yml
@@ -1,4 +1,5 @@
 ---
+php_version: "8.1"
 install_ruby_from_source: true
 bundler_version: "2.3.18"
 ruby_version_override: "ruby-3.1.3"
@@ -14,7 +15,7 @@ ealapp_db_user: "ealapps_staging_db_user"
 ealapp_db_password: '{{ vault_ealapps_staging_user_password }}'
 mysql_host: "mysql-db-staging1.princeton.edu"
 
-mysql_root_password: "{{ vault_maria_mysql_root_password }}"
+mysql_root_password: "{{ vault_mysql_root_password }}"
 mysql_databases:
   - name: "ealapps_staging_db"
     encoding: utf8mb4

--- a/playbooks/ealapps.yml
+++ b/playbooks/ealapps.yml
@@ -2,6 +2,11 @@
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
 # to use a different connection user, pass `-e ansible_user=my_user`
+# if you are building this from scratch remember to rsync the following directories
+# into the new VM
+# `/var/www/ealapps/shared/EALJ/pdfs`
+# `/var/www/ealapps/shared/newtitles/files`
+# `/var/www/ealapps/shared/shadowfigures/images`
 
 - name: build the ealapps
   hosts: ealapps_{{ runtime_env | default('staging') }}


### PR DESCRIPTION
this adds a new jammy vm for eal-apps-staging1
playbook runs successfully.
files need to be `rsync'ed`

related to #4499
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
