### PR TITLE
[fpul, libwww, recap] upgrade to mariadb 10.6

### DIFF
--- a/group_vars/friends_of_pul/staging.yml
+++ b/group_vars/friends_of_pul/staging.yml
@@ -5,7 +5,7 @@ drupal_db_user: 'fpul_staging'
 drupal_db_password: "{{ fpul_db_password | default('change_this') }}"
 drupal_db_name: 'fpul_staging'
 
-db_host: "mysql-db-dev1.princeton.edu"
+db_host: "mysql-db-staging1.princeton.edu"
 
 mysql_root_password: "{{ vault_mysql_root_password }}"
 datadog_environment: staging

--- a/group_vars/libwww/staging.yml
+++ b/group_vars/libwww/staging.yml
@@ -23,7 +23,7 @@ apache_app_path: '/var/www/library_cap/current'
 ### Uncomment this to force a dump file to be imported
 # drupal_dbimport_file: 'dump.sql'
 
-db_host: "mysql-db-dev1.princeton.edu"
+db_host: "mysql-db-staging1.princeton.edu"
 root_db_password: "{{ vault_mysql_root_password }}"
 db_port: "{{ drupal_db_port }}"
 mariadb__server: "{{ db_host }}"

--- a/group_vars/recap/staging.yml
+++ b/group_vars/recap/staging.yml
@@ -8,9 +8,9 @@ drupal_db_port: '3306'
 drupal_docroot: '/var/www/recap_cap'
 apache_app_path: '{{ drupal_docroot }}/current'
 
-db_host: 'mysql-db-dev1.princeton.edu'
+db_host: 'mysql-db-staging1.princeton.edu'
 
-mysql_host: "mysql-db-dev1.princeton.edu"
+mysql_host: "mysql-db-staging1.princeton.edu"
 mysql_root_password: "{{ vault_mysql_root_password }}"
 mysql_databases:
   - name: "{{ drupal_db_name }}"


### PR DESCRIPTION
- adds upgraded databases for library-staging, fpul-staging, and recap-staging

related to https://github.com/pulibrary/princeton_ansible/issues/4477
