### PR TITLE
Remove old postgresql vars

### DIFF
--- a/host_vars/lib-postgres-prod2.princeton.edu.yml
+++ b/host_vars/lib-postgres-prod2.princeton.edu.yml
@@ -1,8 +1,0 @@
----
-pg_enabled: false
-node_identifier: 2
-repmgr_master: false
-standby_db_host: lib-postgres-prod2.princeton.edu
-leader_db_host: lib-postgres-prod3.princeton.edu
-leader_db_ip: 128.112.204.69
-standby_db_ip: 128.112.204.64

--- a/host_vars/lib-postgres-prod3.princeton.edu.yml
+++ b/host_vars/lib-postgres-prod3.princeton.edu.yml
@@ -1,8 +1,0 @@
----
-pg_enabled: false
-node_identifier: 1
-repmgr_master: true
-standby_db_host: lib-postgres-prod2.princeton.edu
-leader_db_host: lib-postgres-prod3.princeton.edu
-leader_db_ip: 128.112.204.69
-standby_db_ip: 128.112.204.64

--- a/host_vars/lib-postgres-staging2.princeton.edu.yml
+++ b/host_vars/lib-postgres-staging2.princeton.edu.yml
@@ -1,8 +1,0 @@
----
-pg_enabled: false
-node_identifier: 2
-repmgr_master: false
-standby_db_host: lib-postgres-staging2.princeton.edu
-leader_db_host: lib-postgres-staging3.princeton.edu
-leader_db_ip: 128.112.204.72
-standby_db_ip: 128.112.204.57

--- a/host_vars/lib-postgres-staging3.princeton.edu.yml
+++ b/host_vars/lib-postgres-staging3.princeton.edu.yml
@@ -1,8 +1,0 @@
----
-pg_enabled: false
-node_identifier: 1
-repmgr_master: true
-standby_db_host: lib-postgres-staging2.princeton.edu
-leader_db_host: lib-postgres-staging3.princeton.edu
-leader_db_ip: 128.112.204.72
-standby_db_ip: 128.112.204.57


### PR DESCRIPTION
These files predate the current postgresql cluster architecture.

Current, correct postgres cluster vars are in `group_vars/postgres_<env>_cluster.yml` files.

As of today, we are running postgresql 15 of lib-postgres-<env>1/2. We still have a postgresql 13 box on lib-postgres-prod3.