### PR TITLE
[catalog-3896]: Add large_client_header_buffers to application-level nginx config

### DIFF
--- a/roles/passenger/templates/passenger.j2
+++ b/roles/passenger/templates/passenger.j2
@@ -10,6 +10,7 @@ server {
   set_real_ip_from 128.112.203.145;
   set_real_ip_from 128.112.203.146;
   real_ip_header X-Real-IP;
+  large_client_header_buffers 4 16k;
 
   access_log /var/log/nginx/access.log custom if=$logging_enabled;
 


### PR DESCRIPTION
Without this commit, users with extremely large *.princeton.edu cookies got 400 errors when requesting the catalog.  This increases the possible size for the Cookie header to allow them to make successful requests.

See: http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers