### PR TITLE
adds second box to Tower config on nginxplus

### DIFF
--- a/roles/nginxplus/files/conf/http/ansible-tower_prod.conf
+++ b/roles/nginxplus/files/conf/http/ansible-tower_prod.conf
@@ -4,6 +4,7 @@ proxy_cache_path /data/nginx/ansible-tower/NGINX_cache/ keys_zone=ansible-towerc
 upstream ansible-tower {
     zone ansible-tower 64k;
     server ansible-tower1.princeton.edu:443;
+    server ansible-tower2.princeton.edu:443;
     sticky learn
           create=$upstream_cookie_ansible-towercookie
           lookup=$cookie_ansible-towercookie


### PR DESCRIPTION
We now have two VMs for our Tower/Controller.

This PR adds the second one to the config for the load balancer.