### PR TITLE
[pas] manage .env file in the capistrano shared directory, rather than the home directory

### DIFF
--- a/roles/pas/tasks/main.yml
+++ b/roles/pas/tasks/main.yml
@@ -103,7 +103,7 @@
 - name: update .env
   ansible.builtin.template:
     src: 'templates/env-craft{{ craft_version }}.j2'
-    dest: '/home/{{ deploy_user }}/.env'
+    dest: "{{ capistrano_base_dir }}/{{capistrano_directory}}/shared/.env"
     owner: 'deploy'
     group: 'deploy'
     mode: 0644


### PR DESCRIPTION
Related to https://github.com/PrincetonUniversityLibrary/pas-craft3/issues/102

Sibling PR: https://github.com/PrincetonUniversityLibrary/pas-craft3/pull/108