### PR TITLE
Add a least_time algorithm to maps to fix -no live upstreams while connecting to upstream-

### DIFF
--- a/roles/nginxplus/files/conf/http/maps-prod.conf
+++ b/roles/nginxplus/files/conf/http/maps-prod.conf
@@ -2,6 +2,7 @@
 proxy_cache_path /data/nginx/maps-prod/NGINX_cache/ keys_zone=maps-prodcache:10m;
 
 upstream maps-prod {
+    least_time header 'inflight';
     zone maps-prod 64k;
     server maps1.princeton.edu resolve;
     server maps2.princeton.edu resolve;


### PR DESCRIPTION
See [incident report](https://docs.google.com/document/d/1b7rjSdW7DKXC9B2MlEuHcn7XkMdbjZBuek2Pn1A_5zA/edit)