### PR TITLE
EAL Pinyin GitHub redirect

### DIFF
--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -85,14 +85,6 @@
   register: apache2_disable
   changed_when: '"disabled." in apache2_disable.stdout'
 
-- name: ealapps | create empty hishi file
-  copy:
-    content: ""
-    dest: /var/www/ealapps/shared/hishi/hishi.json
-    force: false
-    owner: deploy
-    mode: 0644
-
 - name: ealapps | create empty newtitles file
   copy:
     content: ""
@@ -100,15 +92,6 @@
     force: false
     owner: deploy
     mode: 0644
-
-- name: ealapps | add hishi cron job
-  ansible.builtin.cron:
-    name: "generate hishi.json"
-    weekday: "1-5"
-    minute: "0"
-    hour: "1"
-    user: deploy
-    job: "cd /var/www/ealapps/current/hishi; php hishiDownload.php > /var/www/ealapps/shared/hishi/hishi.json 2> /dev/null"
 
 - name: ealapps | add newtitles cron job
   ansible.builtin.cron:

--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -23,7 +23,6 @@
     - '{{ capistrano_directory }}/shared/EALJ/pdfs'
     - '{{ capistrano_directory }}/shared/shadowfigures/images'
     - '{{ capistrano_directory }}/shared/connections'
-    - '{{ capistrano_directory }}/shared/hishi'
     - '{{ capistrano_directory }}/shared/newtitles/files'
 
 - name: ealapps | grant temp subdirectories different permissions

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -8,6 +8,8 @@
     rewrite ^/research/databases/subjects https://libguides.princeton.edu/az.php redirect;
     rewrite ^/resource/(\d+)$ https://libguides.princeton.edu/resource/$1 redirect;
     rewrite ^/eastasian/hishi(.*)$ https://catalog.princeton.edu/catalog?utf8=%E2%9C%93&search_field=all_fields&q=%22hishi+collection%22 redirect;
+    rewrite ^/eastasian/oclcpinyin(.*)$ https://github.com/pulibrary/oclcpinyin redirect;
+    rewrite ^/eastasian/addpinyin-plugin-marcedit(.*)$ https://github.com/pulibrary/addpinyin-marcedit redirect;
 
     location /mudd-dbs {
         proxy_pass https://lib-mudd-prod.princeton.edu/;
@@ -82,13 +84,6 @@
     }
     location /eastasian/stafftools/ {
         proxy_pass https://eal-apps-prod.princeton.edu/stafftools/;
-    }
-
-    location /eastasian/oclcpinyin/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/oclcpinyin/;
-    }
-    location /eastasian/addpinyin-plugin-marcedit/InstallAddPinyin.zip {
-        proxy_pass https://eal-apps-prod.princeton.edu/addpinyin-plugin-marcedit/InstallAddPinyin.zip;
     }
     location /eastasian/assets/ {
         proxy_pass https://eal-apps-prod.princeton.edu/assets/;

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -4,6 +4,8 @@
     rewrite ^/AssignedSpaceApplication(.*)$ https://lockers-and-study-spaces-staging.princeton.edu/ redirect;
     rewrite ^/AssignedSpaces https://lockers-and-study-spaces-staging.princeton.edu/ redirect;
     rewrite ^/eastasian/hishi(.*)$ https://catalog-staging.princeton.edu/catalog?utf8=%E2%9C%93&search_field=all_fields&q=%22hishi+collection%22 redirect;
+    rewrite ^/eastasian/oclcpinyin(.*)$ https://github.com/pulibrary/oclcpinyin redirect;
+    rewrite ^/eastasian/addpinyin-plugin-marcedit(.*)$ https://github.com/pulibrary/addpinyin-marcedit redirect;
 
     location /mudd-dbs {
         proxy_pass https://lib-mudd-staging.princeton.edu/;
@@ -79,13 +81,6 @@
     }
     location /eastasian/stafftools/ {
         proxy_pass https://eal-apps-staging.princeton.edu/stafftools/;
-    }
-
-    location /eastasian/oclcpinyin/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/oclcpinyin/;
-    }
-    location /eastasian/addpinyin-plugin-marcedit/InstallAddPinyin.zip {
-        proxy_pass https://eal-apps-staging.princeton.edu/addpinyin-plugin-marcedit/InstallAddPinyin.zip;
     }
     location /eastasian/assets/ {
         proxy_pass https://eal-apps-staging.princeton.edu/assets/;


### PR DESCRIPTION
Two projects (oclcpinyin and addpinyin-plugin-marcedit) have been moved from the ealapps server to github.  This PR implements the redirects to github from the old URLs.