### PR TITLE
ealapps pinyin projects redirect to github

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -8,6 +8,8 @@
     rewrite ^/research/databases/subjects https://libguides.princeton.edu/az.php redirect;
     rewrite ^/resource/(\d+)$ https://libguides.princeton.edu/resource/$1 redirect;
     rewrite ^/eastasian/hishi(.*)$ https://catalog.princeton.edu/catalog?utf8=%E2%9C%93&search_field=all_fields&q=%22hishi+collection%22 redirect;
+    rewrite ^/eastasian/oclcpinyin(.*)$ https://github.com/pulibrary/oclcpinyin redirect;
+    rewrite ^/eastasian/addpinyin-plugin-marcedit(.*)$ https://github.com/pulibrary/addpinyin-marcedit redirect;
     rewrite ^/firestone/renovations https://library.princeton.edu/firestone redirect;
 
     location /mudd-dbs {
@@ -85,13 +87,6 @@
     }
     location /eastasian/stafftools/ {
         proxy_pass https://eal-apps-prod.princeton.edu/stafftools/;
-    }
-
-    location /eastasian/oclcpinyin/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/oclcpinyin/;
-    }
-    location /eastasian/addpinyin-plugin-marcedit/InstallAddPinyin.zip {
-        proxy_pass https://eal-apps-prod.princeton.edu/addpinyin-plugin-marcedit/InstallAddPinyin.zip;
     }
     location /eastasian/assets/ {
         proxy_pass https://eal-apps-prod.princeton.edu/assets/;

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -3,6 +3,8 @@
     rewrite ^/research-data(.*)$ https://researchdata-staging.princeton.edu redirect;
     rewrite ^/AssignedSpaceApplication(.*)$ https://lockers-and-study-spaces-staging.princeton.edu/ redirect;
     rewrite ^/AssignedSpaces https://lockers-and-study-spaces-staging.princeton.edu/ redirect;
+    rewrite ^/eastasian/oclcpinyin(.*)$ https://github.com/pulibrary/oclcpinyin redirect;
+    rewrite ^/eastasian/addpinyin-plugin-marcedit(.*)$ https://github.com/pulibrary/addpinyin-marcedit redirect;
     rewrite ^/eastasian/hishi(.*)$ https://catalog-staging.princeton.edu/catalog?utf8=%E2%9C%93&search_field=all_fields&q=%22hishi+collection%22 redirect;
 
     location /mudd-dbs {
@@ -85,13 +87,6 @@
     }
     location /eastasian/stafftools/ {
         proxy_pass https://eal-apps-staging.princeton.edu/stafftools/;
-    }
-
-    location /eastasian/oclcpinyin/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/oclcpinyin/;
-    }
-    location /eastasian/addpinyin-plugin-marcedit/InstallAddPinyin.zip {
-        proxy_pass https://eal-apps-staging.princeton.edu/addpinyin-plugin-marcedit/InstallAddPinyin.zip;
     }
     location /eastasian/assets/ {
         proxy_pass https://eal-apps-staging.princeton.edu/assets/;


### PR DESCRIPTION
Two projects in ealapps (oclcpinyin, addpinyin-plugin-marcedit) have been moved to github.  This PR implements the redirects from the old site.