### PR TITLE
[tigerdata] Allow newer bundler

### DIFF
--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -22,6 +22,7 @@ passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
 passenger_app_root: "/opt/tigerdata/current/public"
+passenger_extra_config: "passenger_preload_bundler on;"
 nginx_remove_default_vhost: true
 install_mailcatcher: true
 mailcatcher_user: 'pulsys'


### PR DESCRIPTION
fixes 
```
App 1234797 output: Error: The application encountered the following error: You have already activated base64 0.1.1, but your Gemfile requires base64 0.2.0. Since base64 is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports base64 as a default gem. (Gem::LoadError)
```