### PR TITLE
[lib-jobs] point load balancer to correct vm

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
@@ -3,7 +3,8 @@ proxy_cache_path /data/nginx/libjobs-staging/NGINX_cache/ keys_zone=libjobs-stag
 
 upstream libjobs-staging {
     zone libjobs-staging 64k;
-    server lib-jobs-staging1.princeton.edu resolve;
+    # server lib-jobs-staging1.princeton.edu resolve;
+    server lib-jobs-staging2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_libjobsstagingcookie
           lookup=$cookie_libjobsstagingcookie


### PR DESCRIPTION
load balancer is pointing to wrong VM

