### PR TITLE
[Tower] adds public key for Tower to pulsys SSH template and to keys dir

### DIFF
--- a/keys/TowerKey.pub
+++ b/keys/TowerKey.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP+lnexM16ZDOV113XlSHO2cgiGiO4bE3/IdFYkbv0RL pulsys@ansible-tower1.princeton.edu

--- a/roles/common/templates/pulsys_keys.j2
+++ b/roles/common/templates/pulsys_keys.j2
@@ -1,4 +1,7 @@
 {{ ansible_managed | comment }}
+## Tower key goes on all machines
+# Key for our Tower instance
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP+lnexM16ZDOV113XlSHO2cgiGiO4bE3/IdFYkbv0RL pulsys@ansible-tower1.princeton.edu
 ## ops staff keys go on all machines
 # Keys for Operations Staff
 {% for item in ops_keys_from_github.results %}


### PR DESCRIPTION
Our new Ansible Tower instance is mostly working. I regenerated an SSH key (ed25519) on the ansible-tower1 box for the new installation. There's already a Credential in Tower for this, so we can use it for Template (playbook) runs. This PR adds the public key to the repo.