### PR TITLE
adds bastion info for GCP hosts

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -31,3 +31,28 @@ pulmirror.princeton.edu
 [sftp_production]
 filedrop.sinaiarchive.org
 proquestdrop.pulcloud.io
+
+[gcp_dev:children]
+dspace_dev
+obsd_httpd_dev
+
+[gcp_dev:vars]
+ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-dev.pulcloud.io"'
+
+[gcp_production:children]
+dspace_production
+docnow_production
+obsd_httpd_production
+pulmirror_production
+sftp_production
+
+[gcp_production:vars]
+ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-prod.pulcloud.io"'
+
+[gcp_staging:children]
+dspace_staging
+docnow_staging
+obsd_httpd_staging
+
+[gcp_staging:vars]
+ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-staging.pulcloud.io"'


### PR DESCRIPTION
Partial fix for #4018.

This provides connection details for our Google cloud resources. However, we still need to provide connection details for our AWS cloud resources.