### PR TITLE
[redis] ensure redis starts

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -33,9 +33,8 @@
     sysctl_file: "/etc/sysctl.d/30-redis.conf"
   when: redis__overcommit_memory_enable|bool
 
-- name: redis | disable Redis Server service if not enabled
+- name: redis | ensure Redis Server service enabled
   service:
     name: "redis-server"
-    state: stopped
+    state: started
     enabled: false
-  when: not redis__server_enabled|bool


### PR DESCRIPTION
not finding a use case for why we would install redis and not start it

Closes #4589
