### PR TITLE
[nfsserver] add fqdn

### DIFF
--- a/roles/nfsserver/tasks/main.yml
+++ b/roles/nfsserver/tasks/main.yml
@@ -38,6 +38,14 @@
   loop:
     - "{{ cdh_fileshare_mount }}"
 
+- name: nfsserver | add fqdn for idmapping
+  ansible.builtin.lineinfile:
+    path: /etc/idmapd.conf
+    insertbefore: '# Domain = localdomain'
+    line: "Domain = {{ inventory_hostname }}"
+    state: present  
+  when: running_on_server
+
 - name: nfsserver | make idmapping work
   ansible.builtin.copy:
     content: "options nfsd nfs4_disable_idmapping=N"


### PR DESCRIPTION
while idmap is enabled on the NFS servers we need to add the FQDN or it will export this are princeton.edu

related to #4622
