### PR TITLE
[POSTGRES] Removing the failing task until a better solution can be found

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -89,13 +89,13 @@
   when:
     - postgresql_is_local
 
-- name: PostgreSQL | add pg_stat_statements extension to the default db
-  community.postgresql.postgresql_ext:
-    name: pg_stat_statements
-    db: postgres
-  become: true
-  become_user: postgres
-  when: running_on_server
+# - name: PostgreSQL | add pg_stat_statements extension to the default db
+#   community.postgresql.postgresql_ext:
+#     name: pg_stat_statements
+#     db: postgres
+#   become: true
+#   become_user: postgres
+#   when: running_on_server
 
 - name: PostgreSQL | restart leader postgres server
   ansible.builtin.service:


### PR DESCRIPTION
Fixes:
```
TASK [postgresql : PostgreSQL | add pg_stat_statements extension to the default db] ****************************************************************************************************
fatal: [tigerdata-staging2.princeton.edu]: FAILED! => {"changed": false, "module_stderr": "sudo: unknown user postgres\nsudo: error initializing audit plugin sudoers_audit\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
fatal: [tigerdata-staging1.princeton.edu]: FAILED! => {"changed": false, "module_stderr": "sudo: unknown user postgres\nsudo: error initializing audit plugin sudoers_audit\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

refs #4618