### PR TITLE
[allsearch-frontend] add envvar for bibdata url

### DIFF
--- a/group_vars/allsearch_frontend/production.yml
+++ b/group_vars/allsearch_frontend/production.yml
@@ -1,4 +1,5 @@
 ---
 allsearch_api_url: https://allsearch-api.princeton.edu
+bibdata_url: https://bibdata.princeton.edu
 passenger_server_name: allsearch.princeton.edu
 allsearch_frontend_environment: production

--- a/group_vars/allsearch_frontend/staging.yml
+++ b/group_vars/allsearch_frontend/staging.yml
@@ -1,4 +1,5 @@
 ---
 allsearch_api_url: https://allsearch-api-staging.princeton.edu
+bibdata_url: https://bibdata-staging.princeton.edu
 passenger_server_name: allsearch-staging.princeton.edu
 allsearch_frontend_environment: staging

--- a/roles/allsearch_frontend/templates/env.j2
+++ b/roles/allsearch_frontend/templates/env.j2
@@ -4,5 +4,6 @@
 # If you need the variable to be available to the client after it has been compiled
 # (i.e. at runtime), make sure to include the prefix VITE_
 VITE_ALLSEARCH_API_URL='{{ allsearch_api_url |default('https://allsearch-api-staging.princeton.edu') }}'
+VITE_BIBDATA_URL='{{ bibdata_url | default('https://bibdata-staging.princeton.edu') }}'
 VITE_HONEYBADGER_API_KEY='{{ vault_allsearch_frontend_honeybadger_api_key | default('this-is-visible-on-requests') }}'
 VITE_HONEYBADGER_ENV='{{ allsearch_frontend_environment | default('set-environment') }}'


### PR DESCRIPTION
This URL will be used for availability API calls

Helps with https://github.com/pulibrary/allsearch_frontend/issues/166

I ran this on staging on 7 February, 2024