### PR TITLE
[Orangelight] Upgrade node to v18.19.1

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -4,7 +4,7 @@ application_dbuser_name: "{{ ol_db_user }}"
 application_dbuser_password: "{{ ol_db_password }}"
 application_dbuser_role_attr_flags: "CREATEDB"
 application_host_protocol: "https"
-desired_nodejs_version: 'v18.17.0'
+desired_nodejs_version: 'v18.19.1'
 ol_admin_netids: 
   - cc62
   - heberlei


### PR DESCRIPTION
See also [Orangelight PR](https://github.com/pulibrary/orangelight/pull/3961)

Connected to pulibrary/dacs_handbook#157