### PR TITLE
[pas] remove node role

### DIFF
--- a/roles/pas/meta/main.yml
+++ b/roles/pas/meta/main.yml
@@ -18,6 +18,5 @@ dependencies:
   - role: 'deploy_user'
   - role: 'php'
   - role: 'mysql'
-  - role: 'nodejs'
   - role: 'samba'
   - role: 'capistrano'

--- a/roles/pas/tasks/main.yml
+++ b/roles/pas/tasks/main.yml
@@ -59,18 +59,6 @@
     - proxy
     - proxy_fcgi
 
-- name: Install "sass" node.js package globally.
-  community.general.npm:
-    name: sass
-    global: true
-  ignore_errors: true
-
-- name: Install "grunt-cli" node.js package globally.
-  community.general.npm:
-    name: grunt-cli
-    global: true
-  ignore_errors: true
-
 - name: Create mount directories
   ansible.builtin.file:
     path: '/mnt/diglibdata1'


### PR DESCRIPTION
PAS no longer uses node for anything, so let's remove it from this role.  I'm also removing it from the boxes manually with:

```
sudo apt-get remove -y yarn
sudo rm /usr/local/bin/node /usr/local/bin/npm
sudo rm -rf /usr/local/node-v18.18.2-linux-x64
```

I did this on staging today, ran the playbook, then deployed, and I didn't see any problems.

closes https://github.com/PrincetonUniversityLibrary/pas-craft3/issues/113