### PR TITLE
Don't install node for allsearch_api

### DIFF
--- a/group_vars/allsearch_api/common.yml
+++ b/group_vars/allsearch_api/common.yml
@@ -15,6 +15,8 @@ postgresql_is_local: false
 postgres_version: 15
 postgres_admin_user: postgres
 
+install_nodejs: false
+
 rails_app_vars:
   - name: SECRET_KEY_BASE
     value: '{{ allsearch_api_secret_key }}'

--- a/roles/rails_app/meta/main.yml
+++ b/roles/rails_app/meta/main.yml
@@ -19,4 +19,4 @@ dependencies:
   - role: 'deploy_user'
   - role: 'passenger'
   - { role: 'postgresql', tags: 'postgresql' }
-  - role: 'nodejs'
+  - { role: 'nodejs', when: install_nodejs|default(true) }


### PR DESCRIPTION
I manually removed it from the staging boxes, then ran the playbook with this branch on staging, then deployed.  It looked like it works well without node.

Here's how I removed it manually:
```
sudo apt-get remove -y yarn
sudo rm /usr/local/bin/node /usr/local/bin/npm
sudo rm -rf /usr/local/node-v18.18.2-linux-x64
```

closes https://github.com/pulibrary/allsearch_api/issues/197