### PR TITLE
[prancible] add dependabot PR

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -34,7 +34,6 @@ jsonschema-specifications = "==2023.12.1"
 markdown-it-py = "==3.0.0"
 markupsafe = "==2.1.3"
 mdurl = "==0.1.2"
-molecule-plugins = {extras = ["docker"], version = "==23.5.0"}
 mypy-extensions = "==1.0.0"
 packaging = "==23.2"
 pathspec = "==0.12.1"
@@ -53,6 +52,7 @@ subprocess-tee = "==0.4.1"
 urllib3 = "==2.1.0"
 wcmatch = "==8.5"
 yamllint = "==1.33.0"
+molecule-plugins = {extras = ["docker"], version = "==23.5.0"}
 
 [dev-packages]
 


### PR DESCRIPTION
add the dependabot PR #4677 to match our pipenv

the dependabot only updates the `requirements.txt` file

running `pipenv install -r requirements.txt` from #4677 allows our pipenv environment to match it.
