### PR TITLE
[researchdata] don't install nodejs

### DIFF
--- a/group_vars/researchdata/common.yml
+++ b/group_vars/researchdata/common.yml
@@ -1,3 +1,2 @@
 ---
-desired_nodejs_version: "v18.18.2"
 php_version: '8.1'

--- a/roles/drupal9/meta/main.yml
+++ b/roles/drupal9/meta/main.yml
@@ -17,7 +17,6 @@ dependencies:
   - role: common
   - role: deploy_user
   - role: php
-  - role: nodejs
   - role: composer
   - role: postgresql
   - role: 'ruby_s'

--- a/roles/drupal9/tasks/main.yml
+++ b/roles/drupal9/tasks/main.yml
@@ -118,13 +118,6 @@
     name: ["php{{ php_version }}-gd", "postgresql-client", "php{{ php_version }}-mbstring"]
     state: present
 
-- name: drupal9 | Install gulp globally
-  npm:
-    name: gulp-cli
-    global: true
-  become: true
-  when: running_on_server
-
 - name: drupal9 | Allow www-data to access deploy's drush dir
   ansible.builtin.file:
     state: directory


### PR DESCRIPTION
We no longer use nodejs for this drupal site.

Today, I manually deleted node from the staging box with:

```
sudo apt-get remove -y yarn
sudo rm /usr/local/bin/node /usr/local/bin/npm
sudo rm -rf /usr/local/node-v18.18.2-linux-x64
```


Then ran the playbook with this branch and deployed.  Everything worked as expected.

closes https://github.com/pulibrary/researchdata/issues/273