### PR TITLE
[lib-static-prod] visual resources 

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -52,7 +52,7 @@
         proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Scheide/;
     }
     location /visual_materials {
-        proxy_pass https://lib-dbserver.princeton.edu/visual_materials;
+        proxy_pass https://lib-static-prod.princeton.edu/visual_materials;
     }
     location /mssimages {
         proxy_pass https://lib-static-prod.princeton.edu/mssimages/;

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass.conf
@@ -30,27 +30,27 @@
     }
 
     # bb, Circus, hb, maps, Misc & pulc and Scheide are off of lib-dbserver
-    location /visual_materials/bb {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/bb/;
-    }
-    location /visual_materials/Circus {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Circus/;
-    }
-    location /visual_materials/hb {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/hb/;
-    }
-    location /visual_materials/maps {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/maps/;
-    }
-    location /visual_materials/Misc/ {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Misc/;
-    }
-    location /visual_materials/pulc {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/pulc/;
-    }
-    location /visual_materials/Scheide {
-        proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Scheide/;
-    }
+    # location /visual_materials/bb {
+    #    proxy_pass https://lib-static-prod.princeton.edu/visual_materials/bb/;
+    # }
+    # location /visual_materials/Circus {
+    #     proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Circus/;
+    #}
+    #location /visual_materials/hb {
+    #    proxy_pass https://lib-static-prod.princeton.edu/visual_materials/hb/;
+    #}
+    # location /visual_materials/maps {
+    #     proxy_pass https://lib-static-prod.princeton.edu/visual_materials/maps/;
+   #  }
+    # location /visual_materials/Misc/ {
+     #    proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Misc/;
+    # }
+    # location /visual_materials/pulc {
+    #     proxy_pass https://lib-static-prod.princeton.edu/visual_materials/pulc/;
+   #  }
+   #  location /visual_materials/Scheide {
+    #     proxy_pass https://lib-static-prod.princeton.edu/visual_materials/Scheide/;
+   #  }
     location /visual_materials {
         proxy_pass https://lib-static-prod.princeton.edu/visual_materials;
     }


### PR DESCRIPTION
the lib-db-server name is no longer available
this points the service to the lib-static-prod server.

Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>

possibly related to #4592
