### PR TITLE
[recap] don't install nodejs

### DIFF
--- a/group_vars/recap/common.yml
+++ b/group_vars/recap/common.yml
@@ -29,3 +29,5 @@ mysql_users:
       password: "{{ app_db_password }}"
       priv: "{{ drupal_db_name }}.*:ALL"
       update_password: on_create
+
+install_nodejs: false

--- a/roles/drupal/meta/main.yml
+++ b/roles/drupal/meta/main.yml
@@ -18,7 +18,7 @@ dependencies:
   - role: 'common'
   - role: 'deploy_user'
   - role: 'php'
-  - role: 'nodejs'
+  - { role: 'nodejs', when: install_nodejs|default(true) }
   - role: 'drush'
   - role: 'mysql'
   - role: 'capistrano'

--- a/roles/drupal/tasks/main.yml
+++ b/roles/drupal/tasks/main.yml
@@ -194,3 +194,4 @@
     - gulp-cli
     - gulp
   become: true
+  when: install_nodejs | default(true)


### PR DESCRIPTION
We no longer use nodejs for this drupal site.

Today, I manually deleted node from the staging box with:

```
sudo apt-get remove -y yarn
sudo rm /usr/local/bin/node /usr/local/bin/npm
sudo rm -rf /usr/local/node-v18.18.2-linux-x64
```


Then ran the playbook with this branch and deployed.  Everything worked as expected.

closes https://github.com/pulibrary/recap/issues/266