### PR TITLE
[byzantine] don't install node

### DIFF
--- a/group_vars/byzantine/common.yml
+++ b/group_vars/byzantine/common.yml
@@ -34,3 +34,4 @@ shared_files:
   - name: 'hp_logo.jpg'
   - name: 'pul-logo.gif'
 systems_user: 'deploy'
+install_nodejs: false


### PR DESCRIPTION
We no longer use nodejs for this drupal site.

Today, I manually deleted node from the staging box with:

```
sudo apt-get remove -y yarn nodejs
sudo rm /usr/local/bin/node /usr/local/bin/npm
sudo rm -rf /usr/local/node-v18.18.2-linux-x64
```

Then ran the playbook with this branch and deployed.  Everything worked as expected.

closes https://github.com/pulibrary/byzantine_translations/issues/53

To check that the staging site was working as expected, I did `ssh -L 1234:localhost:80 deploy@byzantine-tsp-staging[12]`, and then checked localhost:1234 in my browser