### PR TITLE
Do not define a version of bundler

### DIFF
--- a/group_vars/abid/production.yml
+++ b/group_vars/abid/production.yml
@@ -16,7 +16,6 @@ passenger_app_env: "production"
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.18"
 desired_nodejs_version: "v18.18.0"
 rails_app_name: "abid"
 rails_app_directory: "abid"

--- a/group_vars/abid/staging.yml
+++ b/group_vars/abid/staging.yml
@@ -15,7 +15,6 @@ passenger_server_name: "abid-staging1.princeton.edu"
 passenger_app_root: "/opt/abid/current/public"
 passenger_app_env: "staging"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 desired_nodejs_version: "v18.18.0"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"

--- a/group_vars/allsearch_api/common.yml
+++ b/group_vars/allsearch_api/common.yml
@@ -1,7 +1,6 @@
 ---
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.3.0"
-bundler_version: "2.5.6"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 

--- a/group_vars/approvals/common.yml
+++ b/group_vars/approvals/common.yml
@@ -2,5 +2,4 @@
 desired_nodejs_version: "v20.11.1"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.22"
 passenger_ruby: "/usr/local/bin/ruby"

--- a/group_vars/bibdata/common.yml
+++ b/group_vars/bibdata/common.yml
@@ -3,7 +3,6 @@ desired_nodejs_version: v18.19.1
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.25"
 bibdata_admin_netids:
   - cc62
   - heberlei

--- a/group_vars/byzantine/common.yml
+++ b/group_vars/byzantine/common.yml
@@ -1,6 +1,5 @@
 ---
 apache_app_path: '{{ drupal_docroot }}/current'
-bundler_version: '2.3.26'
 db_is_mysql: true
 db_port: "{{ drupal_db_port }}"
 deploy_user: 'deploy'

--- a/group_vars/cicognara/production.yml
+++ b/group_vars/cicognara/production.yml
@@ -1,7 +1,6 @@
 ---
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
-bundler_version: "2.1.4"
 postgresql_is_local: false
 postgres_host: "lib-postgres-prod3.princeton.edu"
 postgres_admin_user: "postgres"

--- a/group_vars/cicognara/staging.yml
+++ b/group_vars/cicognara/staging.yml
@@ -1,7 +1,6 @@
 ---
 passenger_ruby: "/usr/bin/ruby2.6"
 ruby_version_override: "ruby2.6"
-bundler_version: "2.1.4"
 postgres_host: 'lib-postgres-staging3.princeton.edu'
 postgresql_is_local: false
 postgres_version: 13

--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -19,7 +19,6 @@ passenger_app_env: "production"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
 rails_app_name: "dpul"

--- a/group_vars/dpul/staging.yml
+++ b/group_vars/dpul/staging.yml
@@ -19,7 +19,6 @@ passenger_app_env: "staging"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
 rails_app_name: "dpul"

--- a/group_vars/dss/common.yml
+++ b/group_vars/dss/common.yml
@@ -3,4 +3,3 @@ desired_nodejs_version: "v20.11.1"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: 2.3.26

--- a/group_vars/ealapps/production.yml
+++ b/group_vars/ealapps/production.yml
@@ -1,6 +1,5 @@
 ---
 install_ruby_from_source: true
-bundler_version: "2.3.18"
 ruby_version_override: "ruby-3.1.3"
 mysql_server: false
 

--- a/group_vars/ealapps/staging.yml
+++ b/group_vars/ealapps/staging.yml
@@ -1,7 +1,6 @@
 ---
 php_version: "8.1"
 install_ruby_from_source: true
-bundler_version: "2.3.18"
 ruby_version_override: "ruby-3.1.3"
 install_mailcatcher: true
 mailcatcher_user: "pulsys"

--- a/group_vars/ezproxy/production.yml
+++ b/group_vars/ezproxy/production.yml
@@ -2,7 +2,6 @@
 install_ruby_from_source: true
 desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.18"
 generic_app_user: ezproxy
 domain_name: "*.ezproxy"
 domain_place_name: "ezproxy"

--- a/group_vars/ezproxy/testing.yml
+++ b/group_vars/ezproxy/testing.yml
@@ -2,7 +2,6 @@
 install_ruby_from_source: true
 desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.18"
 domain_name: "*.ezproxy-test"
 domain_place_name: "ezproxy-test"
 generic_app_user: ezproxy

--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -7,7 +7,6 @@ rails_app_site_config_services:
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.18"
 postgres_host: 'figgy-db-prod1.princeton.edu'
 postgresql_is_local: false
 memcached_listen_ip: 0.0.0.0

--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -7,7 +7,6 @@ rails_app_site_config_services:
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.18"
 postgres_host: 'figgy-db-staging1.princeton.edu'
 postgres_version: 15
 postgresql_is_local: false

--- a/group_vars/friends_of_pul/staging.yml
+++ b/group_vars/friends_of_pul/staging.yml
@@ -16,7 +16,6 @@ mailcatcher_group: "pulsys"
 mailcatcher_install_location: "/var/lib/gems/3.1.0/gems/mailcatcher-0.8.1/bin/mailcatcher"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.18"
 
 mysql_server: false
 

--- a/group_vars/geaccirc/common.yml
+++ b/group_vars/geaccirc/common.yml
@@ -20,6 +20,5 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 application_host_protocol: 'https'
 running_on_server: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: '2.4.20'
 install_ruby_from_source: true
 passenger_ruby: "/usr/local/bin/ruby"

--- a/group_vars/imagecat_rails/main.yml
+++ b/group_vars/imagecat_rails/main.yml
@@ -33,4 +33,3 @@ project_db_host: '{{postgres_host}}'
 # Use Ruby 3.2.0 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.2.0"
-bundler_version: "2.3.7"

--- a/group_vars/lae/production.yml
+++ b/group_vars/lae/production.yml
@@ -14,7 +14,6 @@ passenger_server_name: "lae1.princeton.edu"
 passenger_app_root: "/opt/lae-blacklight/current/public"
 passenger_app_env: "production"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
 postgresql_is_local: false

--- a/group_vars/lae/staging.yml
+++ b/group_vars/lae/staging.yml
@@ -14,7 +14,6 @@ passenger_server_name: "lae-staging1.princeton.edu"
 passenger_app_root: "/opt/lae-blacklight/current/public"
 passenger_app_env: "staging"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
 postgresql_is_local: false

--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -12,7 +12,6 @@ application_db_name: '{{ app_db_name }}'
 application_dbuser_name: '{{ app_db_user }}'
 application_dbuser_password: '{{ app_db_password }}'
 application_host_protocol: 'https'
-bundler_version: "2.5.6"
 desired_nodejs_version: v18.19.1
 postgresql_is_local: false
 open_marc_records_directory: 'open_marc_records'

--- a/group_vars/libwww/production.yml
+++ b/group_vars/libwww/production.yml
@@ -28,7 +28,6 @@ special_collections_drupal_base_path: 'https://library.princeton.edu/special-col
 special_collections_drupal_ssl_base_path: 'https://library.princeton.edu/special-collections'
 special_collections_drupal_db_name: 'special_collections_prod'
 special_collections_drupal_db_host: 'mysql-db-prod1.princeton.edu'
-bundler_version: '2.2.19'
 nodejs__upstream_release: 'node_11.x'
 
 mysql_server: false

--- a/group_vars/libwww/staging.yml
+++ b/group_vars/libwww/staging.yml
@@ -42,7 +42,6 @@ mailcatcher_group: "pulsys"
 mailcatcher_install_location: "/var/lib/gems/3.1.0/gems/mailcatcher-0.8.1/bin/mailcatcher"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.4.14"
 
 mysql_server: false
 

--- a/group_vars/lockers_and_study_spaces/production.yml
+++ b/group_vars/lockers_and_study_spaces/production.yml
@@ -24,7 +24,6 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 app_host_name: 'lockers_and_study_spaces.princeton.edu'
 application_host_protocol: 'https'
 running_on_server: true
-bundler_version: '2.3.26'
 desired_nodejs_version: 'v20.11.1'
 lockers_honeybadger_key: '{{ vault_lockers_and_study_spaces_honeybadger_key }}'
 datadog_api_key: "{{ vault_datadog_key }}"

--- a/group_vars/lockers_and_study_spaces/staging.yml
+++ b/group_vars/lockers_and_study_spaces/staging.yml
@@ -25,7 +25,6 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 app_host_name: 'lockers_and_study_spaces_staging.princeton.edu'
 application_host_protocol: 'https'
 running_on_server: true
-bundler_version: '2.3.26'
 desired_nodejs_version: 'v20.11.1'
 install_mailcatcher: true
 mailcatcher_user: 'pulsys'

--- a/group_vars/mudd/common.yml
+++ b/group_vars/mudd/common.yml
@@ -3,4 +3,3 @@ install_ruby_from_source: true
 desired_nodejs_version: 'v18.17.0'
 ruby_version_override: "ruby-3.2.1"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: 2.4.8

--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -29,7 +29,6 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 # Use Ruby 3.0.3 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.22"
 
 # System Node.js
 desired_nodejs_version: "v18.17.0"

--- a/group_vars/oawaiver/staging.yml
+++ b/group_vars/oawaiver/staging.yml
@@ -28,7 +28,6 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 # Use Ruby 3.0.3 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.22"
 
 # System Node.js
 desired_nodejs_version: "v18.17.0"

--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -37,7 +37,6 @@ passenger_extra_config: '{{ lookup("file", "roles/orangelight/templates/nginx_ex
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.26"
 pg_hba_contype: "host"
 pg_hba_method: "md5"
 pg_hba_postgresql_database: "all"

--- a/group_vars/orcid/main.yml
+++ b/group_vars/orcid/main.yml
@@ -29,7 +29,6 @@ project_db_host: '{{postgres_host}}'
 # Use Ruby 3.2.0 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.2.0"
-bundler_version: "2.4.20"
 
 rails_app_vars:
   - name: SECRET_KEY_BASE

--- a/group_vars/pdc_describe/main.yml
+++ b/group_vars/pdc_describe/main.yml
@@ -29,4 +29,3 @@ project_db_host: '{{postgres_host}}'
 # Use Ruby 3.0.3 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.22"

--- a/group_vars/pdc_discovery/common.yml
+++ b/group_vars/pdc_discovery/common.yml
@@ -33,4 +33,3 @@ project_db_host: '{{postgres_host}}'
 # Use Ruby 3.1.0 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.22"

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -20,7 +20,6 @@ passenger_server_name: "findingaids.princeton.edu"
 passenger_app_root: "/opt/pulfalight/current/public"
 passenger_app_env: "production"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.4.22"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"

--- a/group_vars/pulfalight/qa.yml
+++ b/group_vars/pulfalight/qa.yml
@@ -18,7 +18,6 @@ passenger_server_name: "pulfalight-qa-web-1.princeton.edu"
 passenger_app_root: "/opt/pulfalight/current/public"
 passenger_app_env: "qa"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.4.22"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"

--- a/group_vars/pulmap/production.yml
+++ b/group_vars/pulmap/production.yml
@@ -10,7 +10,6 @@ passenger_app_root: "/opt/pulmap/current/public"
 passenger_app_env: "production"
 passenger_server_name: "pulmap.princeton.edu"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
 pulmap_rabbit_user: '{{vault_rabbit_production_user}}'

--- a/group_vars/pulmap/staging.yml
+++ b/group_vars/pulmap/staging.yml
@@ -10,7 +10,6 @@ passenger_server_name: "maps-staging.princeton.edu"
 passenger_app_root: "/opt/pulmap/current/public"
 passenger_app_env: "production"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: "2.3.18"
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
 pulmap_rabbit_user: '{{vault_rabbit_staging_user}}'

--- a/group_vars/repec/common.yml
+++ b/group_vars/repec/common.yml
@@ -5,5 +5,4 @@ ruby_version_override: "ruby-3.1.3"
 passenger_ruby: "/usr/local/bin/ruby"
 
 running_on_server: true
-bundler_version: '2.2.27'
 desired_nodejs_version: v18.17.0

--- a/group_vars/solr8cloud/production.yml
+++ b/group_vars/solr8cloud/production.yml
@@ -2,7 +2,6 @@
 desired_ruby_version: "3.1.0"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.18"
 solr_heap_setting: '20g'
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'

--- a/group_vars/solr8cloud/staging.yml
+++ b/group_vars/solr8cloud/staging.yml
@@ -2,7 +2,6 @@
 desired_ruby_version: "3.1.0"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.18"
 solr_heap_setting: '20g'
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'

--- a/group_vars/solr9cloud/production.yml
+++ b/group_vars/solr9cloud/production.yml
@@ -4,7 +4,6 @@ install_ruby_from_source: true
 install_zookeeper_from_source: true
 desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.18"
 solr_heap_setting: '20g'
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'

--- a/group_vars/solr9cloud/staging.yml
+++ b/group_vars/solr9cloud/staging.yml
@@ -4,7 +4,6 @@ install_ruby_from_source: true
 install_zookeeper_from_source: true
 desired_ruby_version: "3.1.0"
 ruby_version_override: "ruby-3.1.0"
-bundler_version: "2.3.18"
 solr_heap_setting: '20g'
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'

--- a/group_vars/special_collections/production.yml
+++ b/group_vars/special_collections/production.yml
@@ -5,7 +5,6 @@ drupal_base_path: 'https://library.princeton.edu/special-collections'
 drupal_ssl_base_path: 'https://library.princeton.edu/special-collections'
 drupal_db_name: 'special_collections_prod'
 drupal_db_host: '{{ db_host }}'
-bundler_version: '2.1.4'
 
 
 db_host: 'mysql-db-prod1.princeton.edu'

--- a/group_vars/special_collections/staging.yml
+++ b/group_vars/special_collections/staging.yml
@@ -31,4 +31,3 @@ mailcatcher_group: "pulsys"
 mailcatcher_install_location: "/var/lib/gems/3.1.0/gems/mailcatcher-0.8.1/bin/mailcatcher"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
-bundler_version: "2.3.18"

--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -16,7 +16,6 @@ app_host_name: '{{ passenger_server_name }}'
 application_host_protocol: 'https'
 running_on_server: true
 tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
-bundler_version: '2.5.6'
 desired_nodejs_version: 'v18.13.0'
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true

--- a/group_vars/towerdeploy/production.yml
+++ b/group_vars/towerdeploy/production.yml
@@ -1,5 +1,4 @@
 ---
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.2.1"
-bundler_version: "2.4.10"
 deploy_id_rsa_private_key: "{{ vault_deployment_private_key }}"

--- a/roles/dss/vars/main.yml
+++ b/roles/dss/vars/main.yml
@@ -15,7 +15,6 @@ application_host: '{{ passenger_server_name }}'
 application_host_protocol: 'https'
 nodejs_version: "9.x"
 project_db_host: '{{ db_host }}'
-bundler_version: "2.2.27"
 rails_app_vars:
   - name: SECRET_KEY_BASE
     value: '{{ vault_dss_secret_key | default("dss_secret")}}'

--- a/roles/oawaiver/defaults/main.yml
+++ b/roles/oawaiver/defaults/main.yml
@@ -4,4 +4,3 @@
 # Use Ruby 3.0.3 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.0.3"
-bundler_version: "2.3.11"

--- a/roles/oawaiver/molecule/default/converge.yml
+++ b/roles/oawaiver/molecule/default/converge.yml
@@ -7,7 +7,6 @@
     - nodejs__upstream_key_id: '68576280'
     - install_ruby_from_source: true
     - ruby_version_override: "ruby-3.0.3"
-    - bundler_version: "2.3.11"
     - postgres_version: 15
   become: true
   pre_tasks:

--- a/roles/oawaiver/molecule/default/verify.yml
+++ b/roles/oawaiver/molecule/default/verify.yml
@@ -46,10 +46,5 @@
     failed_when:
       - "'ruby 3.0' not in ruby_version.stdout"
 
-  # bundler is no longer being installed by the ruby_s role in molecule
-  # - name: "Ensure that a 2.3 release of the Bundler Gem is installed" # noqa no-changed-when
-  #   ansible.builtin.command:
-  #     cmd: "/usr/local/bin/gem info bundler"
-  #   register: gem_info_bundler
-  #   failed_when:
-  #     - "'2.3.11' not in gem_info_bundler.stdout"
+  # the ruby_s role does not install bundler in molecule
+  # so we do not test whether bundler is present or a specific version


### PR DESCRIPTION
Partial fix for #4663.

Removes all definitions of `bundler_version` from group_vars and from roles.

With this gone, we can probably remove the `install_bundler` tasks file from the ruby_s role. 

Do we need a task in the main ruby_s tasks file for installing bundler, or can we rely on deployments to do that for us?