### PR TITLE
[nginxplus] fix tag location

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -34,7 +34,7 @@
           msg: "Ansible is now running `{{ ansible_play_name }}` from the `{{ git_branch.stdout }}` branch with the `{{ ansible_run_tags }}` tag on {{ inventory_hostname }}"
           channel: "{{ item }}"
         loop: "{{ slack_alerts_channel }}"
-        tags: always
+      tags: always
       become: false
 
   # updates existing load balancer


### PR DESCRIPTION
we move the tags two spaces to the left to allow this to run

The tag needs to affect the block not the task

closes #4682

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
