### PR TITLE
[mudd-db] Update node to 20.11.1

### DIFF
--- a/group_vars/mudd/common.yml
+++ b/group_vars/mudd/common.yml
@@ -1,6 +1,5 @@
 ---
 install_ruby_from_source: true
-desired_nodejs_version: 'v18.17.0'
+desired_nodejs_version: 'v20.11.1'
 ruby_version_override: "ruby-3.2.1"
 passenger_ruby: "/usr/local/bin/ruby"
-bundler_version: 2.4.8


### PR DESCRIPTION
Update node to 20.11.1
Remove bundler_version


Initially I removed node from the box. I purged all the node packages and then when I tried to add node back mudd-staging complained about bundler (yes). Even though the x version of bundler was installed and set as the default it couldn’t see it. I removed the y version of bundler that was also installed. It still didn’t want to look the x version, even though it was installed. I removed the x version and then ran the playbook with bundler_version x. Nothing was installed. 
In the end I manually installed the x version of bundler.