### PR TITLE
Adding a playbook to enable redis

### DIFF
--- a/playbooks/utils/enable_redis_on_restart.yml
+++ b/playbooks/utils/enable_redis_on_restart.yml
@@ -1,0 +1,31 @@
+---
+#  This playbook will enable the redis running on the server indicated by `--limit` to start on reboot
+#     for example running this playbook `--limit tigerdata-staging1.princeton.edu -e slack_alerts_channel=ansible-alerts`
+#     will enable redis on reboot on tigerdata-staging1 and notify the ansible alerts channel
+- name: Run the command to enable redis on a host
+  hosts: staging:qa:production
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../../group_vars/all/vault.yml
+    - ../../group_vars/all/vars.yml
+
+  pre_tasks:
+    - name: stop playbook if you didn't use --limit
+      fail:
+        msg: "you must use -l or --limit"
+      when: ansible_limit is not defined
+      run_once: true
+
+
+  tasks:
+    - name: enable redis
+      ansible.builtin.service:
+        name: "redis-server"
+        enabled: true
+        state: restarted
+
+  post_tasks:
+    - name: send information to slack
+      ansible.builtin.include_tasks:
+        file: slack_tasks_end_of_playbook.yml


### PR DESCRIPTION
fixes #4707

See enabled on the third line down... Prior to running the playbook it stated disabled
```
pulsys@tigerdata-staging2:~$ sudo systemctl status redis-server
● redis-server.service - Advanced key-value store
     Loaded: loaded (/lib/systemd/system/redis-server.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2024-02-28 13:33:16 UTC; 1min 1s ago
       Docs: http://redis.io/documentation,
             man:redis-server(1)
   Main PID: 456492 (redis-server)
     Status: "Ready to accept connections"
      Tasks: 6 (limit: 9347)
     Memory: 3.1M
        CPU: 218ms
     CGroup: /system.slice/redis-server.service
             └─456492 "/usr/bin/redis-server 0.0.0.0:6379" "" "" "" "" "" "" "" "" ""

Feb 28 13:33:16 tigerdata-staging2 systemd[1]: Starting Advanced key-value store...
Feb 28 13:33:16 tigerdata-staging2 systemd[1]: Started Advanced key-value store.
```