### PR TITLE
adds new jammy VMs for dpul, lae, and maps to inventory

### DIFF
--- a/inventory/all_projects/dpul
+++ b/inventory/all_projects/dpul
@@ -1,6 +1,12 @@
 [dpul_production]
 dpul1.princeton.edu
 dpul2.princeton.edu
+# jammy boxes
+dpul-prod1.princeton.edu
+dpul-prod2.princeton.edu
 [dpul_staging]
 dpul-staging1.princeton.edu
 dpul-staging2.princeton.edu
+# jammy boxes
+dpul-staging3.princeton.edu
+dpul-staging4.princeton.edu

--- a/inventory/all_projects/lae
+++ b/inventory/all_projects/lae
@@ -1,5 +1,10 @@
 [lae_production]
 lae1.princeton.edu
 lae2.princeton.edu
+# jammy boxes
+lae-prod1.princeton.edu
+lae-prod2.princeton.edu
 [lae_staging]
 lae-staging1.princeton.edu
+# jammy box
+lae-staging2.princeton.edu

--- a/inventory/all_projects/pulmap
+++ b/inventory/all_projects/pulmap
@@ -1,5 +1,11 @@
 [pulmap_production]
 maps1.princeton.edu
 maps2.princeton.edu
+# jammy boxes
+maps-prod1.princeton.edu
+maps-prod2.princeton.edu
+
 [pulmap_staging]
 maps-staging1.princeton.edu
+# jammy box
+maps-staging2.princeton.edu


### PR DESCRIPTION
Partial fix for #4662.

Part our upgrade-to-Jammy-Jellyfish project. This PR adds the newly created Jammy VMs for pulmap, dpul, and lae-blacklight to our inventory for Princeton Ansible. 

Related to:
https://github.com/pulibrary/lae-blacklight/issues/365
https://github.com/pulibrary/dpul/issues/1493
https://github.com/pulibrary/pulmap/issues/1187
