### PR TITLE
we want redis to restart on reboot

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -37,4 +37,4 @@
   service:
     name: "redis-server"
     state: started
-    enabled: false
+    enabled: true


### PR DESCRIPTION
Follow-up to #4629.

Enable the redis service so it will start up when a machine is rebooted.
