### PR TITLE
adds new jammy figgy VMs to inventory

### DIFF
--- a/inventory/all_projects/figgy
+++ b/inventory/all_projects/figgy
@@ -1,6 +1,9 @@
 [figgy_staging]
 # figgy-web-staging-1.princeton.edu # new jammy box; not served
 figgy-staging2.princeton.edu
+# new/added jammy VMs
+figgy-web-staging1.princeton.edu
+figgy-web-staging2.princeton.edu
 # no worker VMs in staging
 [figgy_production_workers]
 lib-proc6.princeton.edu
@@ -9,11 +12,23 @@ lib-proc8.princeton.edu
 lib-proc9.princeton.edu
 lib-proc10.princeton.edu
 lib-proc11.princeton.edu
+# jammy VMs
+figgy-worker-prod1.princeton.edu
+figgy-worker-prod2.princeton.edu
+figgy-worker-prod3.princeton.edu
+figgy-worker-prod4.princeton.edu
+figgy-worker-prod5.princeton.edu
+figgy-worker-prod6.princeton.edu
 [figgy_production_webservers]
 figgy1.princeton.edu
 figgy-web-prod-2.princeton.edu
 figgy3.princeton.edu
 figgy-web-prod-4.princeton.edu
+# jammy VMs
+figgy-web-prod1.princeton.edu
+figgy-web-prod2.princeton.edu
+figgy-web-prod3.princeton.edu
+figgy-web-prod4.princeton.edu
 [figgy_production:children]
 figgy_production_workers
 figgy_production_webservers
@@ -23,9 +38,19 @@ figgy-web-prod-2.princeton.edu
 lib-proc6.princeton.edu
 lib-proc7.princeton.edu
 lib-proc8.princeton.edu
+figgy-web-prod1.princeton.edu
+figgy-web-prod2.princeton.edu
+figgy-worker-prod1.princeton.edu
+figgy-worker-prod2.princeton.edu
+figgy-worker-prod3.princeton.edu
 [figgy_production_group_b]
 figgy3.princeton.edu
 figgy-web-prod-4.princeton.edu
 lib-proc9.princeton.edu
 lib-proc10.princeton.edu
 lib-proc11.princeton.edu
+figgy-web-prod3.princeton.edu
+figgy-web-prod4.princeton.edu
+figgy-worker-prod4.princeton.edu
+figgy-worker-prod5.princeton.edu
+figgy-worker-prod6.princeton.edu


### PR DESCRIPTION
Closes #4662.

Adds two new staging VMs and ten new production VMs (six worker boxes and four web boxes). 

Maintains the "group A/group B" configuration, since we may want that for future upgrades / maintenance.

Once the new infrastructure is in use, we need to decommission the old VMs.