### PR TITLE
[Figgy] Upgrade to Jammy

### DIFF
--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -13,7 +13,7 @@ postgresql_is_local: false
 postgres_admin_user: '{{vault_postgres_staging_admin_user}}'
 nodejs_release_url: "https://github.com/pulibrary/nodejs-binaries/releases/download/"
 desired_nodejs_version: "v18.18.0"
-passenger_server_name: "figgy-staging2.princeton.edu"
+passenger_server_name: "figgy-staging.princeton.edu"
 passenger_app_root: "/opt/figgy/current/public"
 passenger_app_env: "staging"
 figgy_cantaloupe_images_mount: iiif-staging1
@@ -31,6 +31,7 @@ figgy_rabbit_password: '{{vault_rabbit_staging_password}}'
 figgy_rabbit_server: 'amqp://{{figgy_rabbit_user}}:{{figgy_rabbit_password}}@{{figgy_staging_rabbit_host}}:5672'
 figgy_geoserver_user: '{{ vault_figgy_geoserver_user }}'
 figgy_geoserver_password: '{{ vault_figgy_geoserver_password }}'
+figgy_staging_rabbit_host: 'figgy-web-staging1.princeton.edu'
 rabbitmq_user: '{{figgy_rabbit_user}}'
 rabbitmq_password: '{{figgy_rabbit_password}}'
 figgy_read_only_mode: 'false'
@@ -75,7 +76,7 @@ rails_app_vars:
   - name: HONEYBADGER_API_KEY
     value: '{{figgy_honeybadger_key}}'
   - name: FIGGY_REDIS_URL
-    value: '127.0.0.1'
+    value: 'figgy-web-staging1.princeton.edu'
   - name: FIGGY_REDIS_DB
     value: '0'
   - name: FIGGY_PUDL_ROOT

--- a/inventory/all_projects/figgy
+++ b/inventory/all_projects/figgy
@@ -1,17 +1,17 @@
 [figgy_staging]
 # figgy-web-staging-1.princeton.edu # new jammy box; not served
-figgy-staging2.princeton.edu
+# figgy-staging2.princeton.edu
 # new/added jammy VMs
 figgy-web-staging1.princeton.edu
 figgy-web-staging2.princeton.edu
 # no worker VMs in staging
 [figgy_production_workers]
-lib-proc6.princeton.edu
-lib-proc7.princeton.edu
-lib-proc8.princeton.edu
-lib-proc9.princeton.edu
-lib-proc10.princeton.edu
-lib-proc11.princeton.edu
+# lib-proc6.princeton.edu
+# lib-proc7.princeton.edu
+# lib-proc8.princeton.edu
+# lib-proc9.princeton.edu
+# lib-proc10.princeton.edu
+# lib-proc11.princeton.edu
 # jammy VMs
 figgy-worker-prod1.princeton.edu
 figgy-worker-prod2.princeton.edu
@@ -20,10 +20,10 @@ figgy-worker-prod4.princeton.edu
 figgy-worker-prod5.princeton.edu
 figgy-worker-prod6.princeton.edu
 [figgy_production_webservers]
-figgy1.princeton.edu
-figgy-web-prod-2.princeton.edu
-figgy3.princeton.edu
-figgy-web-prod-4.princeton.edu
+# figgy1.princeton.edu
+# figgy-web-prod-2.princeton.edu
+# figgy3.princeton.edu
+# figgy-web-prod-4.princeton.edu
 # jammy VMs
 figgy-web-prod1.princeton.edu
 figgy-web-prod2.princeton.edu
@@ -33,22 +33,22 @@ figgy-web-prod4.princeton.edu
 figgy_production_workers
 figgy_production_webservers
 [figgy_production_group_a]
-figgy1.princeton.edu
-figgy-web-prod-2.princeton.edu
-lib-proc6.princeton.edu
-lib-proc7.princeton.edu
-lib-proc8.princeton.edu
+# figgy1.princeton.edu
+# figgy-web-prod-2.princeton.edu
+# lib-proc6.princeton.edu
+# lib-proc7.princeton.edu
+# lib-proc8.princeton.edu
 figgy-web-prod1.princeton.edu
 figgy-web-prod2.princeton.edu
 figgy-worker-prod1.princeton.edu
 figgy-worker-prod2.princeton.edu
 figgy-worker-prod3.princeton.edu
 [figgy_production_group_b]
-figgy3.princeton.edu
-figgy-web-prod-4.princeton.edu
-lib-proc9.princeton.edu
-lib-proc10.princeton.edu
-lib-proc11.princeton.edu
+# figgy3.princeton.edu
+# figgy-web-prod-4.princeton.edu
+# lib-proc9.princeton.edu
+# lib-proc10.princeton.edu
+# lib-proc11.princeton.edu
 figgy-web-prod3.princeton.edu
 figgy-web-prod4.princeton.edu
 figgy-worker-prod4.princeton.edu

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -4,15 +4,6 @@
   remote_user: pulsys
   become: true
   strategy: free
-  pre_tasks:
-    - name: remove mediainfo installation
-      apt:
-        name: mediainfo
-        state: absent
-    - name: remove mediainfo deb repo
-      apt:
-        name: repo-mediaarea
-        state: absent
   vars_files:
     - ../site_vars.yml
     - ../group_vars/figgy/vault.yml
@@ -24,6 +15,11 @@
     - {role: roles/rabbitmq, when: inventory_hostname == 'figgy1.princeton.edu'}
     - role: roles/figgy
     - role: roles/datadog
+  pre_tasks:
+    - name: remove mediainfo deb repo
+      apt:
+        name: repo-mediaarea
+        state: absent
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       slack:
@@ -45,15 +41,6 @@
   remote_user: pulsys
   become: true
   strategy: free
-  pre_tasks:
-    - name: remove mediainfo installation
-      apt:
-        name: mediainfo
-        state: absent
-    - name: remove mediainfo deb repo
-      apt:
-        name: repo-mediaarea
-        state: absent
   vars_files:
     - ../site_vars.yml
     - ../group_vars/figgy/vault.yml

--- a/playbooks/figgy_staging.yml
+++ b/playbooks/figgy_staging.yml
@@ -3,17 +3,6 @@
   hosts: figgy_staging
   remote_user: pulsys
   become: true
-  pre_tasks:
-    - name: remove mediainfo installation
-      apt:
-        name: mediainfo
-        state: absent
-      tags: mediainfo
-    - name: remove mediainfo deb repo
-      apt:
-        name: repo-mediaarea
-        state: absent
-      tags: mediainfo
   vars_files:
     - ../site_vars.yml
     - ../group_vars/figgy/vault.yml

--- a/roles/mediainfo/defaults/main.yml
+++ b/roles/mediainfo/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for mediainfo
-mediaarea_repo_version: 1.0-12
+mediaarea_repo_version: 1.0-24

--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -4,10 +4,10 @@ proxy_cache_path /data/nginx/figgy/NGINX_cache/ keys_zone=figgycache:10m;
 upstream figgy {
     least_time last_byte inflight;
     zone figgy 128k;
-    server figgy1.princeton.edu resolve;
-    server figgy-web-prod-2.princeton.edu resolve;
-    server figgy3.princeton.edu resolve;
-    server figgy-web-prod-4.princeton.edu resolve;
+    server figgy-web-prod1 resolve max_fails=0;
+    server figgy-web-prod2 resolve max_fails=0;
+    server figgy-web-prod3 resolve max_fails=0;
+    server figgy-web-prod4 resolve max_fails=0;
     sticky learn
           create=$upstream_cookie_figgycookie
           lookup=$cookie_figgycookie

--- a/roles/nginxplus/files/conf/http/figgy-staging.conf
+++ b/roles/nginxplus/files/conf/http/figgy-staging.conf
@@ -4,7 +4,8 @@ proxy_cache_path /data/nginx/figgy-staging/NGINX_cache/ keys_zone=figgy-stagingc
 upstream figgy-staging {
     least_time last_byte inflight;
     zone figgy-staging 128k;
-    server figgy-staging2.princeton.edu resolve;
+    server figgy-web-staging1.princeton.edu resolve max_fails=0;
+    server figgy-web-staging2.princeton.edu resolve max_fails=0;
     sticky learn
           create=$upstream_cookie_figgystagingcookie
           lookup=$cookie_figgystagingcookie

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -62,6 +62,7 @@
     - restart rabbitmq
 
 - name: add user
+  become: true
   rabbitmq_user:
     user: '{{rabbitmq_user}}'
     password: '{{rabbitmq_password}}'


### PR DESCRIPTION
For now this leaves Figgy connected to figgy1.princeton.edu just for Redis until tonight, when the workers finish processing their jobs and I can migrate redis data to figgy-web-prod1.