### PR TITLE
[Figgy/DPUL/Pulfalight/Maps] Add an HTTP check for health endpoints.

### DIFF
--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -167,6 +167,15 @@ datadog_checks:
         service: dpul
         source: nginx
         sourcecategory: http_web_access
+  http_check:
+    init_config:
+    instances:
+      - name: DPUL Health
+        url: 'http://localhost/health.json'
+        include_content: true
+        tags:
+          - 'http_service:dpul'
+          - 'http_service_type:health'
 redis_bind_interface: '0.0.0.0'
 redis__server_default_configuration:
   syslog-enabled: "{{ redis__server_syslog | bool }}"

--- a/group_vars/figgy/production_webserver.yml
+++ b/group_vars/figgy/production_webserver.yml
@@ -1,5 +1,19 @@
 ---
 figgy_tags: "application:figgy, environment:production, type:webserver"
+figgy_datadog_http_check:
+  init_config:
+  instances:
+    - name: Figgy Uptime
+      url: 'https://figgy.princeton.edu'
+      skip_event: true
+      tags:
+        - 'http_service:figgy'
+    - name: Figgy Health
+      url: 'http://localhost/health.json'
+      include_content: true
+      tags:
+        - 'http_service:figgy'
+        - 'http_service_type:health'
 figgy_datadog_nginx_check:
   init_config:
   logs:

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -122,3 +122,12 @@ datadog_checks:
         source: ruby
         sourcecategory: sourcecode
         tags: "pulfalight, environment:production, role:pulfalight"
+  http_check:
+    init_config:
+    instances:
+      - name: Pulfalight Health
+        url: 'http://localhost/health.json'
+        include_content: true
+        tags:
+          - 'http_service:pulfalight'
+          - 'http_service_type:health'

--- a/group_vars/pulfalight/production_workers.yml
+++ b/group_vars/pulfalight/production_workers.yml
@@ -1,0 +1,17 @@
+datadog_checks:
+  tls:
+    init_config:
+    instances:
+      - server: findingaids.princeton.edu
+        port: 443
+        tags:
+          - 'tls_service:findingaids'
+  findingaids_beta_datadog_ruby_check:
+    init_config:
+    logs:
+      - type: file
+        path: /opt/pulfalight/current/log/production.log
+        service: pulfalight
+        source: ruby
+        sourcecategory: sourcecode
+        tags: "pulfalight, environment:production, role:pulfalight"

--- a/group_vars/pulmap/production.yml
+++ b/group_vars/pulmap/production.yml
@@ -113,3 +113,12 @@ datadog_checks:
     instances:
       - server: maps.princeton.edu
         port: 443
+  http_check:
+    init_config:
+    instances:
+      - name: Maps Health
+        url: 'http://localhost/health.json'
+        include_content: true
+        tags:
+          - 'http_service:pulmap'
+          - 'http_service_type:health'

--- a/playbooks/pulfalight.yml
+++ b/playbooks/pulfalight.yml
@@ -32,6 +32,7 @@
   become: true
   vars_files:
     - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}_workers.yml
     - ../group_vars/pulfalight/vault.yml
   roles:
     - { role: 'roles/postgresql', tags: 'postgresql' }


### PR DESCRIPTION
Powers a health status monitor for no extra money, on a per-host basis: https://app.datadoghq.com/monitors/140962600?view=spans