### PR TITLE
Set X-Real-IP header for lae to fix access logging

### DIFF
--- a/roles/nginxplus/files/conf/http/lae-prod.conf
+++ b/roles/nginxplus/files/conf/http/lae-prod.conf
@@ -43,6 +43,7 @@ server {
     location / {
         proxy_pass http://lae;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_cache laeprodcache;
         health_check interval=10 fails=3 passes=2;
         if ($http_user_agent ~ (Dubbotbot) ) {

--- a/roles/nginxplus/files/conf/http/lae-staging.conf
+++ b/roles/nginxplus/files/conf/http/lae-staging.conf
@@ -43,6 +43,7 @@ server {
         app_protect_security_log_enable on;
         proxy_pass http://lae-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_cache lae-stagingcache;
         health_check interval=10 fails=3 passes=2;
         limit_req zone=lae-staging-ratelimit burst=80 nodelay;


### PR DESCRIPTION
Closes #4650 

Sets Real-IP header to enable access logging:
https://github.com/pulibrary/princeton_ansible/blob/main/roles/passenger/templates/passenger.j2#L12-L15