### PR TITLE
Build a custom EE for faster code deploys

### DIFF
--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -5,9 +5,10 @@
 # to deploy a selected branch, pass '-e branch_name=my_branch'
 # to deploy to production, pass '-e runtime_env=production'
 - name: Deploy code with Capistrano
-  hosts: towerdeploy
-  remote_user: pulsys
-  become: true
+  # hosts: towerdeploy
+  hosts: localhost
+  # remote_user: pulsys
+  # become: true
   vars:
     project_dir: /tmp/{{ repo_name }}
 #    github_key_path:
@@ -51,13 +52,9 @@
         clone: true
         update: true
         # force: true
-      become: true
-      become_user: deploy
 
     - name: cap deploy
       ansible.builtin.shell: "cd {{ project_dir }} && BRANCH={{ branch_name | default('main') }} /usr/local/bin/cap {{ runtime_env | default('staging') }} deploy"
-      become: true
-      become_user: deploy
 
 #    - name: update PR
 #      could use the GitHub API:
@@ -82,4 +79,4 @@
         Content-Type: application/x-www-form-urlencoded
       follow_redirects: safe
       status_code: 201,202
-    
+

--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -57,6 +57,28 @@
       ansible.builtin.shell: "cd {{ project_dir }} && rm .ruby-version"
       ignore_errors: true
 
+    - name: towerdeploy | install capistrano dependencies
+      ansible.builtin.command: gem install "{{ item }}"
+      register: capgemoutput
+      changed_when: capgemoutput.rc != 0
+      failed_when: capgemoutput.rc !=0
+      loop:
+        - activesupport
+        - airbrussh
+        - capistrano-composer
+        - capistrano-passenger
+        - capistrano-rails
+        - capistrano-rails-console
+        - capistrano-yarn
+        - concurrent-ruby
+        - honeybadger
+        - i18n
+        - net-scp
+        - net-ssh
+        - rake
+        - sshkit
+        - whenever
+
     - name: cap deploy
       ansible.builtin.shell: "cd {{ project_dir }} && BRANCH={{ branch_name | default('main') }} cap {{ runtime_env | default('staging') }} deploy"
 

--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -54,7 +54,7 @@
         # force: true
 
     - name: cap deploy
-      ansible.builtin.shell: "cd {{ project_dir }} && BRANCH={{ branch_name | default('main') }} /usr/local/bin/cap {{ runtime_env | default('staging') }} deploy"
+      ansible.builtin.shell: "cd {{ project_dir }} && BRANCH={{ branch_name | default('main') }} cap {{ runtime_env | default('staging') }} deploy"
 
 #    - name: update PR
 #      could use the GitHub API:

--- a/playbooks/deploy_code.yml
+++ b/playbooks/deploy_code.yml
@@ -53,6 +53,10 @@
         update: true
         # force: true
 
+    - name: do not use project-defined ruby version
+      ansible.builtin.shell: "cd {{ project_dir }} && rm .ruby-version"
+      ignore_errors: true
+
     - name: cap deploy
       ansible.builtin.shell: "cd {{ project_dir }} && BRANCH={{ branch_name | default('main') }} cap {{ runtime_env | default('staging') }} deploy"
 

--- a/roles/deploy_user/defaults/main.yml
+++ b/roles/deploy_user/defaults/main.yml
@@ -5,6 +5,7 @@ deploy_user_github_keys:
   - https://github.com/kayiwa.keys
 deploy_user_local_keys:
   - { name: 'heaven', key: "{{ lookup('file', '../../../keys/heaven.pub') }}" }
+  - { name: 'tower', key: "{{ lookup('file', '../../../keys/TowerKey.pub') }}" }
 deploy_user_uid: "{{ user_uid | default('1001') }}"
 deploy_user_shell: /bin/bash
 deploy_id_rsa_private_key: "bogus_rsa_key"

--- a/tower_ees/deploy-ee.yml
+++ b/tower_ees/deploy-ee.yml
@@ -71,12 +71,16 @@ additional_build_steps:
     # - RUN /usr/bin/apt-get update
   append_final:
     # install ruby with rbenv
+    - ENV HOME /home/runner
+    - ENV PATH "$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
     - RUN wget -q https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer -O- | sh
-    - RUN ~/.rbenv/bin/rbenv install 3.1.0
-    # On the next task I see 'rbenv: version 3.1.0 not isntalled' even though it exists at /home/runner/.rbenv/versions/3.1.0
-    # - RUN /home/runner/.rbenv/libexec/rbenv global 3.1.0
+    - RUN rbenv install 3.1.0
+    - RUN rbenv global 3.1.0
     # install capistrano
-    - RUN /home/runner/.rbenv/versions/3.1.0/bin/gem install capistrano
+    - RUN gem install capistrano
+    # this worked for runner, see below 
+    # - RUN /home/deploy/.rbenv/versions/3.1.0/bin/gem install capistrano
+    # - RUN /home/runner/.rbenv/versions/3.1.0/bin/gem install capistrano
     # install cap dependencies
     
 # - RUN /usr/bin/python3 -m pip install --upgrade pip

--- a/tower_ees/deploy-ee.yml
+++ b/tower_ees/deploy-ee.yml
@@ -1,0 +1,81 @@
+---
+# EE definition for deploying code
+# to build this EE, run:
+# `ansible-builder build -f deploy-ee.yml`
+
+# builder schema version
+version: 3
+
+images:
+  # build a new image based on this image
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel8:1.0.0-543
+
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.15.7
+  ansible_runner:
+    package_pip: ansible-runner
+  python_interpreter:
+    python_path: "/usr/bin/python3"
+  galaxy:
+    # includes all collections used in the prancible repo
+    # versions taken from the Ansible 8 inclusion list:
+    # https://github.com/ansible-community/ansible-build-data/blob/main/8/ansible-8.7.0.yaml
+    collections:
+      - name: ansible.posix
+        version: 1.5.4
+      - name: ansible.utils
+        version: 2.12.0
+      - name: community.crypto
+        version: 2.16.1
+      - name: community.dns
+        version: 2.6.4
+      - name: community.general
+        version: 7.5.2
+
+  # python packages, stuff you install with 'pip install'
+  python:
+    - six
+    - psutil
+
+  # system packages, stuff you install with 'apt/yum/dnf install'
+  # ansible-builder writes this list into the 'context/bindep.txt' file
+  system:
+    # - "@ruby:3.1"
+    # - rubygems
+    - bzip2
+    - curl
+    - gcc
+    - gdbm-devel
+    - git
+    - libffi-devel
+    - ncurses-devel
+    - openssl-devel
+    - python3-dnf
+    - python3-pip
+    # - readline-devel
+    - wget
+    - zlib-devel
+options:
+  # default path is /usr/bin/dnf, which does not exist on the base image
+  package_manager_path: /usr/bin/microdnf
+
+# if you need to run more commands on the EE, use this section:
+additional_build_steps:
+  # items in the list of append_base steps are expressed
+  # as containerfile directives
+  # prepend_base:
+    # - RUN /usr/bin/apt-get update
+  append_final:
+    # install ruby with rbenv
+    - RUN wget -q https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer -O- | bash
+    - RUN ~/.rbenv/bin/rbenv install 3.1.0
+    - RUN $HOME/.rbenv/bin/rbenv global 3.1.0
+    # install capistrano
+    - RUN ruby -v
+    - RUN gem install bundler
+    - RUN gem install capistrano
+    # install cap dependencies
+    
+# - RUN /usr/bin/python3 -m pip install --upgrade pip

--- a/tower_ees/deploy-ee.yml
+++ b/tower_ees/deploy-ee.yml
@@ -44,12 +44,14 @@ dependencies:
   system:
     # - "@ruby:3.1"
     # - rubygems
+    - automake
     - bzip2
     - curl
     - gcc
     - gdbm-devel
     - git
     - libffi-devel
+    - make
     - ncurses-devel
     - openssl-devel
     - python3-dnf
@@ -69,13 +71,12 @@ additional_build_steps:
     # - RUN /usr/bin/apt-get update
   append_final:
     # install ruby with rbenv
-    - RUN wget -q https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer -O- | bash
+    - RUN wget -q https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer -O- | sh
     - RUN ~/.rbenv/bin/rbenv install 3.1.0
-    - RUN $HOME/.rbenv/bin/rbenv global 3.1.0
+    # On the next task I see 'rbenv: version 3.1.0 not isntalled' even though it exists at /home/runner/.rbenv/versions/3.1.0
+    # - RUN /home/runner/.rbenv/libexec/rbenv global 3.1.0
     # install capistrano
-    - RUN ruby -v
-    - RUN gem install bundler
-    - RUN gem install capistrano
+    - RUN /home/runner/.rbenv/versions/3.1.0/bin/gem install capistrano
     # install cap dependencies
     
 # - RUN /usr/bin/python3 -m pip install --upgrade pip


### PR DESCRIPTION
The EE now builds and a test template runs on it. However, `cap deploy` still fails, and the problem is with SSH keys. Not sure of the details.

We also need to move the installation of the Capistrano dependencies out of the playbook and into the EE build - this will speed things up too. 