### PR TITLE
[Figgy/DPUL/Maps/Pulfalight] Use per-service datadog health checks.

### DIFF
--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -170,12 +170,30 @@ datadog_checks:
   http_check:
     init_config:
     instances:
-      - name: DPUL Health
+      - name: Solr Health
         url: 'http://localhost/health.json'
+        content_match: '{"name":"SolrStatus","message":"","status":"OK"}'
         include_content: true
         tags:
           - 'http_service:dpul'
           - 'http_service_type:health'
+          - 'http_service_check:solr'
+      - name: Database Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"Database","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:dpul'
+          - 'http_service_type:health'
+          - 'http_service_check:postgres'
+      - name: Redis Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"Redis","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:dpul'
+          - 'http_service_type:health'
+          - 'http_service_check:redis'
 redis_bind_interface: '0.0.0.0'
 redis__server_default_configuration:
   syslog-enabled: "{{ redis__server_syslog | bool }}"

--- a/group_vars/figgy/production_webserver.yml
+++ b/group_vars/figgy/production_webserver.yml
@@ -3,17 +3,30 @@ figgy_tags: "application:figgy, environment:production, type:webserver"
 figgy_datadog_http_check:
   init_config:
   instances:
-    - name: Figgy Uptime
-      url: 'https://figgy.princeton.edu'
-      skip_event: true
-      tags:
-        - 'http_service:figgy'
-    - name: Figgy Health
+    - name: Solr Health
       url: 'http://localhost/health.json'
+      content_match: '{"name":"SolrStatus","message":"","status":"OK"}'
       include_content: true
       tags:
         - 'http_service:figgy'
         - 'http_service_type:health'
+        - 'http_service_check:solr'
+    - name: Database Health
+      url: 'http://localhost/health.json'
+      content_match: '{"name":"Database","message":"","status":"OK"}'
+      include_content: true
+      tags:
+        - 'http_service:figgy'
+        - 'http_service_type:health'
+        - 'http_service_check:postgres'
+    - name: Redis Health
+      url: 'http://localhost/health.json'
+      content_match: '{"name":"Redis","message":"","status":"OK"}'
+      include_content: true
+      tags:
+        - 'http_service:figgy'
+        - 'http_service_type:health'
+        - 'http_service_check:redis'
 figgy_datadog_nginx_check:
   init_config:
   logs:

--- a/group_vars/figgy/production_webserver.yml
+++ b/group_vars/figgy/production_webserver.yml
@@ -27,6 +27,14 @@ figgy_datadog_http_check:
         - 'http_service:figgy'
         - 'http_service_type:health'
         - 'http_service_check:redis'
+    - name: ASpace Health
+      url: 'http://localhost/health.json'
+      content_match: '{"name":"AspaceStatus","message":"","status":"OK"}'
+      include_content: true
+      tags:
+        - 'http_service:figgy'
+        - 'http_service_type:health'
+        - 'http_service_check:aspace'
 figgy_datadog_nginx_check:
   init_config:
   logs:

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -125,9 +125,27 @@ datadog_checks:
   http_check:
     init_config:
     instances:
-      - name: Pulfalight Health
+      - name: Solr Health
         url: 'http://localhost/health.json'
+        content_match: '{"name":"SolrStatus","message":"","status":"OK"}'
         include_content: true
         tags:
           - 'http_service:pulfalight'
           - 'http_service_type:health'
+          - 'http_service_check:solr'
+      - name: Database Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"Database","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:pulfalight'
+          - 'http_service_type:health'
+          - 'http_service_check:postgres'
+      - name: Redis Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"Redis","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:pulfalight'
+          - 'http_service_type:health'
+          - 'http_service_check:redis'

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -149,3 +149,11 @@ datadog_checks:
           - 'http_service:pulfalight'
           - 'http_service_type:health'
           - 'http_service_check:redis'
+      - name: ASpace Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"AspaceStatus","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:pulfalight'
+          - 'http_service_type:health'
+          - 'http_service_check:aspace'

--- a/group_vars/pulmap/production.yml
+++ b/group_vars/pulmap/production.yml
@@ -116,9 +116,27 @@ datadog_checks:
   http_check:
     init_config:
     instances:
-      - name: Maps Health
+      - name: Solr Health
         url: 'http://localhost/health.json'
+        content_match: '{"name":"SolrStatus","message":"","status":"OK"}'
         include_content: true
         tags:
           - 'http_service:pulmap'
           - 'http_service_type:health'
+          - 'http_service_check:solr'
+      - name: Database Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"Database","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:pulmap'
+          - 'http_service_type:health'
+          - 'http_service_check:postgres'
+      - name: Redis Health
+        url: 'http://localhost/health.json'
+        content_match: '{"name":"Redis","message":"","status":"OK"}'
+        include_content: true
+        tags:
+          - 'http_service:pulmap'
+          - 'http_service_type:health'
+          - 'http_service_check:redis'


### PR DESCRIPTION
This'll let us create more nuanced monitors.