### PR TITLE
[lib-jobs] add lib-jobs-prod1

### DIFF
--- a/inventory/all_projects/lib-jobs
+++ b/inventory/all_projects/lib-jobs
@@ -2,5 +2,5 @@
 lib-jobs-staging1.princeton.edu
 lib-jobs-staging2.princeton.edu
 [lib_jobs_production]
-# lib-jobs-prod1.princeton.edu
+lib-jobs-prod1.princeton.edu
 lib-jobs-prod2.princeton.edu

--- a/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/libjobs-prod/NGINX_cache/ keys_zone=libjobs-prodcac
 
 upstream libjobs-prod {
     zone libjobs-prod 64k;
-    # server lib-jobs-prod1.princeton.edu resolve;
+    server lib-jobs-prod1.princeton.edu resolve;
     server lib-jobs-prod2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_libjobsprodcookie


### PR DESCRIPTION
The lib-jobs-prod1 VM was still bionic. This change updates it to jammy and puts them in production

Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
