### PR TITLE
adds checkmk to the roles in our standard EE

### DIFF
--- a/tower_ees/execution-environment.yml
+++ b/tower_ees/execution-environment.yml
@@ -51,6 +51,8 @@ dependencies:
         version: 1.0.6
       - name: paloaltonetworks.panos
         version: 2.19.1
+      - name: checkmk.general
+        version: 4.3.1
 
   # python packages, stuff you install with 'pip install'
   python:


### PR DESCRIPTION
Update to #4754.

Follows up on #4782.

We need to rebuild the standard Tower Execution Environment (EE) and include the checkmk.general collection in it. This PR adds the collection to the build instruction file for our standard EE. 