### PR TITLE
comments out annotations boxes, adds python interpreter for GCP bastion

### DIFF
--- a/inventory/all_projects/annotations
+++ b/inventory/all_projects/annotations
@@ -1,4 +1,4 @@
 [annotations_staging]
-annotations-staging1.princeton.edu
+# annotations-staging1.princeton.edu
 [annotations_production]
-annotations-prod1.princeton.edu
+# annotations-prod1.princeton.edu

--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -3,7 +3,7 @@ bastion-dev.pulcloud.io
 [bastion_production]
 bastion-prod.pulcloud.io
 [bastion_staging]
-bastion-staging.pulcloud.io
+bastion-staging.pulcloud.io ansible_python_interpreter=/usr/bin/python
 [dspace_dev]
 gcp_dataspace_dev1 ansible_host=10.0.20.4
 gcp_oar_dev1 ansible_host=10.0.20.3


### PR DESCRIPTION
Related to #4745.

The annotations VMs have been powered off but not fully decommissioned. However, they are causing failures in Ansible. This PR comments them out; when we decommission them, we can remove the entire file for the project, along with any references to the group.

This PR also adds a python interpreter definition for the GCP bastion. This should take care of this warning: `Platform openbsd on host bastion-staging.pulcloud.io is using the discovered Python interpreter at /usr/local/bin/python3.9, but future installation of another Python interpreter could change the meaning of that path.`