### PR TITLE
remove keys for Favour

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -13,7 +13,6 @@ deploy_user_github_keys:
   - https://github.com/cwulfman.keys
   - https://github.com/eliotjordan.keys
   - https://github.com/escowles.keys
-  - https://github.com/FavourNwogbo21.keys
   - https://github.com/hackartisan.keys
   - https://github.com/hectorcorrea.keys
   - https://github.com/ishasinha1.keys
@@ -83,7 +82,6 @@ library_github_keys:
   - https://github.com/cwulfman.keys
   - https://github.com/eliotjordan.keys
   - https://github.com/escowles.keys
-  - https://github.com/FavourNwogbo21.keys
   - https://github.com/hackartisan.keys
   - https://github.com/hectorcorrea.keys
   - https://github.com/ishasinha1.keys


### PR DESCRIPTION
Partial fix for #4787.

Removes SSH keys for Favour. We also need to:
- [x] remove her name from the DevOps groups.