### PR TITLE
[Pulfalight] Add the `mailers` queue to Sidekiq.

### DIFF
--- a/roles/sidekiq_worker/defaults/main.yml
+++ b/roles/sidekiq_worker/defaults/main.yml
@@ -4,6 +4,7 @@ running_on_server: false
 sidekiq_worker_threads: 5
 sidekiq_worker_queues:
   - high
+  - mailers
   - default
   - low
   - super_low


### PR DESCRIPTION
This fixes pulibrary/pulfalight#1398

I added it as a default since this is the default queue Rails uses to background mail and I never want this to happen again.