### PR TITLE
[bibdata] Ensure the condition only applies to one role

### DIFF
--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -14,8 +14,7 @@
   roles:
     - role: roles/bibdata
     - role: roles/bibdata_sqs_poller
-    - role: roles/sidekiq_worker
-      when: "'worker' in inventory_hostname"
+    - { role: roles/sidekiq_worker, when: "'worker' in inventory_hostname" }
     - role: 'hr_share'
     - role: roles/datadog
       when: runtime_env | default('staging') == "production"


### PR DESCRIPTION
When working on something else, we found that, while the Passenger role was running on all machines, the *handler* to restart nginx was only running on the worker machines, because of the conditional `when: "'worker' in inventory_hostname"`. 

By wrapping the line in brackets, it ensures that the conditional is applied only to the sidekiq_worker role.