### PR TITLE
[friends] correct state in ansible.builtin.service call

### DIFF
--- a/roles/friends_of_pul/handlers/main.yml
+++ b/roles/friends_of_pul/handlers/main.yml
@@ -3,4 +3,4 @@
 - name: restart idmapd
   ansible.builtin.service:
     name: idmapd
-    state: restart
+    state: restarted


### PR DESCRIPTION
The documentation says we should use restarted, rather than restart, as the state: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_module.html#parameter-state

This caused an intermittent failure in the friends_of_pul playbook (it only failed in cases where the handler was notified by a change made in the id_mapping lineinfile).