### PR TITLE
Decommission DLS Bionic VMs

### DIFF
--- a/inventory/all_projects/dpul
+++ b/inventory/all_projects/dpul
@@ -1,8 +1,6 @@
 [dpul_production]
-# jammy boxes
 dpul-prod1.princeton.edu
 dpul-prod2.princeton.edu
 [dpul_staging]
-# jammy boxes
 dpul-staging3.princeton.edu
 dpul-staging4.princeton.edu

--- a/inventory/all_projects/figgy
+++ b/inventory/all_projects/figgy
@@ -1,18 +1,8 @@
 [figgy_staging]
-# figgy-web-staging-1.princeton.edu # new jammy box; not served
-# figgy-staging2.princeton.edu
-# new/added jammy VMs
 figgy-web-staging1.princeton.edu
 figgy-web-staging2.princeton.edu
 # no worker VMs in staging
 [figgy_production_workers]
-# lib-proc6.princeton.edu
-# lib-proc7.princeton.edu
-# lib-proc8.princeton.edu
-# lib-proc9.princeton.edu
-# lib-proc10.princeton.edu
-# lib-proc11.princeton.edu
-# jammy VMs
 figgy-worker-prod1.princeton.edu
 figgy-worker-prod2.princeton.edu
 figgy-worker-prod3.princeton.edu
@@ -20,11 +10,6 @@ figgy-worker-prod4.princeton.edu
 figgy-worker-prod5.princeton.edu
 figgy-worker-prod6.princeton.edu
 [figgy_production_webservers]
-# figgy1.princeton.edu
-# figgy-web-prod-2.princeton.edu
-# figgy3.princeton.edu
-# figgy-web-prod-4.princeton.edu
-# jammy VMs
 figgy-web-prod1.princeton.edu
 figgy-web-prod2.princeton.edu
 figgy-web-prod3.princeton.edu
@@ -33,22 +18,12 @@ figgy-web-prod4.princeton.edu
 figgy_production_workers
 figgy_production_webservers
 [figgy_production_group_a]
-# figgy1.princeton.edu
-# figgy-web-prod-2.princeton.edu
-# lib-proc6.princeton.edu
-# lib-proc7.princeton.edu
-# lib-proc8.princeton.edu
 figgy-web-prod1.princeton.edu
 figgy-web-prod2.princeton.edu
 figgy-worker-prod1.princeton.edu
 figgy-worker-prod2.princeton.edu
 figgy-worker-prod3.princeton.edu
 [figgy_production_group_b]
-# figgy3.princeton.edu
-# figgy-web-prod-4.princeton.edu
-# lib-proc9.princeton.edu
-# lib-proc10.princeton.edu
-# lib-proc11.princeton.edu
 figgy-web-prod3.princeton.edu
 figgy-web-prod4.princeton.edu
 figgy-worker-prod4.princeton.edu

--- a/inventory/all_projects/lae
+++ b/inventory/all_projects/lae
@@ -1,7 +1,5 @@
 [lae_production]
-# jammy boxes
 lae-prod1.princeton.edu
 lae-prod2.princeton.edu
 [lae_staging]
-# jammy box
 lae-staging2.princeton.edu

--- a/inventory/all_projects/pulmap
+++ b/inventory/all_projects/pulmap
@@ -1,8 +1,5 @@
 [pulmap_production]
-# jammy boxes
 maps-prod1.princeton.edu
 maps-prod2.princeton.edu
-
 [pulmap_staging]
-# jammy box
 maps-staging2.princeton.edu


### PR DESCRIPTION
Closes #4750.

This PR tidies our inventory. It also reflects a lot of work in our VM environment and on our firewall.

We have deleted all DLS VMs running Bionic Beaver, as well as all related firewall rules and objects. Note that OIT will repurpose these IPs, so we may need to update our known_hosts files.

Here's the list of deleted VMs:

- Dpul1 - 128.112.203.160/32
- Dpul2 - 128.112.203.158/32
- dpul-staging1 - 128.112.202.27/32
- dpul-staging2 - - 128.112.204.67/32
- Figgy1 128.112.201.194/32
- Figgy2 128.112.203.9/32
- Figgy3 128.112.200.144/32
- Figgy-Staging1 128.112.202.216/32
- Figgy-Staging2 128.112.200.42/32
- Figgy-Web-Prod-2 (with a DASH!) 128.112.204.63/32
- Figgy-Web-Prod-4 (with a DASH!) 128.112.204.62/32
- lae1 - 128.112.202.137/32
- lael2 - 128.112.203.148/32
- lae-staging1 - 128.112.202.251/32
- lib-proc6 - unsure of the IP
- lib-proc7 128.112.203.118
- lib-proc8 128.112.200.196
- lib-proc9 128.112.203.79
- lib-proc10 128.112.202.197
- lib-proc11 128.112.202.219
-  * note that the new figgy processor boxes are called `figgy-worker-prod[1-6]`
- Maps1 - 128.112.202.127/32
- Maps2 - 128.112.202.218/32
- Maps-staging1 - 128.112.202.220
