### PR TITLE
remove mailcatcher version from PAS group vars

### DIFF
--- a/group_vars/pas/staging.yml
+++ b/group_vars/pas/staging.yml
@@ -30,4 +30,3 @@ install_ruby_from_source: true
 install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.1.0/gems/mailcatcher-0.8.2/bin/mailcatcher"


### PR DESCRIPTION
Mailcatcher runs fine without a version. If we upgrade the gem without re-running the whole role, the mailcatcher service fails when we've specified a version.

There is a role default that sets the mailcatcher location to `/usr/local/bin/mailcatcher`, which works just fine. So, don't specify anything in group vars.