### PR TITLE
updates zookeeper inventory, round 1

### DIFF
--- a/inventory/all_projects/zookeeper
+++ b/inventory/all_projects/zookeeper
@@ -6,9 +6,11 @@ lib-zk4.princeton.edu
 lib-zk5.princeton.edu
 lib-zk6.princeton.edu
 [zookeeper_staging]
+# Solr 9 - serve lib-solr-staging1/2/3
 lib-zk-staging4.princeton.edu
 lib-zk-staging5.princeton.edu
 lib-zk-staging6.princeton.edu
+# Solr 8 - serve lib-solr-staging4d/5d/6d
 lib-zk-staging1d.princeton.edu
 lib-zk-staging2d.princeton.edu
 lib-zk-staging3d.princeton.edu

--- a/inventory/all_projects/zookeeper
+++ b/inventory/all_projects/zookeeper
@@ -6,9 +6,9 @@ lib-zk4.princeton.edu
 lib-zk5.princeton.edu
 lib-zk6.princeton.edu
 [zookeeper_staging]
-lib-zk-staging4.princeton.edu
-lib-zk-staging5.princeton.edu
-lib-zk-staging6.princeton.edu
+lib-zk-staging1d.princeton.edu
+lib-zk-staging2d.princeton.edu
+lib-zk-staging3d.princeton.edu
 [zookeepersolr9_production]
 lib-zk4.princeton.edu
 lib-zk5.princeton.edu

--- a/inventory/all_projects/zookeeper
+++ b/inventory/all_projects/zookeeper
@@ -1,5 +1,5 @@
 [zookeeper_production]
-lib-zk1.princeton.edu # needs keys added (acozine keys not present)
+lib-zk1.princeton.edu
 lib-zk2.princeton.edu
 lib-zk3.princeton.edu
 lib-zk4.princeton.edu

--- a/inventory/all_projects/zookeeper
+++ b/inventory/all_projects/zookeeper
@@ -6,6 +6,9 @@ lib-zk4.princeton.edu
 lib-zk5.princeton.edu
 lib-zk6.princeton.edu
 [zookeeper_staging]
+lib-zk-staging4.princeton.edu
+lib-zk-staging5.princeton.edu
+lib-zk-staging6.princeton.edu
 lib-zk-staging1d.princeton.edu
 lib-zk-staging2d.princeton.edu
 lib-zk-staging3d.princeton.edu


### PR DESCRIPTION
I think the zookeeper inventory hasn't kept pace with the Solr cloud changes.

When we [updated the Solr8 cloud](https://github.com/pulibrary/princeton_ansible/pull/4587/files#diff-a27de0ecaa34c807588fafc5c43509e72fb3261580dbcaba32f1633da341b07c), we changed the staging solr config to look at new zookeeper boxes, but we didn't update the zookeeper inventory.

This might need more cleanup. I cannot SSH to some of the zookeeper prod boxes in the inventory - we may have obsolete boxes listed there too.