### PR TITLE
[bibdata] Run sidekiq role first so that handlers are notified last without conditional

### DIFF
--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -12,9 +12,9 @@
     - ../group_vars/bibdata/vault.yml
     - ../group_vars/bibdata/{{ runtime_env | default('staging') }}.yml
   roles:
+    - { role: roles/sidekiq_worker, when: "'worker' in inventory_hostname" }
     - role: roles/bibdata
     - role: roles/bibdata_sqs_poller
-    - { role: roles/sidekiq_worker, when: "'worker' in inventory_hostname" }
     - role: 'hr_share'
     - role: roles/datadog
       when: runtime_env | default('staging') == "production"

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -33,7 +33,7 @@
     src: nginx.conf.j2
     dest: /etc/nginx/nginx.conf
     mode: 0644
-  notify: restart nginx
+  notify: 'passenger : restart nginx'
 
 - name: Phusion | Insert/Update passenger-config reopen nginx rotate line
   ansible.builtin.blockinfile:


### PR DESCRIPTION
When the Sidekiq role (which depends on the Passenger role downstream), which is limited to worker boxes, is run *after* the bibdata role (which depends on the Passenger role downstream), when it notifies the "restart nginx" handler, it notifies it with the limit to worker boxes last, and applies that limit. If we put the Sidekiq role first, and the bibdata role second, the last notification to the handler is made without the limit, meaning nginx is restarted on the web boxes.

- Use role name in handler, to ensure it does not use handler from another role.

Closes #4824