### PR TITLE
[catalog] Lower the rate limit

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -9,7 +9,7 @@ map $limit $external_traffic {
 }
 
 # zone: 10mb can hold 160K IP addresses in memory
-limit_req_zone $external_traffic zone=catalog-prod-ratelimit:10m rate=10r/s;
+limit_req_zone $external_traffic zone=catalog-prod-ratelimit:10m rate=1r/s;
 
 upstream catalog-prod {
     zone catalog-prod 64k;

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -9,7 +9,7 @@ map $limit $external_traffic {
 }
  
 # zone: 10mb can hold 160K IP addresses in memory
-limit_req_zone $external_traffic zone=catalog-staging-ratelimit:10m rate=10r/s;
+limit_req_zone $external_traffic zone=catalog-staging-ratelimit:10m rate=1r/s;
 
 upstream catalog-staging {
     zone catalog-staging 64k;


### PR DESCRIPTION
This PR persists a change that we made live in the nginx configs yesterday, amidst this [DDOS event](https://docs.google.com/document/d/1YhY2JOVoiAF5vTrDoofQZ5HAlYe8sH8Fuzh4vX_Nykw/edit).

This rate limit is still more generous than what we encourage in our robots.txt.  The burst of 80 should still allow human users to use the site (including all js, css, image files) without interruption.