### PR TITLE
[bibdata] Move dependencies into playbook to reduce repetition

### DIFF
--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -1,4 +1,6 @@
 ---
+central_redis_host: "lib-redis-staging1.princeton.edu"
+central_redis_db: "6"
 nfs_server: "128.112.203.82"
 postgres_host: "lib-postgres-staging1.princeton.edu"
 postgres_version: 15
@@ -19,6 +21,7 @@ rails_app_dependencies:
   - pkg-config
   - libtool
   - autoconf
+  - redis-tools
 rails_app_env: "production"
 rails_app_vars:
   - name: ALMA_REGION
@@ -110,9 +113,9 @@ rails_app_vars:
   - name: SQS_QUEUE_URL
     value: "{{ vault_staging_sqs_queue_url }}"
   - name: BIBDATA_REDIS_URL
-    value: 'bibdata-alma-worker-staging2.princeton.edu'
+    value: "{{ central_redis_host }}"
   - name: BIBDATA_REDIS_DB
-    value: '6'
+    value: "{{ central_redis_db }}"
   - name: FIGGY_ARK_CACHE_PATH
     value: '/data/bibdata_files/figgy_ark_cache'
   - name: BUNDLE_GEMS__CONTRIBSYS__COM

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -12,12 +12,31 @@
     - ../group_vars/bibdata/vault.yml
     - ../group_vars/bibdata/{{ runtime_env | default('staging') }}.yml
   roles:
+    # re-add when removed from: ruby_s, deploy_user, rails_app, and samba
+    # - role: common
     - role: deploy_user
-    - { role: roles/sidekiq_worker, when: "'worker' in inventory_hostname" }
-    - role: roles/bibdata
-    - role: roles/bibdata_sqs_poller
-    - role: 'hr_share'
-    - role: roles/datadog
+    - role: redis
+    # re-add when removed from passenger
+    # - role: ruby_s
+    # re-add when removed from rails_app
+    # - role: bind9
+    # re-add when removed from rails_app
+    # - role: passenger
+    # re-add when removed from rails_app
+    # - role: postgresql
+    # re-add when removed from rails_app
+    # - role: nodejs
+    # Must be before the rails_app & passenger roles so that nginx restarts on all boxes
+    - role: sidekiq_worker
+      when: "'worker' in inventory_hostname"
+    - role: rails_app
+    - role: timezone
+    - role: bibdata
+    - role: bibdata_sqs_poller
+    # re-add when removed from hr_share
+    # - role: samba
+    - role: hr_share
+    - role: datadog
       when: runtime_env | default('staging') == "production"
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -12,28 +12,31 @@
     - ../group_vars/bibdata/vault.yml
     - ../group_vars/bibdata/{{ runtime_env | default('staging') }}.yml
   roles:
-    # re-add when removed from: ruby_s, deploy_user, rails_app, and samba
+    # re-add common when removed from: ruby_s, deploy_user, rails_app, and samba
     # - role: common
     - role: deploy_user
+    # remove redis role if / when all bibdata machines use central redis
     - role: redis
-    # re-add when removed from passenger
+    # re-add ruby_s when removed from passenger
     # - role: ruby_s
-    # re-add when removed from rails_app
+    # re-add bind9 when removed from rails_app
     # - role: bind9
-    # re-add when removed from rails_app
+    # re-add passenger when removed from rails_app
+    # can be run on only web machines
     # - role: passenger
-    # re-add when removed from rails_app
+    # re-add postgresql when removed from rails_app
     # - role: postgresql
-    # re-add when removed from rails_app
+    # re-add nodejs when removed from rails_app
+    # can be run on only web machines
     # - role: nodejs
-    # Must be before the rails_app & passenger roles so that nginx restarts on all boxes
+    # sidekiq_worker role must be before the rails_app & passenger roles so that nginx restarts on all boxes
     - role: sidekiq_worker
       when: "'worker' in inventory_hostname"
     - role: rails_app
     - role: timezone
     - role: bibdata
     - role: bibdata_sqs_poller
-    # re-add when removed from hr_share
+    # re-add samba when removed from hr_share
     # - role: samba
     - role: hr_share
     - role: datadog

--- a/roles/bibdata/meta/main.yml
+++ b/roles/bibdata/meta/main.yml
@@ -14,11 +14,4 @@ galaxy_info:
       versions:
         - bionic
 
-dependencies:
-  - role: 'redis'
-  - role: 'ruby_s'
-  - role: 'deploy_user'
-  - role: 'nodejs'
-  - role: 'rails_app'
-  - role: 'timezone'
-  - role: 'samba'
+dependencies: []

--- a/roles/bibdata/molecule/default/converge.yml
+++ b/roles/bibdata/molecule/default/converge.yml
@@ -13,10 +13,30 @@
         update_cache: true
         cache_valid_time: 600
   roles:
-    # Will need to re-add common when we move it out of deploy_user
+    # re-add when removed from: ruby_s, deploy_user, rails_app, and samba
     # - role: common
     - role: deploy_user
     - role: redis
+    # re-add when removed from passenger
+    # - role: ruby_s
+    # re-add when removed from rails_app
+    # - role: bind9
+    # re-add when removed from rails_app
+    # - role: passenger
+    # re-add when removed from rails_app
+    # - role: postgresql
+    # re-add when removed from rails_app
+    # - role: nodejs
+    # Must be before the rails_app & passenger roles so that nginx restarts on all boxes
+    - role: sidekiq_worker
+      when: "'worker' in inventory_hostname"
+    - role: rails_app
+    - role: timezone
+    - role: bibdata
+    - role: bibdata_sqs_poller
+    # re-add when removed from hr_share
+    # - role: samba
+    - role: hr_share
   tasks:
     - name: "Include bibdata"
       include_role:

--- a/roles/bibdata/molecule/default/converge.yml
+++ b/roles/bibdata/molecule/default/converge.yml
@@ -12,6 +12,11 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    # Will need to re-add common when we move it out of deploy_user
+    # - role: common
+    - role: deploy_user
+    - role: redis
   tasks:
     - name: "Include bibdata"
       include_role:

--- a/roles/bibdata_sqs_poller/meta/main.yml
+++ b/roles/bibdata_sqs_poller/meta/main.yml
@@ -5,12 +5,11 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: '2.9'
 
   platforms:
     - name: Ubuntu
       versions:
         - bionic
 
-dependencies:
-  - role: 'deploy_user'
+dependencies: []

--- a/roles/bibdata_sqs_poller/molecule/default/converge.yml
+++ b/roles/bibdata_sqs_poller/molecule/default/converge.yml
@@ -9,6 +9,10 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    # Will need to re-add common when we move it out of deploy_user
+    # - role: common
+    - role: deploy_user
   tasks:
     - name: "Include bibdata_sqs_poller"
       ansible.builtin.include_role:


### PR DESCRIPTION
- Move role dependencies for testing to converge.yml
- List all roles that are actually needed, comment out roles that are currently duplicates

~As a nice side effect, test runs appear to be [much faster on average](https://github.com/pulibrary/princeton_ansible/actions/workflows/molecule_tests.yml?query=branch%3Abibdata_move_roles_to_playbook+is%3Asuccess)~

To verify, switch to fresh staging VMs, run the playbook, deploy bibdata to the fresh staging VMs, and trigger an incremental update on the Alma sandbox.

Performed the above on April 9-10. 2024, and successfully built the boxes and ran jobs on Sidekiq. 