### PR TITLE
[bibdata] Fix unintended consequences of conditional on sidekiq_worker role

### DIFF
--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -12,6 +12,7 @@
     - ../group_vars/bibdata/vault.yml
     - ../group_vars/bibdata/{{ runtime_env | default('staging') }}.yml
   roles:
+    - role: deploy_user
     - { role: roles/sidekiq_worker, when: "'worker' in inventory_hostname" }
     - role: roles/bibdata
     - role: roles/bibdata_sqs_poller


### PR DESCRIPTION
- When the deploy_user role starts as limited to worker boxes, the "build authorized keys file" task fails