### PR TITLE
Add fail2ban and enable ufw on load balancers

### DIFF
--- a/roles/nginxplus/README.md
+++ b/roles/nginxplus/README.md
@@ -5,6 +5,22 @@ nginxplus
 
 **Note** We copied [https://github.com/nginxinc/ansible-role-nginx](https://github.com/nginxinc/ansible-role-nginx), then removed things we don't use to simplify it. All credit goes to NGINX for writing the upstream role. 
 
+fail2ban
+========
+
+Nobody in the VPN gets blocked, thanks to our nginx
+load balancer rate-limit configuration.
+
+* To see which IPs are currently banned: `sudo ufw status`
+* To see which IPs are banned due to a certain fail2ban rule: `sudo fail2ban-client status nginx-limit-req`
+* To unban an IP: `sudo fail2ban-client unban [IP address]`, for example, if the IP address is 123.123.123.456, run `sudo fail2ban-client unban 123.123.123.456`.
+* To manually ban an IP permanently from all load-balanced resources: `sudo ufw deny from [IP address]` (this step would need to be repeated on both load balancers)
+
+Note that ufw needs to have at least one rule for the fail2ban
+integration to work.  We have a permanent REJECT rule for traffic
+from 192.0.2.0 (which is a reserved IP for special use that
+will never actually send us any traffic) for this reason, do not delete this rule please.
+
 Using this role
 ===============
 

--- a/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
@@ -1,0 +1,7 @@
+[Definition]
+
+badbots = 360Spider|claudebot
+
+failregex = (?i)<HOST> -.*"(GET|POST|HEAD).*HTTP.*(?:%(badbots)s).*"$
+
+ignoreregex =

--- a/roles/nginxplus/files/fail2ban/nginx-badbots-restriction.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-badbots-restriction.conf
@@ -1,0 +1,12 @@
+# If there are 10 requests in the last minute from a known bad bot, ban it for a
+# day. We might want to make this more strict.
+[nginx-badbots]
+
+enabled = true
+filter = nginx-badbots
+banaction = ufw
+banaction_allports = ufw
+logpath = /var/log/nginx/access.log
+findtime = 60
+bantime = 1d
+maxretry = 10

--- a/roles/nginxplus/files/fail2ban/nginx-limit-req.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-limit-req.conf
@@ -1,0 +1,16 @@
+# protection for the load balancer
+# this rule says:
+# if your IP is logged to error.log for rate limiting
+# ten times in any one-minute period
+# we ban your IP from any contact using ufw for an hour
+
+[nginx-limit-req]
+
+enabled = true
+filter = nginx-limit-req
+banaction = ufw
+banaction_allports = ufw
+logpath = /var/log/nginx/error.log
+findtime = 60
+bantime = 3600
+maxretry = 10

--- a/roles/nginxplus/handlers/main.yml
+++ b/roles/nginxplus/handlers/main.yml
@@ -1,18 +1,23 @@
 ---
 - name: Start NGINX
-  service:
+  ansible.builtin.service:
     name: nginx
     state: started
     enabled: true
 
 - name: Restart NGINX
-  service:
+  ansible.builtin.service:
     name: nginx
     state: restarted
     enabled: true
   when: running_on_server
 
 - name: Reload NGINX
-  service:
+  ansible.builtin.service:
     name: nginx
     state: reloaded
+
+- name: restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted

--- a/roles/nginxplus/molecule/default/converge.yml
+++ b/roles/nginxplus/molecule/default/converge.yml
@@ -5,10 +5,14 @@
     - running_on_server: false
   become: true
   pre_tasks:
-    - name: update cache
+    - name: update cache & install ufw
       apt:
+        name: '{{ item }}'
+        state: present
         update_cache: true
         cache_valid_time: 600
+      loop:
+        - ufw
   tasks:
     - name: "Include nginxplus"
       include_role:

--- a/roles/nginxplus/molecule/default/molecule.yml
+++ b/roles/nginxplus/molecule/default/molecule.yml
@@ -9,10 +9,11 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
+    image: "geerlingguy/docker-ubuntu2204-ansible"
     command: ""
+    cgroupns_mode: host
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
 provisioner:

--- a/roles/nginxplus/tasks/main.yml
+++ b/roles/nginxplus/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - import_tasks: prerequisites/install-prerequisites.yml
+  tags: fail2ban
 
 - import_tasks: adjust_ulimit.yml
   when: nginx_type == "plus"

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -4,3 +4,19 @@
     name:
       - apt-transport-https
       - dirmngr
+      - fail2ban
+
+- name: ensure ufw does not block anything
+  community.general.ufw:
+    state: enabled
+    policy: allow
+
+- name: make sure jail.d dir is empty (get rid of jail.d/defaults-debian.conf)
+
+- name: add fail2ban jail definition
+
+- name: restart and enable fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted
+    enabled: true

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -63,11 +63,4 @@
     name: fail2ban
     state: started
     enabled: true
-  register: fail2ban_status
-
-- name: restart fail2ban if necessary
-  ansible.builtin.service:
-    name: fail2ban
-    state: restarted
-    enabled: true
-  when: fail2ban_status.changed
+  notify: restart fail2ban

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -11,9 +11,35 @@
     state: enabled
     policy: allow
 
-- name: make sure jail.d dir is empty (get rid of jail.d/defaults-debian.conf)
+# Note: the following IP address is "reserved for special use",
+# we expect to never receive any traffic from it, so it is safe
+# to block indefinitely as an example
+- name: add an intial ufw rule that blocks a sample ip
+  community.general.ufw:
+    rule: reject
+    from_ip: "192.0.2.0"
 
-- name: add fail2ban jail definition
+- name: identify unwanted configuration files that we should delete
+  ansible.builtin.find:
+    paths: /etc/fail2ban/jail.d
+    file_type: file
+    excludes: 
+      - "nginx-limit-req.conf"
+  register: unwanted_fail2ban_files
+
+- name: Delete unwanted configuration files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ unwanted_fail2ban_files['files'] }}"
+
+- name: Add nginx-limit-req fail2ban configuration
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-limit-req.conf"
+    dest: "/etc/fail2ban/jail.d/nginx-limit-req.conf"
+    owner: root
+    group: root
+    mode: 0644
 
 - name: restart and enable fail2ban
   ansible.builtin.service:

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -57,9 +57,15 @@
     owner: root
     group: root
     mode: 0644
+- name: check if fail2ban is running
+  ansible.builtin.service:
+    name: fail2ban
+    state: started
+  register: fail2ban_status
 
 - name: restart and enable fail2ban
   ansible.builtin.service:
     name: fail2ban
     state: restarted
     enabled: true
+  when: fail2ban_status.changed

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -57,13 +57,15 @@
     owner: root
     group: root
     mode: 0644
-- name: check if fail2ban is running
+
+- name: start and enable fail2ban
   ansible.builtin.service:
     name: fail2ban
     state: started
+    enabled: true
   register: fail2ban_status
 
-- name: restart and enable fail2ban
+- name: restart fail2ban if necessary
   ansible.builtin.service:
     name: fail2ban
     state: restarted

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -25,6 +25,7 @@
     file_type: file
     excludes: 
       - "nginx-limit-req.conf"
+      - "nginx-badbots.conf"
   register: unwanted_fail2ban_files
 
 - name: Delete unwanted configuration files
@@ -32,6 +33,22 @@
     path: "{{ item.path }}"
     state: absent
   with_items: "{{ unwanted_fail2ban_files['files'] }}"
+
+- name: Add nginx-badbots filter
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-badbots-filter.conf"
+    dest: "/etc/fail2ban/filter.d/nginx-badbots.conf"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Add nginx-badbots restriction
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-badbots-restriction.conf"
+    dest: "/etc/fail2ban/jail.d/nginx-badbots.conf"
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Add nginx-limit-req fail2ban configuration
   ansible.builtin.copy:


### PR DESCRIPTION
Related to this [DDOS incident](https://docs.google.com/document/d/1YhY2JOVoiAF5vTrDoofQZ5HAlYe8sH8Fuzh4vX_Nykw/edit).

When an IP address repeatedly makes so many requests to a site that has rate limiting configured that nginx rate limits them several times, fail2ban and ufw will work together to reject all requests from that IP for an hour for all load-balanced resources.

We ran this on both load balancers today, 5 April 2024.