### PR TITLE
Inventory and OS-discovery improvements

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -47,6 +47,8 @@ sftp_production
 
 [gcp_production:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-prod.pulcloud.io"'
+# this var assumes that all GCP boxes run OpenBSD
+become_method: doas
 
 [gcp_staging:children]
 dspace_staging
@@ -55,3 +57,5 @@ obsd_httpd_staging
 
 [gcp_staging:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-staging.pulcloud.io"'
+# this var assumes that all GCP boxes run OpenBSD
+become_method: doas

--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -1,7 +1,9 @@
+# most GCP resources run openBSD, which has 'doas'
+# instead of 'sudo', so we set the become_method for those
 [bastion_dev]
-bastion-dev.pulcloud.io
+bastion-dev.pulcloud.io become_method: doas
 [bastion_production]
-bastion-prod.pulcloud.io
+bastion-prod.pulcloud.io become_method: doas
 [bastion_staging]
 bastion-staging.pulcloud.io ansible_python_interpreter=/usr/bin/python
 [dspace_dev]

--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -1,5 +1,5 @@
 # for openBSD, which has 'doas'instead of 'sudo'
-# set ansible_become_method
+# set ansible_become_method - see the 'obsd' group of groups
 
 [bastion_dev]
 bastion-dev.pulcloud.io
@@ -8,16 +8,7 @@ bastion-dev.pulcloud.io
 bastion-prod.pulcloud.io
 
 [bastion_staging]
-bastion-staging.pulcloud.io 
-
-[bastions: children]
-bastion_dev
-bastion_production
-bastion_staging
-
-[bastions: vars]
-ansible_python_interpreter=/usr/bin/python
-ansible_become_method: doas
+bastion-staging.pulcloud.io ansible_python_interpreter=/usr/bin/python
 
 [dspace_dev]
 gcp_dataspace_dev1 ansible_host=10.0.20.4
@@ -79,3 +70,16 @@ obsd_httpd_staging
 
 [gcp_staging:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-staging.pulcloud.io"'
+
+[obsd:children]
+bastion_dev
+bastion_production
+bastion_staging
+obsd_httpd_dev
+obsd_httpd_production
+obsd_httpd_staging
+pulmirror_production
+sftp_production
+
+[obsd:vars]
+ansible_become_method=doas

--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -1,35 +1,57 @@
-# most GCP resources run openBSD, which has 'doas'
-# instead of 'sudo', so we set the become_method for those
+# for openBSD, which has 'doas'instead of 'sudo'
+# set ansible_become_method
+
 [bastion_dev]
-bastion-dev.pulcloud.io become_method: doas
+bastion-dev.pulcloud.io
+
 [bastion_production]
-bastion-prod.pulcloud.io become_method: doas
+bastion-prod.pulcloud.io
+
 [bastion_staging]
-bastion-staging.pulcloud.io ansible_python_interpreter=/usr/bin/python
+bastion-staging.pulcloud.io 
+
+[bastions: children]
+bastion_dev
+bastion_production
+bastion_staging
+
+[bastions: vars]
+ansible_python_interpreter=/usr/bin/python
+ansible_become_method: doas
+
 [dspace_dev]
 gcp_dataspace_dev1 ansible_host=10.0.20.4
 gcp_oar_dev1 ansible_host=10.0.20.3
 gcp_oar_beta1 ansible_host=10.0.10.12
+
 [dspace_production]
 gcp-dataspace-prod1 ansible_host=10.244.0.2
 gcp-oar-prod1 ansible_host=10.244.0.3
 gcp-postgres-prod1 ansible_host=10.240.0.2
+
 [dspace_staging]
 gcp_dataspace_staging1 ansible_host=10.132.0.5
 gcp_oar_staging1 ansible_host=10.132.0.4
+
 [docnow_production]
 community.docnow.io ansible_host=10.140.0.4
+
 [docnow_staging]
 smoketest.docnow.io ansible_host=10.244.0.5
+
 [obsd_httpd_dev]
 dev.pulcloud.io
+
 [obsd_httpd_production]
 #inventory name is prod.pucloud.io but the VM name in google cloud is pul-gcdc-prod-adc
 prod.pulcloud.io ansible_host=10.246.0.2
+
 [obsd_httpd_staging]
 staging.pulcloud.io ansible_host=10.140.0.3
+
 [pulmirror_production]
 pulmirror.princeton.edu ansible_host=10.132.0.20
+
 [sftp_production]
 proquestdrop.pulcloud.io ansible_host=10.140.0.15
 
@@ -49,8 +71,6 @@ sftp_production
 
 [gcp_production:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-prod.pulcloud.io"'
-# this var assumes that all GCP boxes run OpenBSD
-become_method: doas
 
 [gcp_staging:children]
 dspace_staging
@@ -59,5 +79,3 @@ obsd_httpd_staging
 
 [gcp_staging:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-staging.pulcloud.io"'
-# this var assumes that all GCP boxes run OpenBSD
-become_method: doas

--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -2,7 +2,6 @@
 abid_production
 allsearch_api_production
 allsearch_frontend_production
-annotations_production
 ansible_tower
 approvals_production
 bastion_production

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -2,7 +2,6 @@
 abid_staging
 allsearch_api_staging
 allsearch_frontend_staging
-annotations_staging
 approvals_staging
 bastion_staging
 bibdata_staging

--- a/playbooks/utils/check_os_versions.yml
+++ b/playbooks/utils/check_os_versions.yml
@@ -5,6 +5,6 @@
   become: true
 
   tasks:
-    - name: report operating system version
+    - name: report operating system & version
       ansible.builtin.debug:
-        var: "{{ ansible_distribution_version}}"
+        msg: "Distro: {{ ansible_distribution }}, Version: {{ ansible_distribution_version}}"

--- a/playbooks/utils/check_os_versions.yml
+++ b/playbooks/utils/check_os_versions.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check operating system versions for all managed inventory
-  hosts: staging:qa:production
+  hosts: all
+  # hosts: staging:qa:production
   remote_user: pulsys
   become: true
 


### PR DESCRIPTION
Partial fix for #3897.

Adds an `obsd` group that sets `doas` for the privilege escalation method for all GCP OpenBSD boxes.
Removes the `annotations` groups from the `staging` and `production` supergroups.
Sets `hosts: all` for the Check OS playbook, so we don't miss strays (not all boxes are included in the three `env` groups - `staging` and `qa` and `production`).
Shows the distro as well as the version in the playbook output.