### PR TITLE
[rapid7] correct the group attribute

### DIFF
--- a/playbooks/utils/security_theater.yml
+++ b/playbooks/utils/security_theater.yml
@@ -88,7 +88,7 @@
     when: "ansible_facts.services['ir_agent.service'] is not defined"
 
   - name: Execute Rapid7 install script
-    ansible.builtin.shell: sudo /opt/rapid7/Rapid7_agent_installer.sh install_start --token {{ vault_Rapid7_token }} --attributes="library"
+    ansible.builtin.shell: sudo /opt/rapid7/Rapid7_agent_installer.sh install_start --token {{ vault_Rapid7_token }} --attributes="Library Systems"
     when: "ansible_facts.services['ir_agent.service'] is not defined"
 
   - name: Restart or start rapid7


### PR DESCRIPTION
we have been using the "library" as an attribute and it needs "Library
Systems" this fixes rapid7s implementation.

closes #4820
