### PR TITLE
[bibdata] Only run the poller daemon on one server per environment

### DIFF
--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -32,6 +32,10 @@
     # sidekiq_worker role must be before the rails_app & passenger roles so that nginx restarts on all boxes
     - role: sidekiq_worker
       when: "'worker' in inventory_hostname"
+    - role: bibdata_sqs_poller
+      when: 
+        - "'worker' in inventory_hostname"
+        - "'1' in inventory_hostname"
     - role: rails_app
     - role: timezone
     - role: bibdata


### PR DESCRIPTION
I believe running the poller daemon on multiple servers per environment is causing Postgres database locks, because four servers are trying to create the same exact object at the same time.

This PR limits installing the daemon on one machine, but it does not remove it from machines where it is already installed.

See also https://github.com/pulibrary/bibdata/pull/2362