### PR TITLE
[bibdata] Cludge to create consistent working systems with consistent rubygems and bundler

### DIFF
--- a/roles/bibdata/tasks/main.yml
+++ b/roles/bibdata/tasks/main.yml
@@ -8,17 +8,21 @@
   ansible.builtin.include_tasks: mounts.yml
 
 - name: bibdata | update rubygems
-  ansible.builtin.command: sudo gem update --system 3.5.7
-  changed_when: false
+  ansible.builtin.command: gem update --system 3.5.7
+  become: true
+  register: update_rubygems
+  changed_when: '"Latest version already installed. Done." not in update_rubygems.stdout'
   tags: rubygems
 
 - name: bibdata | install default bundler
-  ansible.builtin.command: sudo gem install --default bundler:2.5.7
-  changed_when: false
+  ansible.builtin.command: gem install --default bundler:2.5.7
+  become: true
+  register: install_default_bundler
+  changed_when: '"Fetching bundler-2.5.7.gem" in install_default_bundler.stdout'
   tags: rubygems
 
 - name: bibdata | remove old default bundler
-  ansible.builtin.command: sudo rm -rf /usr/local/lib/ruby/gems/3.1.0/specifications/default/bundler-2.5.9.gemspec
-  changed_when: false
+  ansible.builtin.file:
+    path: /usr/local/lib/ruby/gems/3.1.0/specifications/default/bundler-2.5.9.gemspec
+    state: absent
   tags: rubygems
-  notify: restart nginx

--- a/roles/bibdata/tasks/main.yml
+++ b/roles/bibdata/tasks/main.yml
@@ -6,3 +6,19 @@
 
 - name: bibdata | include tasks to mount disks
   ansible.builtin.include_tasks: mounts.yml
+
+- name: bibdata | update rubygems
+  ansible.builtin.command: sudo gem update --system 3.5.7
+  changed_when: false
+  tags: rubygems
+
+- name: bibdata | install default bundler
+  ansible.builtin.command: sudo gem install --default bundler:2.5.7
+  changed_when: false
+  tags: rubygems
+
+- name: bibdata | remove old default bundler
+  ansible.builtin.command: sudo rm -rf /usr/local/lib/ruby/gems/3.1.0/specifications/default/bundler-2.5.9.gemspec
+  changed_when: false
+  tags: rubygems
+  notify: restart nginx


### PR DESCRIPTION
We've had continuing difficulties with getting Passenger, Rubygems, Ruby, and Bundler to play nicely with each other.

This is what worked to get the new bibdata boxes into a state where you can just deploy to them and they work, without having to run anything on the command line.

It is not pretty. But it works. For now.