### PR TITLE
[prancible] move Deny001-Deny005 from panOS to AWS denylist

### DIFF
--- a/roles/denyhost/vars/main.yml
+++ b/roles/denyhost/vars/main.yml
@@ -118,6 +118,22 @@ banned_ranges:
   - name: whisperisp
     ip_range:
       - 45.40.0.0/20
+  - name: University of Massachusettes
+    ip_range: 
+      - 69.16.0.0/16
+  - name: Croatian Academic and Research Network
+    ip_range: 
+      - 161.53.0.0/16
+  - name: TPG Telecom Limited
+    ip_range: 
+     - 203.87.0.0/16
+  - name: TulsaConnect
+    ip_range: 
+    - 65.38.0.0/16
+  - name: Proximus NV
+    ip_range: 
+    - 81.169.0.0/16
+
 # Below is an example of banning Francis
   # - name: Francis test
     # ip_range:


### PR DESCRIPTION
Affiliated ServiceNow ticket to remove rules from PanOS: TKT0419458