### PR TITLE
[nginxplus] Extend timeouts for Shakespeare and Co sites

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_prosody.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_prosody.conf
@@ -82,7 +82,7 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-#        # app_protect_enable on;
+        # app_protect_enable on;
         # app_protect_security_log_enable on;
         proxy_pass http://prosody;
         proxy_set_header Host $http_host;

--- a/roles/nginxplus/files/conf/http/cdh_prod_shakespeareandco.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_shakespeareandco.conf
@@ -65,6 +65,9 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache shxco_prodcache;
+        proxy_connect_timeout      2h;
+        proxy_send_timeout         2h;
+        proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
     }
     include /etc/nginx/conf.d/templates/prod-maintenance.conf;

--- a/roles/nginxplus/files/conf/http/cdh_test_shakespeareandco.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_shakespeareandco.conf
@@ -63,6 +63,9 @@ server {
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_cache test_shxcocache;
+       proxy_connect_timeout      2h;
+       proxy_send_timeout         2h;
+       proxy_read_timeout         2h;
        proxy_intercept_errors on;
        health_check interval=10 fails=3 passes=2;
        # allow princeton network


### PR DESCRIPTION
Closes #4913.

Add proxy timeouts to shxco site configs.

Also removes extra comment from prosody config.