### PR TITLE
[postfix] replacement ponyexpr

### DIFF
--- a/playbooks/postfix.yml
+++ b/playbooks/postfix.yml
@@ -1,6 +1,8 @@
 ---
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
+# most common use case is `ansible-playbook playbooks/postfix.yml -t update_config`
+# after adding the IP address of your vm in `vars/main.yml`
 - name: build mailrelay to proofpoint
   hosts: postfix_{{ runtime_env | default('staging') }}
   remote_user: pulsys

--- a/roles/postfix/README.md
+++ b/roles/postfix/README.md
@@ -7,14 +7,9 @@ Creates a relay to proofpoint and creates a relay for our applications
 Role Variables
 --------------
 
-Most use for this role will involve adding your IP address to the allow list with the following variable:
+Most use for this role will involve adding your IP address to the allow list of our relay. Edit the [vars/main.yml](vars/main.yml)
 
-```bash
-relay_add_host: 1.2.3.4
-relay_remove_host: 1.2.3.4
-postfix_host: "<hostname of pony express>"
-```
-
+Add the IP address of your VM under `postfix_relay_hosts_addresses:`
 
 Example Playbook
 ----------------

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -56,3 +56,6 @@
   when: running_on_server
   notify: restart postfix
 
+- name: Postfix | Add relay host
+  ansible.builtin.include_tasks: update_config.yml
+  tags: update_config

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Postfix | create networks file
   ansible.builtin.template:
-    src: "mynetworks.cf"
+    src: "mynetworks.j2"
     dest: "{{ postfix_allowed_relay_hosts }}"
     owner: root
     group: root

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -17,8 +17,8 @@
     update_cache: true
 
 - name: Postfix | create networks file
-  ansible.builtin.copy:
-    src: "mynetworks"
+  ansible.builtin.template:
+    src: "mynetworks.cf"
     dest: "{{ postfix_allowed_relay_hosts }}"
     owner: root
     group: root
@@ -56,29 +56,3 @@
   when: running_on_server
   notify: restart postfix
 
-- name: Postfix | Add Postfix hosts
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_allowed_relay_hosts }}"
-    line: "{{ relay_add_host }}"
-    state: present
-    mode: '0644'
-    insertafter: EOF
-  delegate_to: "{{ postfix_host }}"
-  when:
-    - running_on_server
-    - not relay_host
-  tags: relay_add
-  notify: restart postfix
-
-- name: Postfix | Remove Postfix hosts
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_allowed_relay_hosts }}"
-    line: "{{ relay_remove_host }}"
-    state: absent
-    mode: '0644'
-  delegate_to: "{{ postfix_host }}"
-  when:
-    - running_on_server
-    - not relay_host
-  tags: relay_remove
-  notify: restart postfix

--- a/roles/postfix/tasks/update_config.yml
+++ b/roles/postfix/tasks/update_config.yml
@@ -6,22 +6,7 @@
     owner: root
     group: root
     mode: '0644'
-  delegate_to: "{{ postfix_host }}"
   when:
     - running_on_server
-    - not relay_host
   tags: update_config
-  notify: restart postfix
-
-- name: Postfix | Remove Postfix hosts
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_allowed_relay_hosts }}"
-    line: "{{ relay_remove_host }}"
-    state: absent
-    mode: '0644'
-  delegate_to: "{{ postfix_host }}"
-  when:
-    - running_on_server
-    - not relay_host
-  tags: relay_remove update_config
   notify: restart postfix

--- a/roles/postfix/tasks/update_config.yml
+++ b/roles/postfix/tasks/update_config.yml
@@ -1,11 +1,11 @@
 ---
 - name: Postfix | Add Postfix hosts
-  ansible.builtin.lineinfile:
-    path: "{{ postfix_allowed_relay_hosts }}"
-    line: "{{ relay_add_host }}"
-    state: present
+  ansible.builtin.template:
+    dest: "{{ postfix_allowed_relay_hosts }}"
+    src: mynetworks.j2
+    owner: root
+    group: root
     mode: '0644'
-    insertafter: EOF
   delegate_to: "{{ postfix_host }}"
   when:
     - running_on_server

--- a/roles/postfix/tasks/update_config.yml
+++ b/roles/postfix/tasks/update_config.yml
@@ -1,0 +1,27 @@
+---
+- name: Postfix | Add Postfix hosts
+  ansible.builtin.lineinfile:
+    path: "{{ postfix_allowed_relay_hosts }}"
+    line: "{{ relay_add_host }}"
+    state: present
+    mode: '0644'
+    insertafter: EOF
+  delegate_to: "{{ postfix_host }}"
+  when:
+    - running_on_server
+    - not relay_host
+  tags: update_config
+  notify: restart postfix
+
+- name: Postfix | Remove Postfix hosts
+  ansible.builtin.lineinfile:
+    path: "{{ postfix_allowed_relay_hosts }}"
+    line: "{{ relay_remove_host }}"
+    state: absent
+    mode: '0644'
+  delegate_to: "{{ postfix_host }}"
+  when:
+    - running_on_server
+    - not relay_host
+  tags: relay_remove update_config
+  notify: restart postfix

--- a/roles/postfix/templates/mynetworks.j2
+++ b/roles/postfix/templates/mynetworks.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 127.0.0.0/8
 [::ffff:127.0.0.0]/104
 [::1]/128

--- a/roles/postfix/templates/mynetworks.j2
+++ b/roles/postfix/templates/mynetworks.j2
@@ -2,3 +2,6 @@
 127.0.0.0/8
 [::ffff:127.0.0.0]/104
 [::1]/128
+{% for ip in postfix_relay_hosts_addresses %}
+{{ ip }}
+{% endfor %}

--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -3,4 +3,4 @@
 postfix_main_cf: "/etc/postfix/main.cf"
 postfix_allowed_relay_hosts: "/etc/postfix/mynetworks"
 postfix_relay_hosts_addresses:
-  - []
+  - 172.20.80.12

--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -2,3 +2,5 @@
 # vars file for roles/postfix
 postfix_main_cf: "/etc/postfix/main.cf"
 postfix_allowed_relay_hosts: "/etc/postfix/mynetworks"
+postfix_relay_hosts_addresses:
+  - []


### PR DESCRIPTION
- **template a file instead of copy a file**
- **add empty relay host address**
- **use a template instead of lineinfile module**
- **add pointers on how to add a VM to the list of allowed relays**
closes #4891 
