### PR TITLE
Make use of yarn for pkg management optional

### DIFF
--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -10,3 +10,6 @@ nodejs__yarn_upstream_repository: 'deb https://dl.yarnpkg.com/debian/ stable mai
 # default node
 desired_nodejs_version: v18.18.2
 nodejs_release_url: "https://pulmirror.princeton.edu/mirror/node/dist/"
+
+# use yarn rather than npm as package manager
+use_yarn: true

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -4,13 +4,16 @@
     url: https://dl.yarnpkg.com/debian/pubkey.gpg
     state: present
   register: yarn_pkg_registered
+  when: "{{ use_yarn }}"
 
 - name: nodejs | get yarn keys from other sources
   ansible.builtin.apt_key:
     id: "{{ nodejs__yarn_upstream_key_id }}"
     keyserver: "{{ item }}"
     state: present
-  when: yarn_pkg_registered is failed
+  when: 
+    - yarn_pkg_registered is failed
+    - "{{ use_yarn }}"
   register: yarn_key_registered
   loop:
     - "hkp://pool.sks-keyservers.net"
@@ -23,6 +26,7 @@
   ansible.builtin.apt_repository:
     repo: "{{ nodejs__yarn_upstream_repository }}"
     state: present
+  when: "{{ use_yarn }}"
 
 - name: nodejs | uninstall any apt installed node
   ansible.builtin.apt:
@@ -53,3 +57,4 @@
   ansible.builtin.apt:
     name: ["yarn"]
     state: present
+  when: "{{ use_yarn }}"


### PR DESCRIPTION
We may sometimes want to use npm as our package manager (as for the new static_tables app), and we don't want to install yarn if we don't need it.