### PR TITLE
use local user instead of Active Directory user for aspace

### DIFF
--- a/roles/system_ldap/tasks/main.yml
+++ b/roles/system_ldap/tasks/main.yml
@@ -15,7 +15,7 @@
   loop:
     - "{{ sssd__unwanted_packages_list }}"
 
-- name: system_ldap | change hostname to match AD 
+- name: system_ldap | change hostname to match AD
   ansible.builtin.command: hostnamectl set-hostname {{ host_ad_name | default(omit)}}
   when:
     - running_on_server
@@ -24,15 +24,15 @@
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     state: present
-    regexp: '^PasswordAuthentication no'
-    line: 'PasswordAuthentication yes'
+    regexp: "^PasswordAuthentication no"
+    line: "PasswordAuthentication yes"
 
 - name: system_ldap | allow users authentication
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     state: present
-    regexp: '^AllowUsers pulsys'
-    line: '# AllowUsers pulsys'
+    regexp: "^AllowUsers pulsys"
+    line: "# AllowUsers pulsys"
   notify: restart sshd
 
 - name: system_ldap | configure pam to enable mkhomedir
@@ -63,20 +63,31 @@
     - "/alma/publishing"
     - "/alma/recap"
     - "/alma/scsb_renewals"
-    
+
 - name: system_ldap | grant {{ deploy_user }} access to alma directory
   ansible.builtin.user:
     name: "{{ deploy_user }}"
     group: "domain users@pu.win.princeton.edu"
     append: true
-    
+
+- name: system_ldap | create pul_g group for aspace
+  ansible.builtin.group:
+    name: "pul_g"
+    state: present
+
+- name: system_ldap | create aspace user
+  ansible.builtin.user:
+    name: "{{ aspaceftp_user }}"
+    shell: /usr/bin/bash
+    group: "pul_g"
+
 - name: system_ldap | create aspace directory drop
   ansible.builtin.file:
     path: /alma/aspace
     state: directory
     recurse: true
     owner: "{{ aspaceftp_user }}"
-    group: "domain users@pu.win.princeton.edu"
+    group: "pul_g"
     mode: 0775
 
 - name: system_ldap | create local group for alma

--- a/roles/system_ldap/vars/main.yml
+++ b/roles/system_ldap/vars/main.yml
@@ -2,7 +2,7 @@
 # vars file for system_ldap
 #
 almasftp_user: "almasftp@pu.win.princeton.edu"
-aspaceftp_user: "lib-aspacesftp@pu.win.princeton.edu"
+aspaceftp_user: "lib-aspacesftp"
 sssd_pkg_list:
   - adcli
   - libnss-sss


### PR DESCRIPTION
Closes #4879.

Changes on production were made manually and we don't have a record of which commands were run, so I'm not sure if this makes the correct changes or not. Here's what it looks like on production:

```
lib-sftp-prod1:~$ ls -la /alma/aspace/
total 928
drwxrwxr-x  2 lib-aspacesftp pul_g   4096 May 13 08:30 .
drwxrwxr-x 19 almasftp       pul_g 139264 May 10 14:32 ..
-rw-r--r--  1 lib-aspacesftp pul_g   2309 May 13 02:22 marcao_export.xml
-rw-r--r--  1 almasftp       pul_g 398071 May 13 07:17 sc_active_barcodes.csv
-rw-r--r--  1 almasftp       pul_g 398071 May 12 07:26 sc_active_barcodes_old.csv
lib-sftp-prod1:~$ groups lib-aspacesftp
lib-aspacesftp : pul_g
```
Sorry about the whitespace and quotation changes. My new editor is very eager to be "helpful".