### PR TITLE
add an easy-to-find message for nginx restarts

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -41,7 +41,7 @@
   roles:
     - role: ../roles/nginxplus
 
-- name: restart nginx with updated loadbalancer configuration
+- name: restart nginx, load new config
   hosts: nginxplus_production
   remote_user: pulsys
   strategy: linear
@@ -60,7 +60,7 @@
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
-        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
+        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}. Honeybadger may log connection errors around this time due to the nginx restart."
         channel: "{{ item }}"
       loop: "{{ slack_alerts_channel }}"
       tags: always


### PR DESCRIPTION
We've been seeing connection failures for both Solr and PostgreSQL, and we're trying to eliminate the ones that have known causes. One known cause is Patch [Mon/Tues]day. The other is load balancer restarts. 

This PR adds a special message for the nginx restart play, which would let us track that known cause more easily.
