### PR TITLE
Adding bash script for monitoring log rotate

### DIFF
--- a/group_vars/checkmk/local_check_templates/logrotatecheck.j2
+++ b/group_vars/checkmk/local_check_templates/logrotatecheck.j2
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This script check to see when the last time the logrotate status file was updated
+#   If it was updated today the status is ok
+#   If it was updated yesterday the status is warn
+#   Otherwise the status is critical
+#
+message=$(find /var/lib/logrotate/status -mtime 0)
+if [ "$message" = "/var/lib/logrotate/status" ]; then   
+   echo "0 \"Log Rotate\" - Logs were rotated today"; 
+else
+   yest_message=$(find /var/lib/logrotate/status -mtime 1)
+   if [ "$yest_message" = "/var/lib/logrotate/status" ]; then   
+      echo "1 \"Log Rotate\" - No logs were rotated today, but they were yesterday";
+   else 
+      echo "2 \"Log Rotate\" - No logs were rotated today or yesterday";
+   fi
+fi

--- a/group_vars/checkmk/rule_rails.yml
+++ b/group_vars/checkmk/rule_rails.yml
@@ -6,4 +6,7 @@ checkmk_rules:
     ruleset: "checkgroup_parameters:systemd_services_summary"
     folder: "/linux"
 checkmk_local_scripts:
-  - "examplelocalcheck.j2"
+  - template: "examplelocalcheck.j2"
+    dest: "examplelocalcheck.sh"
+  - template: "logrotatecheck.j2"
+    dest: "logrotatecheck.sh"

--- a/playbooks/utils/checkmk_add_local_checks.yml
+++ b/playbooks/utils/checkmk_add_local_checks.yml
@@ -29,8 +29,8 @@
   tasks:
     - name: write hostname using jinja2
       ansible.builtin.template:
-        src: "../../group_vars/checkmk/local_check_templates/{{ item }}"
-        dest: /usr/lib/check_mk_agent/local
+        src: "../../group_vars/checkmk/local_check_templates/{{ item.template }}"
+        dest: "/usr/lib/check_mk_agent/local/{{ item.dest }}"
         mode: "+x"
       with_items: "{{ checkmk_local_scripts }}"
 


### PR DESCRIPTION
also changed the file name on the server to .sh instead of .j2

fixes #4871
![Screenshot 2024-05-14 at 2 19 42 PM](https://github.com/pulibrary/princeton_ansible/assets/1599081/c3e73cb2-fbc2-4c42-914a-077245f15818)

