### PR TITLE
Moved root to /dist for the vite build

### DIFF
--- a/roles/static_tables/files/default.conf
+++ b/roles/static_tables/files/default.conf
@@ -6,7 +6,7 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
-        root   /opt/static_tables/current/site;
+        root   /opt/static_tables/current/dist;
         index  index.html index.htm;
     }
 


### PR DESCRIPTION
Using Vite to build the application has move the root directory we need to serve up to /dist