### PR TITLE
Run Solr8 on Jammy with Java >9

### DIFF
--- a/group_vars/solr8cloud/staging.yml
+++ b/group_vars/solr8cloud/staging.yml
@@ -2,11 +2,11 @@
 desired_ruby_version: "3.1.0"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
-solr_heap_setting: '20g'
+solr_heap_setting: "20g"
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'
 solr_cloud_download_version: 8.4.1
-solr_log4j_path: '/solr/log4j2.xml'
+solr_log4j_path: "/solr/log4j2.xml"
 lib_zk1_host_name: lib-zk-staging1d
 lib_zk2_host_name: lib-zk-staging2d
 lib_zk3_host_name: lib-zk-staging3d
@@ -14,8 +14,6 @@ lib_zk1_host: 128.112.204.145
 lib_zk2_host: 128.112.204.146
 lib_zk3_host: 128.112.204.147
 solr_znode: solr8
-gc_log_settings: "-verbose:gc -XX:+PrintGCDetails"
-solr_gc_tune: "-XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:PretenureSizeThreshold=64m -XX:+ParallelRefProcEnabled"
 cjkfoldingfilter: https://github.com/pulibrary/pul_solr/raw/master/solr8_jars/CJKFoldingFilter.jar
 datadog_api_key: "{{vault_datadog_key}}"
 datadog_config:
@@ -52,12 +50,12 @@ datadog_checks:
     init_config:
     instances:
       - name: Catalog Staging
-        url: 'http://localhost:8983/solr/catalog-staging/admin/ping?wt=json&distrib=true&indent=true'
+        url: "http://localhost:8983/solr/catalog-staging/admin/ping?wt=json&distrib=true&indent=true"
         skip_event: true
         tags:
-          - 'http_service:solr'
-          - 'application:orangelight'
-          - 'environment:staging'
+          - "http_service:solr"
+          - "application:orangelight"
+          - "environment:staging"
   solr:
     instances:
       # location of tomcat

--- a/inventory/all_projects/solr8cloud
+++ b/inventory/all_projects/solr8cloud
@@ -1,8 +1,5 @@
 [solr8cloud_production]
-# lib-solr-prod4.princeton.edu
-# lib-solr-prod5.princeton.edu
-lib-solr-prod6.princeton.edu
-# jammy solr8 boxes
+# all solr8 boxes are now on jammy
 lib-solr-prod7.princeton.edu
 lib-solr-prod8.princeton.edu
 lib-solr-prod9.princeton.edu

--- a/inventory/all_projects/solr8cloud
+++ b/inventory/all_projects/solr8cloud
@@ -1,9 +1,10 @@
 [solr8cloud_production]
-lib-solr-prod4.princeton.edu
+# lib-solr-prod4.princeton.edu
 lib-solr-prod5.princeton.edu
 lib-solr-prod6.princeton.edu
 # jammy solr8 boxes
 lib-solr-prod7.princeton.edu
+lib-solr-prod8.princeton.edu
 [solr8cloud_staging]
 lib-solr-staging4d.princeton.edu
 lib-solr-staging5d.princeton.edu

--- a/inventory/all_projects/solr8cloud
+++ b/inventory/all_projects/solr8cloud
@@ -1,10 +1,11 @@
 [solr8cloud_production]
 # lib-solr-prod4.princeton.edu
-lib-solr-prod5.princeton.edu
+# lib-solr-prod5.princeton.edu
 lib-solr-prod6.princeton.edu
 # jammy solr8 boxes
 lib-solr-prod7.princeton.edu
 lib-solr-prod8.princeton.edu
+lib-solr-prod9.princeton.edu
 [solr8cloud_staging]
 lib-solr-staging4d.princeton.edu
 lib-solr-staging5d.princeton.edu

--- a/inventory/all_projects/solr8cloud
+++ b/inventory/all_projects/solr8cloud
@@ -2,6 +2,8 @@
 lib-solr-prod4.princeton.edu
 lib-solr-prod5.princeton.edu
 lib-solr-prod6.princeton.edu
+# jammy solr8 boxes
+lib-solr-prod7.princeton.edu
 [solr8cloud_staging]
 lib-solr-staging4d.princeton.edu
 lib-solr-staging5d.princeton.edu

--- a/roles/nginxplus/files/conf/http/lib-solr8-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8-prod.conf
@@ -5,9 +5,9 @@ proxy_cache_path /data/nginx/lib-solr8-prod/NGINX_cache/ keys_zone=lib-solr8-pro
 upstream lib-solr8-prod {
     least_time header 'inflight';
     zone lib-solr8-prod 128k;
-    server lib-solr-prod4.princeton.edu:8983 resolve;
-    server lib-solr-prod5.princeton.edu:8983 resolve;
-    server lib-solr-prod6.princeton.edu:8983 resolve;
+    server lib-solr-prod7.princeton.edu:8983 resolve;
+    server lib-solr-prod8.princeton.edu:8983 resolve;
+    server lib-solr-prod9.princeton.edu:8983 resolve;
     sticky learn
           create=$upstream_cookie_lib-solr8-prodcookie
           lookup=$cookie_lib-solr8-prodcookie

--- a/roles/solrcloud/defaults/main.yml
+++ b/roles/solrcloud/defaults/main.yml
@@ -15,40 +15,33 @@ solr_service_state: started
 solr_log4j: "{{ solr_log4j_path | default('/solr/log4j.properties') }}"
 solr_log_dir: /solr/logs
 solr_home: /solr
-solr_data_dir: '{{ solr_home }}/data'
+solr_data_dir: "{{ solr_home }}/data"
 solr_installation: /opt/solr
 
 # Ports
 solr_port: 8983
-solr_jmx_enabled: 'true'
+solr_jmx_enabled: "true"
 solr_jmx_port: 1099
-solr_host: '{{ inventory_hostname }}'
+solr_host: "{{ inventory_hostname }}"
 
 # garbage collection settings
 solr_gc_tune: "-XX:NewRatio=3 \
--XX:SurvivorRatio=4 \
--XX:TargetSurvivorRatio=90 \
--XX:MaxTenuringThreshold=8 \
--XX:+UseConcMarkSweepGC \
--XX:+UseParNewGC \
--XX:ConcGCThreads=4 \
--XX:ParallelGCThreads=4 \
--XX:+CMSScavengeBeforeRemark \
--XX:PretenureSizeThreshold=64m \
--XX:+UseCMSInitiatingOccupancyOnly \
--XX:CMSInitiatingOccupancyFraction=50 \
--XX:CMSMaxAbortablePrecleanTime=6000 \
--XX:+CMSParallelRemarkEnabled \
--XX:+ParallelRefProcEnabled"
+  -XX:SurvivorRatio=4 \
+  -XX:TargetSurvivorRatio=90 \
+  -XX:MaxTenuringThreshold=8 \
+  -XX:ConcGCThreads=4 \
+  -XX:ParallelGCThreads=4 \
+  -XX:PretenureSizeThreshold=64m \
+  -XX:+ParallelRefProcEnabled"
 
 # Enable verbose GC logging
+# these are the Java 9 settings
+# GCID and GCCause are always logged
 gc_log_settings: "-verbose:gc \
--XX:+PrintHeapAtGC \
--XX:+PrintGCDetails \
--XX:+PrintGCDateStamps \
--XX:+PrintGCTimeStamps \
--XX:+PrintTenuringDistribution \
--XX:+PrintGCApplicationStoppedTime"
+  -Xlog:gc=debug:file=/solr/logs/gc.txt:time,uptime,pid,tid,level,tags \
+  -Xlog:gc+heap=debug \
+  -Xlog:gc+age=trace \
+  -Xlog:safepoint"
 
 solr_stack_size: 256k
 solr_heap: "{{ solr_heap_setting | default('20g') }}"
@@ -64,22 +57,22 @@ solr_jetty_output_buffer_size: 32768
 solr_jetty_output_aggregation_size: 8192
 solr_jetty_request_header_size: 8192
 solr_jetty_response_header_size: 8192
-solr_jetty_send_server_version: 'false'
-solr_jetty_send_date_header: 'false'
+solr_jetty_send_server_version: "false"
+solr_jetty_send_date_header: "false"
 solr_jetty_header_cache_size: 512
-solr_jetty_delay_dispatch_until_content: 'false'
+solr_jetty_delay_dispatch_until_content: "false"
 solr_jetty_http_selectors: -1
 solr_jetty_http_acceptors: -1
 
 # ZOOKEEPER
 solr_zookeeper_client_port: 2181
 lib_zk1_host_name: localhost
-solr_zookeeper_hosts_string_multi: '{{ lib_zk1_host_name }}:{{ solr_zookeeper_client_port }},{{ lib_zk2_host_name }}:{{ solr_zookeeper_client_port }},{{ lib_zk3_host_name }}:{{ solr_zookeeper_client_port }}'
+solr_zookeeper_hosts_string_multi: "{{ lib_zk1_host_name }}:{{ solr_zookeeper_client_port }},{{ lib_zk2_host_name }}:{{ solr_zookeeper_client_port }},{{ lib_zk3_host_name }}:{{ solr_zookeeper_client_port }}"
 solr_zookeeper_hosts_string_default: localhost:{{ solr_zookeeper_client_port }}
 solr_zookeeper_hosts_string: '{{ solr_zookeeper_hosts_string_default if lib_zk1_host_name == "localhost" else solr_zookeeper_hosts_string_multi }}'
 
-solr_znode: ''
-solr_znode_path: '/{{ solr_znode }}'
+solr_znode: ""
+solr_znode_path: "/{{ solr_znode }}"
 
 solr_zk_host: '{{ solr_zookeeper_hosts_string }}{{ solr_znode_path if solr_znode else "" }}'
 
@@ -95,7 +88,7 @@ log_root_level: WARN
 log_file_size: 500MB
 log_max_backup_index: 9
 
-solr_log_root_level: '{{ log_root_level }}'
-solr_log_file_size: '{{ log_file_size }}'
-solr_log_max_backup_index: '{{ log_max_backup_index }}'
+solr_log_root_level: "{{ log_root_level }}"
+solr_log_file_size: "{{ log_file_size }}"
+solr_log_max_backup_index: "{{ log_max_backup_index }}"
 solr_cloud_url: "https://pulmirror.princeton.edu/mirror/solr/dist/lucene/solr/{{ solr_cloud_version }}/{{ solr_cloud_package }}"

--- a/roles/solrcloud/templates/solr.in.sh.j2
+++ b/roles/solrcloud/templates/solr.in.sh.j2
@@ -26,7 +26,7 @@ SOLR_HEAP='{{ solr_heap }}'
 # SOLR_JAVA_MEM=
 
 # Enable verbose GC logging
-GC_LOG_OPTS={{ gc_log_settings }}
+GC_LOG_OPTS='{{ gc_log_settings }}'
 
 # These GC settings have shown to work well for a number of common Solr workloads
 GC_TUNE='{{ solr_gc_tune }}'


### PR DESCRIPTION
Partial fix for #4858.

We are upgrading the VMs in our Solr8 cluster to run on Ubuntu 22 (Jammy). The default Java on Jammy is Java 17. Back in Java 9, the settings for garbage collection and logging changed.

This [post](https://blog.gceasy.io/2017/10/17/43-gc-logging-flags-removed-in-java-9/) has a great chart of the pre-9 and post-9 settings for gc logging. See also the [openJDK documentation](https://openjdk.org/jeps/158) with examples.

With these settings, Solr8 runs happily on Jammy. We should update the Solr9 cluster to use these settings for consistency and to prepare for the next migration step.

We will build one Jammy Solr8 VM from this branch at a time, add it to the cluster, replicate to it, then decommission an old box. Once we have replaced all VMs in the cluster with Jammy VMs, we can merge these changes.
