### PR TITLE
[passenger] Add a variable to set number of passenger processes

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -153,6 +153,7 @@ rails_app_vars:
   - name: NODE_OPTIONS
     value: '--openssl-legacy-provider'
 passenger_extra_config: "{{ lookup('file', 'roles/figgy/templates/nginx_extra_config')  }}"
+passenger_max_pool_size: '12'
 deploy_ssh_users:
   - name: tpendragon
     key: https://github.com/tpendragon.keys

--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -141,6 +141,7 @@ rails_app_vars:
   - name: NODE_OPTIONS
     value: '--openssl-legacy-provider'
 passenger_extra_config: "{{ lookup('file', 'roles/figgy/templates/nginx_extra_config')  }}"
+passenger_max_pool_size: '12'
 redis_bind_interface: '0.0.0.0'
 redis__server_default_configuration:
   syslog-enabled: "{{ redis__server_syslog | bool }}"

--- a/roles/passenger/README.md
+++ b/roles/passenger/README.md
@@ -42,6 +42,9 @@ Values for passenger configuration directives inside `nginx.conf`. These default
     nginx_keepalive_timeout: "65"
     nginx_remove_default_vhost: true
 
+optional variable: `passenger_max_pool_size`: if you set this the role will set a number of passenger processes. passenger default is 6. also this will make the role pre-warm your site.
+
+
 Nginx directives.
 
 ## Dependencies

--- a/roles/passenger/templates/nginx.conf.j2
+++ b/roles/passenger/templates/nginx.conf.j2
@@ -14,6 +14,12 @@ events {
 
 http {
 
+  {% if passenger_max_pool_size is defined %}
+  passenger_max_pool_size {{ passenger_max_pool_size }};
+  passenger_min_instances {{ passenger_max_pool_size }};
+  passenger_pre_start {{ passenger_server_name }};
+  {% endif %}
+
   ##
   # Basic Settings
   ##


### PR DESCRIPTION
I ran the figgy staging role with and without this variable defined. When not defined, it continues to use the passenger defaults. when defined, it sets the number of processes and warms them.

closes pulibrary/figgy#6398
