### PR TITLE
[PDCDisocvery] Factor out the common vars into main

### DIFF
--- a/group_vars/pdc_discovery/main.yml
+++ b/group_vars/pdc_discovery/main.yml
@@ -33,3 +33,31 @@ project_db_host: '{{postgres_host}}'
 # Use Ruby 3.1.0 and install from source
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
+
+rails_app_vars:
+  - name: RAILS_MASTER_KEY
+    value: '{{ rails_master_key }}'
+  - name: SECRET_KEY_BASE
+    value: '{{ secret_key_base }}'
+  - name: SOLR_URL
+    value: '{{solr_url}}'
+  - name: APP_DB
+    value: '{{pdc_discovery_db_name}}'
+  - name: APP_DB_USERNAME
+    value: '{{pdc_discovery_db_user}}'
+  - name: APP_DB_PASSWORD
+    value: '{{pdc_discovery_db_password}}'
+  - name: APP_DB_HOST
+    value: '{{postgres_host}}'
+  - name: APPLICATION_HOST
+    value: '{{pdc_discovery_host_name}}'
+  - name: APPLICATION_HOST_PROTOCOL
+    value: '{{application_host_protocol}}'
+  - name: APPLICATION_PORT
+    value: '{{application_port}}'
+  - name: HONEYBADGER_API_KEY
+    value: '{{vault_pdc_discovery_honeybadger_key}}'
+  - name: DATASPACE_URL
+    value: 'https://dataspace.princeton.edu'
+  - name: PLAUSIBLE_KEY
+    value: '{{plausible_key}}'

--- a/group_vars/pdc_discovery/production.yml
+++ b/group_vars/pdc_discovery/production.yml
@@ -56,32 +56,7 @@ datadog_typed_checks:
           source: rails
           service: pdc-discovery
 
-# Note that this MUST stay in the environment-specific playbook.
-# Moving any of these to common.yml will not work.
-rails_app_vars:
-  - name: RAILS_MASTER_KEY
-    value: '{{vault_rails_master_key}}'
-  - name: SECRET_KEY_BASE
-    value: '{{vault_pdc_discovery_production_secret_key}}'
-  - name: SOLR_URL
-    value: '{{solr_url}}'
-  - name: APP_DB
-    value: '{{pdc_discovery_db_name}}'
-  - name: APP_DB_USERNAME
-    value: '{{pdc_discovery_db_user}}'
-  - name: APP_DB_PASSWORD
-    value: '{{pdc_discovery_db_password}}'
-  - name: APP_DB_HOST
-    value: '{{postgres_host}}'
-  - name: APPLICATION_HOST
-    value: '{{pdc_discovery_host_name}}'
-  - name: APPLICATION_HOST_PROTOCOL
-    value: '{{application_host_protocol}}'
-  - name: APPLICATION_PORT
-    value: '{{application_port}}'
-  - name: HONEYBADGER_API_KEY
-    value: '{{vault_pdc_discovery_honeybadger_key}}'
-  - name: DATASPACE_URL
-    value: 'https://dataspace.princeton.edu'
-  - name: PLAUSIBLE_KEY
-    value: '{{vault_pdc_discovery_production_plausible_key}}'
+secret_key_base: {{ vault_pdc_discovery_production_secret_key }}
+rails_master_key: {{ vault_rails_master_key }}
+plausible_key: {{ vault_pdc_discovery_production_plausible_key }}
+

--- a/group_vars/pdc_discovery/staging.yml
+++ b/group_vars/pdc_discovery/staging.yml
@@ -56,32 +56,7 @@ datadog_typed_checks:
           source: rails
           service: pdc-discovery
 
-# Note that this MUST stay in the environment-specific playbook.
-# Moving any of these to common.yml will not work.
-rails_app_vars:
-  - name: RAILS_MASTER_KEY
-    value: '{{vault_rails_master_key}}'
-  - name: SECRET_KEY_BASE
-    value: '{{vault_pdc_discovery_staging_secret_key}}'
-  - name: SOLR_URL
-    value: '{{solr_url}}'
-  - name: APP_DB
-    value: '{{pdc_discovery_db_name}}'
-  - name: APP_DB_USERNAME
-    value: '{{pdc_discovery_db_user}}'
-  - name: APP_DB_PASSWORD
-    value: '{{pdc_discovery_db_password}}'
-  - name: APP_DB_HOST
-    value: '{{postgres_host}}'
-  - name: APPLICATION_HOST
-    value: '{{pdc_discovery_host_name}}'
-  - name: APPLICATION_HOST_PROTOCOL
-    value: '{{application_host_protocol}}'
-  - name: APPLICATION_PORT
-    value: '{{application_port}}'
-  - name: HONEYBADGER_API_KEY
-    value: '{{vault_pdc_discovery_honeybadger_key}}'
-  - name: DATASPACE_URL
-    value: 'https://dataspace.princeton.edu'
-  - name: PLAUSIBLE_KEY
-    value: '{{vault_pdc_discovery_staging_plausible_key}}'
+
+secret_key_base: '{{ vault_pdc_discovery_staging_secret_key }}'
+rails_master_key: '{{ vault_rails_master_key }}'
+plausible_key: '{{ vault_pdc_discovery_staging_plausible_key }}'

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -7,7 +7,7 @@
   become: true
   vars_files:
     - ../site_vars.yml
-    - ../group_vars/pdc_discovery/common.yml
+    - ../group_vars/pdc_discovery/main.yml
     - ../group_vars/pdc_discovery/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/pdc_discovery/vault.yml
 


### PR DESCRIPTION
rename common to main to reflect latest practice

There is no difference in the output:
![Screenshot 2024-05-16 at 7 56 39 AM](https://github.com/pulibrary/princeton_ansible/assets/1599081/396a846d-1d73-4e18-8375-11db8b1e044e)
