### PR TITLE
[static_tables] Use marquand-catalogs for catalog path

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -51,11 +51,11 @@
 
 # Static tables redirects
 #
-    rewrite ^/marquand/resources/sales-catalogs(.*)$ /marquand/$1 redirect;
-    rewrite ^/libraries/marquand/resources/sale(.*)$ /marquand/$1 redirect;
-    rewrite ^/marquand_catalogs(.*)$ /marquand/$1 redirect;
-    location /marquand/ {
-        proxy_pass https://static-tables-staging.princeton.edu/marquand/;
+    rewrite ^/marquand/resources/sales-catalogs(.*)$ /marquand-catalogs/$1 redirect;
+    rewrite ^/libraries/marquand/resources/sale(.*)$ /marquand-catalogs/$1 redirect;
+    rewrite ^/marquand_catalogs(.*)$ /marquand-catalogs/$1 redirect;
+    location /marquand-catalogs/ {
+        proxy_pass https://static-tables-staging.princeton.edu/marquand-catalogs/;
     }
 
     location /faculty-and-professional-staff-index/ {


### PR DESCRIPTION
Connected to https://github.com/pulibrary/static-tables/issues/130

Run successfully on both load balancers.