### PR TITLE
adds prod derrida VMs to CDH inventory

### DIFF
--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -1,4 +1,8 @@
 [cdh_production]
+cdh-derrida1.princeton.edu
+cdh-derrida2.princeton.edu
+cdh-derrida-crawl1.princeton.edu
+cdh-derrida-crawl2.princeton.edu
 cdh-geniza1.princeton.edu
 cdh-geniza2.princeton.edu
 cdh-prosody1.princeton.edu


### PR DESCRIPTION
Closes #4977.

Updates our inventory so we can maintain and manage these VMs. These are new Jammy VMs.

The `cdh-derrida1` and `cdh-derrida-crawl1` boxes are replacements, so you may see a remote host ID error when you first try to SSH in.
