### PR TITLE
[cdh] update solr hosts

### DIFF
--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -32,7 +32,7 @@ lib-fs-prod.princeton.edu
 lib-postgres-prod1.princeton.edu
 lib-postgres-prod3.princeton.edu
 lib-solr-prod1.princeton.edu
-lib-solr-prod4.princeton.edu
+lib-solr-prod7.princeton.edu
 lib-adc1.princeton.edu
 lib-adc2.princeton.edu
 [cdh_shared_staging]


### PR DESCRIPTION
adds solr7 host which replaced lib-solr-prod4
