### PR TITLE
[solr8] Install the JDK, not just the JRE

### DIFF
--- a/group_vars/solr8cloud/production.yml
+++ b/group_vars/solr8cloud/production.yml
@@ -5,6 +5,7 @@ ruby_version_override: "ruby-3.1.0"
 solr_heap_setting: "20g"
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'
+java_type: jdk
 solr_cloud_download_version: 8.4.1
 solr_log4j_path: "/solr/log4j2.xml"
 lib_zk1_host_name: lib-zk-prod1

--- a/group_vars/solr8cloud/staging.yml
+++ b/group_vars/solr8cloud/staging.yml
@@ -5,6 +5,7 @@ ruby_version_override: "ruby-3.1.0"
 solr_heap_setting: "20g"
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'
+java_type: jdk
 solr_cloud_download_version: 8.4.1
 solr_log4j_path: "/solr/log4j2.xml"
 lib_zk1_host_name: lib-zk-staging1d


### PR DESCRIPTION
This allows us to do two things related to memory troubleshooting:

1. Allows us to run jmap, which is part of these instructions:
   https://github.com/pulibrary/pul_solr?tab=readme-ov-file#heap-dump
2. Allows the oom_killer to automatically dump the heap by providing
   the jstack command, see
   https://solr.apache.org/guide/8_7/jvm-settings.html

I ran this on lib-solr-staging4d today, and confirmed:
* I can still `sudo systemctl restart solr`, and solr still works!
* I can use jmap to create a heap dump of the solr process, after temporarily setting PrivateTmp=false in the systemd service
* The jstack binary is now available and in the path

Helps with https://github.com/pulibrary/orangelight/issues/3601