### PR TITLE
Fix Solr backups

### DIFF
--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -9,6 +9,8 @@
     path: "/mnt/{{ item }}"
     state: "directory"
     mode: 0755
+    group: deploy
+    owner: deploy
   loop:
     - solr_backup
 
@@ -23,7 +25,7 @@
     - solr.smb.credentials
 
 - name: solrcloud | Create mount to diglibdata shares
-  mount:
+  ansible.posix.mount:
     path: "/mnt/{{ item.path }}"
     src: "//diglibdata1.princeton.edu/{{ item.src }}"
     fstype: cifs
@@ -32,19 +34,28 @@
   when:
     - running_on_server
   loop:
-    - {path: "solr_backup", src: "solrbackup", opts: "solr"}
+    - { path: "solr_backup", src: "solrbackup", opts: "solr" }
 
 - name: solrcloud | update host file
   ansible.builtin.lineinfile:
     dest: /etc/hosts
-    regexp: '{{ item.address }}.*{{ item.hostname }}$'
-    line: '{{ item.address }} {{ item.hostname }}'
+    regexp: "{{ item.address }}.*{{ item.hostname }}$"
+    line: "{{ item.address }} {{ item.hostname }}"
     state: present
   become: true
   loop:
-    - {hostname: '{{ lib_zk1_host_name }}.princeton.edu', address: "{{ lib_zk1_host }}"}
-    - {hostname: '{{ lib_zk2_host_name }}.princeton.edu', address: "{{ lib_zk2_host }}"}
-    - {hostname: '{{ lib_zk3_host_name }}.princeton.edu', address: "{{ lib_zk3_host }}"}
+    - {
+        hostname: "{{ lib_zk1_host_name }}.princeton.edu",
+        address: "{{ lib_zk1_host }}",
+      }
+    - {
+        hostname: "{{ lib_zk2_host_name }}.princeton.edu",
+        address: "{{ lib_zk2_host }}",
+      }
+    - {
+        hostname: "{{ lib_zk3_host_name }}.princeton.edu",
+        address: "{{ lib_zk3_host }}",
+      }
   tags:
     - hosts
   when: lib_zk1_host_name != "localhost" and lib_zk2_host_name != "localhost" and lib_zk3_host_name != "localhost"

--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -4,6 +4,15 @@
     name: ["cifs-utils"]
     state: present
 
+- name: Unmount diglibdata shares
+  ansible.posix.mount:
+    path: "/mnt/{{ item.path }}"
+    state: unmounted
+  loop:
+    - { path: "solr_backup", src: "solrbackup", opts: "solr" }
+  tags:
+    - fix_backups
+
 - name: solrcloud | create mounts
   ansible.builtin.file:
     path: "/mnt/{{ item }}"
@@ -13,6 +22,8 @@
     owner: deploy
   loop:
     - solr_backup
+  tags:
+    - fix_backups
 
 - name: solrcloud | Copy smb credentials
   ansible.builtin.copy:
@@ -23,6 +34,8 @@
     - running_on_server
   loop:
     - solr.smb.credentials
+  tags:
+    - fix_backups
 
 - name: solrcloud | Create mount to diglibdata shares
   ansible.posix.mount:
@@ -35,6 +48,8 @@
     - running_on_server
   loop:
     - { path: "solr_backup", src: "solrbackup", opts: "solr" }
+  tags:
+    - fix_backups
 
 - name: solrcloud | update host file
   ansible.builtin.lineinfile:

--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -4,16 +4,7 @@
     name: ["cifs-utils"]
     state: present
 
-- name: Unmount diglibdata shares
-  ansible.posix.mount:
-    path: "/mnt/{{ item.path }}"
-    state: unmounted
-  loop:
-    - { path: "solr_backup", src: "solrbackup", opts: "solr" }
-  tags:
-    - fix_backups
-
-- name: solrcloud | create mounts
+- name: solrcloud | create directories for mounts
   ansible.builtin.file:
     path: "/mnt/{{ item }}"
     state: "directory"
@@ -22,8 +13,6 @@
     owner: deploy
   loop:
     - solr_backup
-  tags:
-    - fix_backups
 
 - name: solrcloud | Copy smb credentials
   ansible.builtin.copy:
@@ -34,15 +23,13 @@
     - running_on_server
   loop:
     - solr.smb.credentials
-  tags:
-    - fix_backups
 
 - name: solrcloud | Create mount to diglibdata shares
   ansible.posix.mount:
     path: "/mnt/{{ item.path }}"
     src: "//diglibdata1.princeton.edu/{{ item.src }}"
     fstype: cifs
-    opts: "credentials=/etc/{{ item.opts }}.smb.credentials"
+    opts: "credentials=/etc/{{ item.opts }}.smb.credentials,uid=1001,gid=1001"
     state: mounted
   when:
     - running_on_server


### PR DESCRIPTION
Partial fix for https://github.com/pulibrary/pul_solr/issues/407.

The diglibdata mount for Solr backups was owned by `root:root` even though we were correctly setting the owner and group on the directories, because the mount process did not specify a GID or UID.

