### PR TITLE
cdh-test-prodigy updates: proxy port 8080 on upstream; remove circular redirect

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
@@ -4,8 +4,8 @@ proxy_cache_path /data/nginx/prodigy/NGINX_cache/ keys_zone=prodigycache:10m;
 upstream prodigy {
     least_time header 'inflight';
     zone prodigy 64k;
-    server cdh-prodigy1.princeton.edu;
-    server cdh-prodigy2.princeton.edu;
+    server cdh-prodigy1.princeton.edu:8080;
+    server cdh-prodigy2.princeton.edu:8080;
     sticky learn
           create=$upstream_cookie_prodigycookie
           lookup=$cookie_prodigycookie
@@ -17,18 +17,18 @@ server {
     server_name cdh-prodigy.princeton.edu;
 
     location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://prodigy.cdh.princeton.edu$request_uri;
     }
 }
 
-#server {
-#    listen 80;
-#    server_name prodigy.cdh.princeton.edu;
-#
-#    location / {
-#        return 301 https://$server_name$request_uri;
-#    }
-#}
+server {
+    listen 80;
+    server_name prodigy.cdh.princeton.edu;
+
+    location / {
+        return 301 https://prodigy.cdh.princeton.edu$request_uri;
+    }
+}
 
 
 server {
@@ -42,7 +42,7 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://prodigy.cdh.princeton.edu$request_uri;
     }
 }
 
@@ -50,7 +50,7 @@ server {
 server {
     listen 443 ssl;
     http2 on;
-    server_name cdh-prodigy.princeton.edu;
+    server_name prodigy.cdh.princeton.edu;
 
     client_max_body_size 50M;
 

--- a/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
@@ -44,9 +44,10 @@ server {
     }
 }
 
+
 server {
     listen 443 ssl;
-    server_name cdh-test-prodigy.princeton.edu;
+    server_name test-prodigy.cdh.princeton.edu;
 
     client_max_body_size 50M;
 

--- a/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
@@ -3,8 +3,8 @@ proxy_cache_path /data/nginx/test_prodigy/NGINX_cache/ keys_zone=test_prodigycac
 
 upstream test_prodigy {
     zone prod_prodigy 64k;
-    server cdh-test-prodigy1.princeton.edu;
-    server cdh-test-prodigy2.princeton.edu;
+    server cdh-test-prodigy1.princeton.edu:8080;
+    server cdh-test-prodigy2.princeton.edu:8080;
     sticky learn
           create=$upstream_cookie_test_prodigycookie
           lookup=$cookie_test_prodigycookie
@@ -33,20 +33,6 @@ server {
 server {
     listen 443 ssl;
     server_name cdh-test-prodigy.princeton.edu;
-
-    ssl_certificate            /etc/letsencrypt/live/cdh-test-prodigy/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/cdh-test-prodigy/privkey.pem;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
-
-    location / {
-        return 301 https://test-prodigy.cdh.princeton.edu$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    server_name test-prodigy.cdh.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/cdh-test-prodigy/fullchain.pem;
     ssl_certificate_key        /etc/letsencrypt/live/cdh-test-prodigy/privkey.pem;


### PR DESCRIPTION
I added port 8080 to the upstream declaration, because the service is running on port 8080 - this is an ASGI application, so we can't run it through nginx/passenger. 

I'm getting a circular redirect when I try to access the public url for the test site. The block I removed looks like the culprit to me, but I did test this on the active load balancer and reloaded nginx but it didn't solve the problem.



