### PR TITLE
[Nomad] Update nomad reverse proxy configuration.

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/nomad.conf
+++ b/roles/nginxplus/files/conf/http/dev/nomad.conf
@@ -2,6 +2,7 @@
 proxy_cache_path /var/cache/nginx/nomad/ keys_zone=nomadcache:10m;
 
 upstream nomad {
+    ip_hash;
     zone nomad 64k;
     server service.consul service=http.nomad-servers resolve max_fails=0;
     sticky learn
@@ -35,7 +36,13 @@ server {
         app_protect_enable off;
         proxy_pass http://nomad;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_cache nomadcache;
+        proxy_read_timeout 310s;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Origin "${scheme}://${proxy_host}";
         # allow princeton network
         # include /etc/nginx/conf.d/templates/restrict.conf;
         # block all IPs outside the princeton network


### PR DESCRIPTION
Pulled from
https://developer.hashicorp.com/nomad/tutorials/manage-clusters/reverse-proxy-ui

This fixes log streaming and exec from the UI when behind a load balancer.