### PR TITLE
Updating the Ruby release to 3.3.0 for tiger data app environments

### DIFF
--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -19,7 +19,7 @@ tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
 desired_nodejs_version: 'v18.13.0'
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
-ruby_version_override: "ruby-3.2.3"
+ruby_version_override: "ruby-3.3.0"
 passenger_app_root: "/opt/tigerdata/current/public"
 passenger_extra_config: "passenger_preload_bundler on;"
 nginx_remove_default_vhost: true


### PR DESCRIPTION
This builds upon the work advanced with https://github.com/pulibrary/tiger-data-app/tree/fix-ci