### PR TITLE
I5013 share solr vars

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -68,9 +68,6 @@ sidekiq_netids:
 figgy_rabbit_host: 'figgy-web-prod1.princeton.edu'
 figgy_staging_rabbit_host: 'figgy-web-staging1.princeton.edu'
 fits_version: 0.8.5
-ol_solr_url: 'http://lib-solr8-prod.princeton.edu:8983/solr/catalog-production'
-ol_solr_reindex_url: 'http://lib-solr8-prod.princeton.edu:8983/solr/catalog-rebuild'
-ol_staging_solr_url: 'http://lib-solr8-staging.princeton.edu:8983/solr/catalog-staging'
 postgres_version: 10
 project_db_host: http://127.0.0.1
 postgres_admin_password: '{{ vault_postgres_admin_password }}'

--- a/group_vars/allsearch_api/common.yml
+++ b/group_vars/allsearch_api/common.yml
@@ -48,9 +48,9 @@ rails_app_vars:
   - name: DPUL_SOLR_COLLECTION
     value: '{{ dpul_solr_collection }}'
   - name: FINDINGAIDS_SOLR_HOST
-    value: '{{ findingaids_solr_host }}'
+    value: '{{ pulfalight_solr_host }}'
   - name: FINDINGAIDS_SOLR_COLLECTION
-    value: '{{ findingaids_solr_collection }}'
+    value: '{{ pulfalight_solr_core }}'
   - name: PULMAP_SOLR_HOST
     value: '{{ pulmap_solr_host }}'
   - name: PULMAP_SOLR_COLLECTION

--- a/group_vars/allsearch_api/production.yml
+++ b/group_vars/allsearch_api/production.yml
@@ -3,8 +3,6 @@ rails_app_env: production
 allsearch_api_secret_key: '{{vault_allsearch_api_production_secret_key}}'
 
 # Solr configurations
-findingaids_solr_host: lib-solr8-prod.princeton.edu
-findingaids_solr_collection: pulfalight-production
 pulmap_solr_host: lib-solr8-prod.princeton.edu
 pulmap_solr_collection: pulmap
 

--- a/group_vars/allsearch_api/production.yml
+++ b/group_vars/allsearch_api/production.yml
@@ -3,10 +3,6 @@ rails_app_env: production
 allsearch_api_secret_key: '{{vault_allsearch_api_production_secret_key}}'
 
 # Solr configurations
-catalog_solr_host: lib-solr8-prod.princeton.edu
-catalog_solr_collection: catalog-alma-production
-dpul_solr_host: lib-solr8-prod.princeton.edu
-dpul_solr_collection: dpul-production
 findingaids_solr_host: lib-solr8-prod.princeton.edu
 findingaids_solr_collection: pulfalight-production
 pulmap_solr_host: lib-solr8-prod.princeton.edu

--- a/group_vars/allsearch_api/production.yml
+++ b/group_vars/allsearch_api/production.yml
@@ -2,10 +2,6 @@
 rails_app_env: production
 allsearch_api_secret_key: '{{vault_allsearch_api_production_secret_key}}'
 
-# Solr configurations
-pulmap_solr_host: lib-solr8-prod.princeton.edu
-pulmap_solr_collection: pulmap
-
 postgres_host: lib-postgres-prod1.princeton.edu
 application_db_name: allsearch_api_prod
 application_dbuser_name: allsearch_api_prod

--- a/group_vars/allsearch_api/staging.yml
+++ b/group_vars/allsearch_api/staging.yml
@@ -2,10 +2,6 @@
 rails_app_env: staging
 allsearch_api_secret_key: '{{vault_allsearch_api_staging_secret_key}}'
 
-# Solr configurations
-pulmap_solr_host: lib-solr8d-staging.princeton.edu
-pulmap_solr_collection: pulmap-staging
-
 postgres_host: lib-postgres-staging1.princeton.edu
 application_db_name: allsearch_api_staging
 application_dbuser_name: allsearch_api_staging

--- a/group_vars/allsearch_api/staging.yml
+++ b/group_vars/allsearch_api/staging.yml
@@ -3,8 +3,6 @@ rails_app_env: staging
 allsearch_api_secret_key: '{{vault_allsearch_api_staging_secret_key}}'
 
 # Solr configurations
-findingaids_solr_host: lib-solr8d-staging.princeton.edu
-findingaids_solr_collection: pulfalight-staging
 pulmap_solr_host: lib-solr8d-staging.princeton.edu
 pulmap_solr_collection: pulmap-staging
 

--- a/group_vars/allsearch_api/staging.yml
+++ b/group_vars/allsearch_api/staging.yml
@@ -3,10 +3,6 @@ rails_app_env: staging
 allsearch_api_secret_key: '{{vault_allsearch_api_staging_secret_key}}'
 
 # Solr configurations
-catalog_solr_host: lib-solr8d-staging.princeton.edu
-catalog_solr_collection: catalog-staging
-dpul_solr_host: lib-solr8d-staging.princeton.edu
-dpul_solr_collection: dpul-staging
 findingaids_solr_host: lib-solr8d-staging.princeton.edu
 findingaids_solr_collection: pulfalight-staging
 pulmap_solr_host: lib-solr8d-staging.princeton.edu

--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -51,7 +51,7 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 application_host: '{{ passenger_server_name }}'
 application_host_protocol: 'https'
 project_db_host: '{{ postgres_host }}'
-dpul_solr: 'http://lib-solr8-prod.princeton.edu:8983/solr/dpul-production'
+dpul_solr: "http://{{ dpul_solr_host }}:8983/solr/{{ dpul_solr_collection }}"
 rails_app_vars:
   - name: POMEGRANATE_SECRET_KEY_BASE
     value: '{{ vault_dpul_secret_key }}'

--- a/group_vars/dpul/production_solr.yml
+++ b/group_vars/dpul/production_solr.yml
@@ -1,0 +1,3 @@
+---
+dpul_solr_host: lib-solr8-prod.princeton.edu
+dpul_solr_collection: dpul-production

--- a/group_vars/dpul/staging.yml
+++ b/group_vars/dpul/staging.yml
@@ -72,7 +72,7 @@ rails_app_vars:
   - name: APPLICATION_HOST_PROTOCOL
     value: '{{ application_host_protocol }}'
   - name: POMEGRANATE_SOLR_URL
-    value: 'http://lib-solr8d-staging.princeton.edu:8983/solr/dpul-staging'
+    value: "http://{{ dpul_solr_host }}:8983/solr/{{ dpul_solr_collection }}"
   - name: HONEYBADGER_API_KEY
     value: '{{ dpul_honeybadger_key }}'
   - name: POMEGRANATE_COLLECTIONS_URL

--- a/group_vars/dpul/staging_solr.yml
+++ b/group_vars/dpul/staging_solr.yml
@@ -1,0 +1,3 @@
+---
+dpul_solr_host: lib-solr8d-staging.princeton.edu
+dpul_solr_collection: dpul-staging

--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -31,7 +31,6 @@ ol_feedback_cc: "{{ vault_ol_feedback_cc }}"
 ol_figgy_url: "https://figgy.princeton.edu"
 ol_honeybadger_key: "{{ vault_ol_honeybadger_key }}"
 ol_rabbit_server: "amqp://{{ ol_rabbit_user }}:{{ ol_rabbit_password }}@{{ ol_rabbit_host }}:5672"
-ol_rails_solr_url: "{{ ol_solr_url }}"
 passenger_app_root: "/opt/orangelight/current/public"
 passenger_extra_config: '{{ lookup("file", "roles/orangelight/templates/nginx_extra_config")  }}'
 passenger_extra_http_config:
@@ -118,6 +117,6 @@ rails_app_vars:
   - name: SMTP_PORT
     value: "{{ ol_smtp_port | default('1025') }}"
   - name: SOLR_URL
-    value: "{{ ol_solr_url }}"
+    value: "http://{{ catalog_solr_host }}:8983/solr/{{ catalog_solr_collection }}"
 sneakers_worker_name: orangelight-sneakers
 sneakers_workers: EventHandler

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -18,7 +18,6 @@ central_redis_db: '7'
 ol_secret_key: "{{ vault_ol_secret_key }}"
 ol_smtp_host: "lib-ponyexpr-prod.princeton.edu"
 ol_smtp_port: "25"
-ol_solr_url: http://lib-solr8-prod.princeton.edu:8983/solr/catalog-alma-production
 passenger_app_env: "production"
 passenger_server_name: "catalog-alma.*"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'

--- a/group_vars/orangelight/production_solr.yml
+++ b/group_vars/orangelight/production_solr.yml
@@ -1,0 +1,3 @@
+---
+catalog_solr_host: lib-solr8-prod.princeton.edu
+catalog_solr_collection: catalog-alma-production

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -19,7 +19,6 @@ ol_read_only_mode: 'false'
 central_redis_host: 'lib-redis-prod1.princeton.edu'
 central_redis_db: '8'
 ol_secret_key: "{{ vault_ol_alma_qa_secret_key }}"
-ol_solr_url: http://lib-solr8d-staging.princeton.edu:8983/solr/catalog-qa
 passenger_app_env: "qa"
 passenger_server_name: "catalog-qa.*"
 postgres_admin_user: "postgres"

--- a/group_vars/orangelight/qa_solr.yml
+++ b/group_vars/orangelight/qa_solr.yml
@@ -1,0 +1,3 @@
+---
+catalog_solr_host: lib-solr8d-staging.princeton.edu
+catalog_solr_collection: catalog-qa

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -18,7 +18,6 @@ ol_read_only_mode: 'false'
 central_redis_host: 'lib-redis-staging1.princeton.edu'
 central_redis_db: '7'
 ol_secret_key: "{{ vault_ol_staging_secret_key }}"
-ol_solr_url: http://lib-solr8d-staging.princeton.edu:8983/solr/catalog-staging
 passenger_app_env: "staging"
 passenger_server_name: "catalog-staging.*"
 postgres_admin_user: "postgres"

--- a/group_vars/orangelight/staging_solr.yml
+++ b/group_vars/orangelight/staging_solr.yml
@@ -1,0 +1,3 @@
+---
+catalog_solr_host: lib-solr8d-staging.princeton.edu
+catalog_solr_collection: catalog-staging

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -39,7 +39,6 @@ pulfalight_db_password: '{{vault_pulfalight_production_db_password}}'
 rails_app_env: "production"
 pulfalight_host_name: 'findingaids.princeton.edu'
 pulfalight_honeybadger_key: '{{vault_pulfalight_honeybadger_key}}'
-pulfalight_solr_core: 'pulfalight-production'
 application_db_name: '{{pulfalight_db_name}}'
 application_dbuser_name: '{{pulfalight_db_user}}'
 application_dbuser_password: '{{pulfalight_db_password}}'
@@ -72,7 +71,7 @@ rails_app_vars:
   - name: APPLICATION_PORT
     value: '{{application_port}}'
   - name: SOLR_URL
-    value: "http://lib-solr8-prod.princeton.edu:8983/solr/{{ pulfalight_solr_core }}"
+    value: "http://{{ pulfalight_solr_host }}:8983/solr/{{ pulfalight_solr_core }}"
   - name: HONEYBADGER_API_KEY
     value: '{{pulfalight_honeybadger_key}}'
   - name: ASPACE_USER

--- a/group_vars/pulfalight/production_solr.yml
+++ b/group_vars/pulfalight/production_solr.yml
@@ -1,0 +1,3 @@
+---
+pulfalight_solr_host: lib-solr8-prod.princeton.edu
+pulfalight_solr_core: pulfalight-production

--- a/group_vars/pulfalight/qa.yml
+++ b/group_vars/pulfalight/qa.yml
@@ -37,7 +37,6 @@ pulfalight_db_password: '{{vault_pulfalight_qa_db_password}}'
 rails_app_env: "qa"
 pulfalight_host_name: 'findingaids-qa.princeton.edu'
 pulfalight_honeybadger_key: '{{vault_pulfalight_honeybadger_key}}'
-pulfalight_solr_core: 'pulfalight-qa'
 application_db_name: '{{pulfalight_db_name}}'
 application_dbuser_name: '{{pulfalight_db_user}}'
 application_dbuser_password: '{{pulfalight_db_password}}'
@@ -71,7 +70,7 @@ rails_app_vars:
   - name: APPLICATION_PORT
     value: '{{application_port}}'
   - name: SOLR_URL
-    value: "http://lib-solr8d-staging.princeton.edu:8983/solr/{{ pulfalight_solr_core }}"
+    value: "http://{{ pulfalight_solr_host }}:8983/solr/{{ pulfalight_solr_core }}"
   - name: HONEYBADGER_API_KEY
     value: '{{pulfalight_honeybadger_key}}'
   - name: ASPACE_USER

--- a/group_vars/pulfalight/qa_solr.yml
+++ b/group_vars/pulfalight/qa_solr.yml
@@ -1,0 +1,3 @@
+---
+pulfalight_solr_host: lib-solr8d-staging.princeton.edu
+pulfalight_solr_core: 'pulfalight-qa'

--- a/group_vars/pulfalight/staging.yml
+++ b/group_vars/pulfalight/staging.yml
@@ -38,7 +38,6 @@ pulfalight_db_password: '{{vault_pulfalight_staging_db_password}}'
 rails_app_env: "staging"
 pulfalight_host_name: 'findingaids-staging.princeton.edu'
 pulfalight_honeybadger_key: '{{vault_pulfalight_honeybadger_key}}'
-pulfalight_solr_core: 'pulfalight-staging'
 application_db_name: '{{pulfalight_db_name}}'
 application_dbuser_name: '{{pulfalight_db_user}}'
 application_dbuser_password: '{{pulfalight_db_password}}'
@@ -71,7 +70,7 @@ rails_app_vars:
   - name: APPLICATION_PORT
     value: '{{application_port}}'
   - name: SOLR_URL
-    value: "http://lib-solr8d-staging.princeton.edu:8983/solr/{{ pulfalight_solr_core }}"
+    value: "http://{{ pulfalight_solr_host }}:8983/solr/{{ pulfalight_solr_core }}"
   - name: HONEYBADGER_API_KEY
     value: '{{pulfalight_honeybadger_key}}'
   - name: ASPACE_USER

--- a/group_vars/pulfalight/staging_solr.yml
+++ b/group_vars/pulfalight/staging_solr.yml
@@ -1,0 +1,3 @@
+---
+pulfalight_solr_host: lib-solr8d-staging.princeton.edu
+pulfalight_solr_core: pulfalight-staging

--- a/group_vars/pulmap/production.yml
+++ b/group_vars/pulmap/production.yml
@@ -16,7 +16,7 @@ pulmap_rabbit_user: '{{vault_rabbit_production_user}}'
 pulmap_rabbit_password: '{{vault_rabbit_production_password}}'
 pulmap_rabbit_host: '{{ figgy_rabbit_host }}'
 pulmap_rabbit_server: 'amqp://{{pulmap_rabbit_user}}:{{pulmap_rabbit_password}}@{{pulmap_rabbit_host}}:5672'
-pulmap_solr_url: http://lib-solr8-prod.princeton.edu:8983/solr/pulmap
+pulmap_solr_url: "http://{{ pulmap_solr_host }}:8983/solr/{{ pulmap_solr_collection }}"
 rails_app_name: "pulmap"
 rails_app_directory: "pulmap"
 rails_app_env: "production"

--- a/group_vars/pulmap/production_solr.yml
+++ b/group_vars/pulmap/production_solr.yml
@@ -1,0 +1,3 @@
+---
+pulmap_solr_host: lib-solr8-prod.princeton.edu
+pulmap_solr_collection: pulmap

--- a/group_vars/pulmap/staging.yml
+++ b/group_vars/pulmap/staging.yml
@@ -42,7 +42,7 @@ pg_hba_source: "{{ ansible_host }}/32"
 postgresql_is_local: false
 rails_app_vars:
   - name: PULMAP_SOLR_URL
-    value: 'http://lib-solr8d-staging.princeton.edu:8983/solr/pulmap-staging'
+    value: "http://{{ pulmap_solr_host }}:8983/solr/{{ pulmap_solr_collection }}"
   - name: PULMAP_DB
     value: '{{ application_db_name }}'
   - name: MAP_FEEDBACK_TO

--- a/group_vars/pulmap/staging_solr.yml
+++ b/group_vars/pulmap/staging_solr.yml
@@ -1,0 +1,3 @@
+---
+pulmap_solr_host: lib-solr8d-staging.princeton.edu
+pulmap_solr_collection: pulmap-staging

--- a/playbooks/allsearch_api.yml
+++ b/playbooks/allsearch_api.yml
@@ -10,6 +10,7 @@
     - ../group_vars/allsearch_api/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/dpul/{{ runtime_env | default('staging') }}_solr.yml
+    - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/allsearch_api/vault.yml
   roles:
     - role: roles/rails_app

--- a/playbooks/allsearch_api.yml
+++ b/playbooks/allsearch_api.yml
@@ -11,6 +11,7 @@
     - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/dpul/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}_solr.yml
+    - ../group_vars/pulmap/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/allsearch_api/vault.yml
   roles:
     - role: roles/rails_app

--- a/playbooks/allsearch_api.yml
+++ b/playbooks/allsearch_api.yml
@@ -8,6 +8,7 @@
   vars_files:
     - ../group_vars/allsearch_api/common.yml
     - ../group_vars/allsearch_api/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/allsearch_api/vault.yml
   roles:
     - role: roles/rails_app

--- a/playbooks/allsearch_api.yml
+++ b/playbooks/allsearch_api.yml
@@ -9,6 +9,7 @@
     - ../group_vars/allsearch_api/common.yml
     - ../group_vars/allsearch_api/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
+    - ../group_vars/dpul/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/allsearch_api/vault.yml
   roles:
     - role: roles/rails_app

--- a/playbooks/dpul.yml
+++ b/playbooks/dpul.yml
@@ -8,6 +8,7 @@
   vars_files:
     - ../site_vars.yml
     - ../group_vars/dpul/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/dpul/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/dpul/vault.yml
   roles:
     - role: roles/dpul

--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -9,6 +9,7 @@
   vars_files:
     - ../group_vars/orangelight/common.yml
     - ../group_vars/orangelight/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/orangelight/vault.yml
   roles:
     - role: mailcatcher

--- a/playbooks/pulfalight.yml
+++ b/playbooks/pulfalight.yml
@@ -9,6 +9,7 @@
   vars_files:
     - ../group_vars/all/vars.yml
     - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/pulfalight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/pulfalight/vault.yml
   roles:
     - { role: 'roles/postgresql', tags: 'postgresql' }

--- a/playbooks/pulmap.yml
+++ b/playbooks/pulmap.yml
@@ -8,6 +8,7 @@
   vars_files:
     - ../group_vars/all/vars.yml
     - ../group_vars/pulmap/{{ runtime_env | default('staging') }}.yml
+    - ../group_vars/pulmap/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/pulmap/vault.yml
   roles:
     - role: roles/pulmap


### PR DESCRIPTION
Allsearch-api uses the Solr of certain apps directly (catalog, dpul, pulfalight, maps), so we need to find a way to keep these in sync. 

Since they are all rails apps, we don't want allsearch-api to use their entire config files, because there are conflicting variables, so splitting solr into its own config files by environment.

Connected to #5013
