### PR TITLE
[bibdata-postfix] Bibdata should not be sending emails, remove from allow-list

### DIFF
--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -5,10 +5,6 @@ postfix_allowed_relay_hosts: "/etc/postfix/mynetworks"
 postfix_relay_hosts_addresses:
   - abid-prod1.princeton.edu
   - abid-prod2.princeton.edu
-  - bibdata-prod1.princeton.edu
-  - bibdata-prod2.princeton.edu
-  - bibdata-worker-prod1.princeton.edu
-  - bibdata-worker-prod2.princeton.edu
   - byzantine-tsp-prod1.princeton.edu
   - byzantine-tsp-prod2.princeton.edu
   - catalog1.princeton.edu


### PR DESCRIPTION
Bibdata should not be sending emails, remove from allow-list

Connected to https://github.com/pulibrary/bibdata/issues/2404 and https://github.com/pulibrary/bibdata/pull/2406