### PR TITLE
[globus] install monit

### DIFF
--- a/playbooks/monit.yml
+++ b/playbooks/monit.yml
@@ -1,0 +1,16 @@
+---
+- name: setup monit on pdc_infrastructure
+  hosts: pdc_production:prds_production
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../../group_vars/all/vars.yml
+    - ../../group_vars/all/vault.yml
+
+  roles:
+    - role: roles/monit
+
+  post_tasks:
+    - name: send information to slack
+      ansible.builtin.include_tasks:
+        file: utils/slack_tasks_end_of_playbook.yml

--- a/roles/monit/README.md
+++ b/roles/monit/README.md
@@ -1,0 +1,39 @@
+Role Name
+=========
+
+This role installs monit on our globus infrastructure. It configures the endpoint and monitors the Apache2 webserver and will restart it for us if the service fails
+
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/monit/defaults/main.yml
+++ b/roles/monit/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for roles/monit
+apache_service_name: "apache2"
+monit_conf_dir: "/etc/monit/conf.d"

--- a/roles/monit/handlers/main.yml
+++ b/roles/monit/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+# handlers file for roles/monit
+- name: Restart monit
+  ansible.builtin.service:
+    name: monit
+    state: restarted

--- a/roles/monit/meta/main.yml
+++ b/roles/monit/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  role_name: monit
+  company: Princeton University Library
+  description: Configures Monit on an Endpoint
+  author: pulibrary
+
+  license: MIT
+
+  min_ansible_version: 2.2
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+dependencies:
+  - role: []

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# tasks file for roles/monit
+- name: Monit | Install Monit
+  ansible.builtin.apt:
+    name: monit
+    state: present
+    update_cache: true
+
+- name: Monit | Ensure Monit is running
+  ansible.builtin.service:
+    name: monit
+    state: started
+    enabled: true
+
+- name: Monit | Create Monit configuration for Apache2
+  ansible.builtin.template:
+    src: apache2_monit.conf.j2
+    dest: "{{ monit_conf_dir }}/apache2_monit.conf"
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Restart monit

--- a/roles/monit/templates/apache2_monit.conf.j2
+++ b/roles/monit/templates/apache2_monit.conf.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+check process {{ apache_service_name }}
+  with pidfile /var/run/{{ apache_service_name }}/{{ apache_service_name }}.pid
+  start program = "/usr/sbin/service {{ apache_service_name }} start"
+  stop program  = "/usr/sbin/service {{ apache_service_name }} stop"
+  if failed port 80 protocol http
+    request "/"
+    with timeout 10 seconds
+    then restart
+  if 5 restarts within 5 cycles then timeout
+

--- a/roles/monit/tests/inventory
+++ b/roles/monit/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/monit/tests/test.yml
+++ b/roles/monit/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/monit

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for roles/monit


### PR DESCRIPTION
This role will install monit on an endpoint. It will monitor the apache2
service and restart it when it fails

related to #4719
