### PR TITLE
[loadbalancer + allsearch-api] set the X-Real-IP header to prevent logs from being filtered out

### DIFF
--- a/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
@@ -46,6 +46,7 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         limit_req zone=allsearch-api-prod-ratelimit burst=20 nodelay;
         proxy_cache allsearch-apicache;
     }

--- a/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
@@ -48,6 +48,7 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         limit_req zone=allsearch-api-staging-ratelimit burst=20 nodelay;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
Closes #5069 

I ran this on both load balancers today (25 June)