### PR TITLE
[allsearch-api] Error statuses in JSON format

### DIFF
--- a/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
@@ -51,5 +51,5 @@ server {
         proxy_cache allsearch-apicache;
     }
 
-    include /etc/nginx/conf.d/templates/errors.conf;
+    include /etc/nginx/conf.d/templates/errors-in-json-format.conf;
 }

--- a/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
@@ -56,6 +56,5 @@ server {
         deny all;
     }
 
-    include /etc/nginx/conf.d/templates/errors.conf;
-
+    include /etc/nginx/conf.d/templates/errors-in-json-format.conf;
 }

--- a/roles/nginxplus/files/conf/http/templates/errors-in-json-format.conf
+++ b/roles/nginxplus/files/conf/http/templates/errors-in-json-format.conf
@@ -1,0 +1,38 @@
+# This error handling template is intended for applications
+# like allsearch-api, which attempt to respond in json for
+# all requests
+#
+# The application creates descriptive JSON for 400 and 500
+# status codes, so those are not specifically handled here.
+#
+# More info at https://github.com/pulibrary/allsearch_api/blob/main/architecture-decisions/001_error_output.md
+
+error_page 401 402 404 405 406 407 408 409 411 412 413 414 415 416 417 418 421 422 423 424 426 428 431 451 501 502 503 504 505 506 507 508 510 511 /error.json;
+
+error_page 403 /forbidden.json;
+error_page 413 /too_large.json;
+error_page 429 /ratelimit.json;
+
+    location = /error.json {
+        ssi on;
+        internal;
+        root /var/local/www/default;
+    }
+
+    location = /forbidden.json {
+        ssi on;
+        internal;
+        root /var/local/www/default;
+    }
+
+    location = /too_large.json {
+        ssi on;
+        internal;
+        root /var/local/www/default;
+    }
+
+    location = /ratelimit.json {
+        ssi on;
+        internal;
+        root /var/local/www/default;
+    }

--- a/roles/nginxplus/files/error.json
+++ b/roles/nginxplus/files/error.json
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "problem": "ERROR",
+        "message": "We encountered an error."
+    }
+}

--- a/roles/nginxplus/files/forbidden.json
+++ b/roles/nginxplus/files/forbidden.json
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "problem": "FORBIDDEN",
+        "message": "You are not allowed to access this.  If you are attempting to reach a staging site, check if you are on VPN."
+    }
+}

--- a/roles/nginxplus/files/ratelimit.json
+++ b/roles/nginxplus/files/ratelimit.json
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "problem": "TOO_MANY_REQUESTS",
+        "message": "You are making too many requests.  Please find a way to accomplish your task without making so many requests."
+    }
+}

--- a/roles/nginxplus/files/too_large.json
+++ b/roles/nginxplus/files/too_large.json
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "problem": "CONTENT_TOO_LARGE",
+        "message": "You are making a request that is too large for us to process.  If you are in a browser, check your cookies to make sure you are not sending many large cookies at once."
+    }
+}

--- a/roles/nginxplus/tasks/localhost.yml
+++ b/roles/nginxplus/tasks/localhost.yml
@@ -26,11 +26,19 @@
     mode: "0644"
   when: running_on_server
 
-- name: Nginxplus | add custom error page for default site
+- name: Nginxplus | add custom error pages
   ansible.builtin.copy:
-    src: files/error.html
-    dest: "/var/local/www/default/error.html"
+    src: "files/{{item}}"
+    dest: "/var/local/www/default/{{item}}"
     owner: nginx
     group: nginx
     mode: "0644"
   when: running_on_server
+  tags:
+    - error_pages
+  loop:
+    - "error.html"
+    - "error.json"
+    - "forbidden.json"
+    - "ratelimit.json"
+    - "too_large.json"


### PR DESCRIPTION
This allows 400 and 500 JSON responses through from the application, and returns other errors in JSON format, rather than the standard "Something went wrong" html page.

Closes #4396

For background information on why we'd like to offer JSON errors, see [this ADR in allsearch_api](https://github.com/pulibrary/allsearch_api/blob/main/architecture-decisions/001_error_output.md)

I ran this on both load balancers today.