### PR TITLE
Pull exact IPs in the firewall playbook

### DIFF
--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -31,7 +31,7 @@
 
     - name: set filter condition
       ansible.builtin.set_fact:
-        filter_condition: 'value contains '
+        filter_condition: "value == "
 
     - name: set filter IP
       ansible.builtin.set_fact:
@@ -60,18 +60,17 @@
       register: sec_rules
 
     - name: Display rules for selected VM
-      vars: 
+      vars:
         output: "{{ VM_host_name }} allows the following traffic:\n
-            {% for item in sec_rules.gathered %}
-              {{ item.rule_name }}\n
-              Packets that match the signature for these applications {{ item.application }}\n
-              Any packets on the port(s) related to these services {{ item.service }}\n
-              From these source addresses (machine or subnet): {{ item.source_ip }}\n
-              \n
-                 {% endfor %}"
+          {% for item in sec_rules.gathered %}
+          {{ item.rule_name }}\n
+          Packets that match the signature for these applications {{ item.application }}\n
+          Any packets on the port(s) related to these services {{ item.service }}\n
+          From these source addresses (machine or subnet): {{ item.source_ip }}\n
+          \n
+          {% endfor %}"
       ansible.builtin.debug:
         msg: "{{ output.split('\n') }}"
-
 # Future work - create tasks to make changes:
 # - name: Generate a new Palo Alto rule set
 #   paloaltonetworks.panos.panos_security_rule:

--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -43,7 +43,7 @@
 
     - name: create filter from condition and IP
       ansible.builtin.set_fact:
-        filter_input: "{{ filter_condition }}{{filter_ip }}"
+        filter_input: "{{ filter_condition }}{{filter_ip }}/32"
 
     - name: find object from filter
       paloaltonetworks.panos.panos_address_object:

--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -37,6 +37,10 @@
       ansible.builtin.set_fact:
         filter_ip: '{{ ip_in_question.stdout | regex_findall("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+") | first  }}'
 
+    - name: Display the filter_ip var
+      ansible.builtin.debug:
+        var: "{{ filter_ip }}"
+
     - name: create filter from condition and IP
       ansible.builtin.set_fact:
         filter_input: "{{ filter_condition }}{{filter_ip }}"

--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -39,7 +39,7 @@
 
     - name: Display the filter_ip var
       ansible.builtin.debug:
-        var: "{{ filter_ip }}"
+        var: filter_ip
 
     - name: create filter from condition and IP
       ansible.builtin.set_fact:
@@ -54,7 +54,7 @@
 
     - name: Display the test_object var
       ansible.builtin.debug:
-        var: "{{ test_object }}"
+        var: test_object
 
     - name: Display the object address
       ansible.builtin.debug:

--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -50,7 +50,7 @@
 
     - name: Display the test_object var
       ansible.builtin.debug:
-        var: "{{ test_object.gathered[0].name }}"
+        var: "{{ test_object }}"
 
     - name: Display the object address
       ansible.builtin.debug:

--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -37,10 +37,6 @@
       ansible.builtin.set_fact:
         filter_ip: '{{ ip_in_question.stdout | regex_findall("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+") | first  }}'
 
-    - name: Display the filter_ip var
-      ansible.builtin.debug:
-        var: filter_ip
-
     - name: create filter from condition and IP
       ansible.builtin.set_fact:
         filter_input: "{{ filter_condition }}{{filter_ip }}/32"
@@ -51,10 +47,6 @@
         state: gathered
         gathered_filter: "{{ filter_input }}"
       register: test_object
-
-    - name: Display the test_object var
-      ansible.builtin.debug:
-        var: test_object
 
     - name: Display the object address
       ansible.builtin.debug:

--- a/playbooks/utils/firewall_update.yml
+++ b/playbooks/utils/firewall_update.yml
@@ -48,6 +48,10 @@
         gathered_filter: "{{ filter_input }}"
       register: test_object
 
+    - name: Display the test_object var
+      ansible.builtin.debug:
+        var: "{{ test_object.gathered[0].name }}"
+
     - name: Display the object address
       ansible.builtin.debug:
         msg: "{{ VM_host_name }} is represented in the firewall as: {{ test_object.gathered[0].name }}"


### PR DESCRIPTION
Closes #4892.

We have cleaned up the data in the firewall enough now that we can pull exact IP addresses (with `/32` at the end). This change will find the exact IP and return rules for it.

Still fails if the FQDN is not represented in the firewall at all. We can make a separate ticket for that if we decide to handle it. 