### PR TITLE
[nginx] use CDH error page for prod shakespeare and co

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_shakespeareandco.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_shakespeareandco.conf
@@ -70,7 +70,7 @@ server {
         proxy_read_timeout         2h;
         health_check interval=10 fails=3 passes=2;
     }
-    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
+    include /etc/nginx/conf.d/templates/cdh-errors.conf;
 }
 
 server {


### PR DESCRIPTION
Closes #1340.

Updates the nginx configuration for the production Shakespeare & Co. site to use the custom CDH error page instead of the old "prod-maintenance" page.
