### PR TITLE
first attempt to redirect PUDL viewer URLs

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
@@ -1,6 +1,8 @@
 # arks redirects
     rewrite ^/objects/(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
+    rewrite ^/viewer.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
+
     rewrite ^/sheetreader.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
 # dpul redirects

--- a/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
@@ -1,9 +1,9 @@
 # arks redirects
     rewrite ^/objects/(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
-    rewrite ^/viewer.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
-
     rewrite ^/sheetreader.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
+
+    rewrite ^/viewer.php?obj=(.*)?(?=#)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
 # dpul redirects
 #

--- a/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
@@ -3,13 +3,13 @@
 
     rewrite ^/sheetreader.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
-    # rewrite ^/viewer.php?obj=(.*)?(?=#)$ https://arks.princeton.edu/ark://88435/$1 redirect;
+    rewrite ^/viewer(.*)$ https://arks.princeton.edu/ark://88435/$arg_obj? permanent;
 
     # rewrite ^/viewer.php\?obj=([a-z0-9]+)(\#.*)?$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
-    if ($args ~* "viewer.php?obj=.*") {
-        rewrite ^ https://arks.princeton.edu/ark://88435/$arg_param1? redirect;
-    }
+    # if ($args ~* "/viewer.php?obj=.*") {
+    #     rewrite ^ https://arks.princeton.edu/ark://88435/$arg_obj? redirect;
+    # }
 
 # dpul redirects
 #

--- a/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
@@ -3,10 +3,14 @@
 
     rewrite ^/sheetreader.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
-    #rewrite ^/viewer.php?obj=(.*)?(?=#)$ https://arks.princeton.edu/ark://88435/$1 redirect;
+    # rewrite ^/viewer.php?obj=(.*)?(?=#)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
-    rewrite ^/viewer.php\?obj=([a-z0-9]+)(\#.*)?$ https://arks.princeton.edu/ark://88435/$1 redirect;
-    
+    # rewrite ^/viewer.php\?obj=([a-z0-9]+)(\#.*)?$ https://arks.princeton.edu/ark://88435/$1 redirect;
+
+    if ($args ~* "viewer.php?obj=.*") {
+        rewrite ^ https://arks.princeton.edu/ark://88435/$arg_param1? redirect;
+    }
+
 # dpul redirects
 #
     rewrite ^/search.php(.*)$ https://dpul.princeton.edu/search.php$1 redirect;

--- a/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
+++ b/roles/nginxplus/files/conf/http/templates/pudl_proxy_pass.conf
@@ -3,8 +3,10 @@
 
     rewrite ^/sheetreader.php?obj=(.*)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
-    rewrite ^/viewer.php?obj=(.*)?(?=#)$ https://arks.princeton.edu/ark://88435/$1 redirect;
+    #rewrite ^/viewer.php?obj=(.*)?(?=#)$ https://arks.princeton.edu/ark://88435/$1 redirect;
 
+    rewrite ^/viewer.php\?obj=([a-z0-9]+)(\#.*)?$ https://arks.princeton.edu/ark://88435/$1 redirect;
+    
 # dpul redirects
 #
     rewrite ^/search.php(.*)$ https://dpul.princeton.edu/search.php$1 redirect;


### PR DESCRIPTION
Closes #4566.

Currently PUDL URLs with `viewer.php` return errors. We should be able to redirect them. Doesn't work yet, but hoping to figure this out soon.
