### PR TITLE
Override the default org-wide issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Tell us about something that's broken
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Actual behavior
+Include screenshots, or links and browser version if relevant
+
+### Steps to replicate
+How would someone else make this error happen?
+
+### Impact of this bug
+E.g. "I can't work until this is fixed" or "I have a workaround"
+
+### Relevant links and code snippets, if applicable
+
+```
+```
+
+### Implementation notes, if any

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
+### User story
+What do you want our ansible automation to do that it does not do today?
+
+### Acceptance criteria
+What would prov=e that the new feature works? Be specific.
+
+- [ ] When I do X, I get Y.
+- [ ] I can . . .
+- [ ] ...
+
+### Concrete example
+
+### Implementation notes, if any


### PR DESCRIPTION
Closes #5089.

Many of the org-wide issues templates make no sense in this repo. This PR includes the most relevant templates for issues in prancible.
