### PR TITLE
Ensuring that tiger-data-app utilizes NodeJS 18.14.0 releases

### DIFF
--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -16,7 +16,7 @@ app_host_name: '{{ passenger_server_name }}'
 application_host_protocol: 'https'
 running_on_server: true
 tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
-desired_nodejs_version: 'v18.13.0'
+desired_nodejs_version: 'v18.14.0'
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.2.3"

--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -19,7 +19,7 @@ tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
 desired_nodejs_version: 'v18.14.0'
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
-ruby_version_override: "ruby-3.2.3"
+ruby_version_override: "ruby-3.3.0"
 passenger_app_root: "/opt/tigerdata/current/public"
 passenger_extra_config: "passenger_preload_bundler on;"
 nginx_remove_default_vhost: true


### PR DESCRIPTION
Resolves https://github.com/pulibrary/tiger-data-app/issues/776