### PR TITLE
Proxy prodigy servers on port 80 instead of 8080

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
@@ -4,8 +4,8 @@ proxy_cache_path /data/nginx/prodigy/NGINX_cache/ keys_zone=prodigycache:10m;
 upstream prodigy {
     least_time header 'inflight';
     zone prodigy 64k;
-    server cdh-prodigy1.princeton.edu:8080;
-    server cdh-prodigy2.princeton.edu:8080;
+    server cdh-prodigy1.princeton.edu:80;
+    server cdh-prodigy2.princeton.edu:80;
     sticky learn
           create=$upstream_cookie_prodigycookie
           lookup=$cookie_prodigycookie

--- a/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
@@ -3,8 +3,8 @@ proxy_cache_path /data/nginx/test_prodigy/NGINX_cache/ keys_zone=test_prodigycac
 
 upstream test_prodigy {
     zone prod_prodigy 64k;
-    server cdh-test-prodigy1.princeton.edu:8080;
-    server cdh-test-prodigy2.princeton.edu:8080;
+    server cdh-test-prodigy1.princeton.edu:80;
+    server cdh-test-prodigy2.princeton.edu:80;
     sticky learn
           create=$upstream_cookie_test_prodigycookie
           lookup=$cookie_test_prodigycookie


### PR DESCRIPTION
This switches the nginxplus config for cdh-prodigy and cdh-test-prodigy from proxying port 8080 to port 80

I discovered that I need to serve out content alongside the application, so I'm setting up nginx on the VMs to proxy the 8080 port and serve out static content.

