### PR TITLE
add openbooks-prod1 back into inventory

### DIFF
--- a/inventory/all_projects/openbooks
+++ b/inventory/all_projects/openbooks
@@ -1,5 +1,5 @@
 [openbooks_production]
-# openbooks-prod1.princeton.edu
+openbooks-prod1.princeton.edu
 openbooks-prod2.princeton.edu
 [openbooks_staging]
 # openbooks-staging1.princeton.edu


### PR DESCRIPTION
As part of auditing our response to a recent CVE, we discovered that updates were not reaching the openbooks-prod1 VM. It turned out the line had been commented out in our inventory.

This PR restores openbooks-prod1 to the inventory so it will get updates along with our other servers.