### PR TITLE
Adds playbook to delete old files from /alma directory

### DIFF
--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -26,8 +26,12 @@
 
     - name: show old files
       ansible.builtin.debug:
-        var: item
-      loop: "{{ files_to_delete | dict2items }}"
+        var: item.path
+      loop: "{{ files_to_delete.files }}"
+      # msg: "{{ files_to_delete[item.path] }}"
+    # loop: "{{ files_to_delete.keys() | list }}"
+    # The task includes an option with an undefined variable.
+    # The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'path'.
 
     - name: delete old files
       ansible.builtin.file:

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -28,16 +28,12 @@
       ansible.builtin.debug:
         msg: this playbook will delete "{{ item.path }}"
       loop: "{{ files_to_delete.files }}"
-      # msg: "{{ files_to_delete[item.path] }}"
-    # loop: "{{ files_to_delete.keys() | list }}"
-    # The task includes an option with an undefined variable.
-    # The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'path'.
 
     - name: delete old files
       ansible.builtin.file:
-        path: "{{ item }}"
+        path: "{{ item.path }}"
         state: absent
-      loop: "{{ files_to_delete }}"
+      loop: "{{ files_to_delete.files }}"
 
   post_tasks:
     - name: let folks on slack know the state of the directories

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -26,7 +26,7 @@
 
     - name: show old files
       ansible.builtin.debug:
-        var: item.path
+        msg: this playbook will delete "{{ item.path }}"
       loop: "{{ files_to_delete.files }}"
       # msg: "{{ files_to_delete[item.path] }}"
     # loop: "{{ files_to_delete.keys() | list }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -19,7 +19,7 @@
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
         paths: /alma/publishing
-        age: "{{ number_of_weeks }}"
+        age: "{{ number_of_weeks | default(16) }}"
         file_type: file
         recurse: true
       register: files_to_delete

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -26,8 +26,8 @@
 
     - name: show old files
       ansible.builtin.debug:
-        var: "{{ item }}"
-      loop: "{{ files_to_delete }}"
+        var: item
+      loop: "{{ files_to_delete | dict2items }}"
 
     - name: delete old files
       ansible.builtin.file:

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -4,12 +4,23 @@
   remote_user: pulsys
   become: true
 
+  vars:
+    slack_alerts_channel: infrastructure
+
   tasks:
+
+    - set_fact:
+        mount: "{{ ansible_mounts[0] }}"
+    - set_fact: disk_usage="{{ mount.size_total - mount.size_available }}"
+    - set_fact: disk_usage_ratio="{{ disk_usage|float / mount.size_total }}"
+    - set_fact: disk_usage_s="{{ (disk_usage|float / 1000000000) | round(1, 'common') }}GB"
+    - set_fact: disk_total_s="{{ (mount.size_total / 1000000000) | round(1, 'common') }}GB"
+
     - name: identify old files
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
         paths: /alma
-        age: 12w # twelve weeks old, roughly 3 months
+        age: 20w # twelve weeks old, roughly 3 months
         filetype: file
         recurse: true
       register: files_to_delete
@@ -23,3 +34,10 @@
         path: "{{ item }}"
         state: absent
       loop: "{{ files_to_delete }}"
+
+  post_tasks:
+  - name: let folks on slack know the state of the directories
+    community.general.slack:
+      token: "{{ vault_tower_slack_token }}"
+      msg: "Ansible has successfully deleted old files from /alma on libsftp_{{ runtime_env | default('staging') }}. The {{ ansible_mounts[0].mount }} disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+      channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -18,10 +18,10 @@
     - name: identify old files
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
-        paths: "{{ alma_path }}"
+        paths: /alma/{{ alma_subdir }}
         age: "{{ number_of_weeks | default(52) }}"
         file_type: file
-        recurse: true
+        recurse: false
       register: files_to_delete
 
     - name: show old files

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -1,0 +1,25 @@
+---
+- name: Delete oldest files from /alma directories
+  hosts: libsftp_{{ runtime_env | default 'production'}}
+  remote_user: pulsys
+  become: true
+
+  tasks:
+    - name: identify old files
+      # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
+      ansible.builtin.find:
+        paths: /alma
+        age: 12w # twelve weeks old, roughly 3 months
+        filetype: file
+        recurse: true
+      register: files_to_delete
+
+    - name: show old files
+      ansible.builtin.debug:
+        var: "{{ files_to_delete }}"
+
+    - name: delete old files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ files_to_delete }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -19,7 +19,7 @@
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
         paths: /alma/publishing
-        age: 20w # twelve weeks old, roughly 3 months
+        age: "{{ number_of_weeks }}"
         file_type: file
         recurse: true
       register: files_to_delete
@@ -39,5 +39,5 @@
     - name: let folks on slack know the state of the directories
       community.general.slack:
         token: "{{ vault_tower_slack_token }}"
-        msg: "Ansible has successfully deleted old files from /alma on libsftp_{{ runtime_env | default('staging') }}. The {{ ansible_mounts[0].mount }} disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+        msg: "Ansible has deleted old files on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
         channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -18,8 +18,8 @@
     - name: identify old files
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
-        paths: /alma/publishing
-        age: "{{ number_of_weeks | default(16) }}"
+        paths: "{{ alma_path }}"
+        age: "{{ number_of_weeks | default(52) }}"
         file_type: file
         recurse: true
       register: files_to_delete
@@ -39,5 +39,5 @@
     - name: let folks on slack know the state of the directories
       community.general.slack:
         token: "{{ vault_tower_slack_token }}"
-        msg: "Ansible has deleted old files on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+        msg: "Ansible has deleted old files from {{ alma_path }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
         channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -1,6 +1,6 @@
 ---
 - name: Delete oldest files from /alma directories
-  hosts: libsftp_{{ runtime_env | default 'production'}}
+  hosts: libsftp_{{ runtime_env | default ('staging') }}
   remote_user: pulsys
   become: true
 
@@ -8,7 +8,6 @@
     slack_alerts_channel: infrastructure
 
   tasks:
-
     - set_fact:
         mount: "{{ ansible_mounts[0] }}"
     - set_fact: disk_usage="{{ mount.size_total - mount.size_available }}"
@@ -19,15 +18,16 @@
     - name: identify old files
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
-        paths: /alma
+        paths: /alma/publishing
         age: 20w # twelve weeks old, roughly 3 months
-        filetype: file
+        file_type: file
         recurse: true
       register: files_to_delete
 
     - name: show old files
       ansible.builtin.debug:
-        var: "{{ files_to_delete }}"
+        var: "{{ item }}"
+      loop: "{{ files_to_delete }}"
 
     - name: delete old files
       ansible.builtin.file:
@@ -36,8 +36,8 @@
       loop: "{{ files_to_delete }}"
 
   post_tasks:
-  - name: let folks on slack know the state of the directories
-    community.general.slack:
-      token: "{{ vault_tower_slack_token }}"
-      msg: "Ansible has successfully deleted old files from /alma on libsftp_{{ runtime_env | default('staging') }}. The {{ ansible_mounts[0].mount }} disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
-      channel: "{{ slack_alerts_channel }}"
+    - name: let folks on slack know the state of the directories
+      community.general.slack:
+        token: "{{ vault_tower_slack_token }}"
+        msg: "Ansible has successfully deleted old files from /alma on libsftp_{{ runtime_env | default('staging') }}. The {{ ansible_mounts[0].mount }} disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -19,7 +19,7 @@
       # equivalent of find /alma/ -type f -not -newermt "2024-01-01" -ls
       ansible.builtin.find:
         paths: /alma/{{ alma_subdir }}
-        age: "{{ number_of_weeks | default(52) }}"
+        age: "{{ number_of_weeks | default(52) }}w"
         file_type: file
         recurse: false
       register: files_to_delete


### PR DESCRIPTION
Closes [bibdata issue 2401.](https://github.com/pulibrary/bibdata/issues/2401) and [lib_jobs issue 795](https://github.com/pulibrary/lib_jobs/issues/795)

This playbook should find, list, and delete all files in the /alma directories older than  limit we set. For testing purposes, setting the limit to 20 weeks and running against staging. 