### PR TITLE
[cdh] access to nfs mounts

### DIFF
--- a/group_vars/nfsserver/production.yml
+++ b/group_vars/nfsserver/production.yml
@@ -176,6 +176,20 @@ nfsserver_exports:
           - no_subtree_check
           - no_root_squash
           - no_wdelay
+      - name: "{{ cdh_web3 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
+      - name: "{{ cdh_web4 }}"
+        options:
+          - rw
+          - sync
+          - no_subtree_check
+          - no_root_squash
+          - no_wdelay
   - share: "{{ open_marc_records_mount }}"
     hosts:
       - name: "{{ lib_jobs_prod1 }}"


### PR DESCRIPTION
merged the last [PR](https://github.com/pulibrary/princeton_ansible/pull/5134) too hastily. This allows the cdh-web{3,4} vms access
to the shares.
