### PR TITLE
adds a template for requesting VMs

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_vm.md
+++ b/.github/ISSUE_TEMPLATE/new_vm.md
@@ -1,0 +1,38 @@
+---
+name: Request a new VM
+about: Assemble the necessary information to request a new VM
+title: ''
+labels: ''
+assignees: ''
+
+---
+### Describe the VM(s) you need
+
+If you do not know the answers to some of these questions, that's okay. Please add the information you do have, and we will work together to gather any other information we need.
+
+Which project are these VMs for?
+- [ ] Project:
+
+How many VMs do you need?
+- [ ] Number of VMs:
+
+What should the FQDN(s) be? (for example, our-new-project-staging1.princeton.edu):
+- [ ] FQDN:
+
+What resources does each VM need?
+- [ ] Number of CPUs per VM:
+- [ ] Amount of memory per VM (in GB):
+- [ ] Amount of storage/disk space per VM (in GB):
+
+What firewall changes should be made? (for example, port 22 for SSH, etc.)
+- [ ] Port number(s)
+- [ ] Service(s) 
+
+What shared resources should be mounted? (for example, Isilon drives)
+- [ ] Resources to mount:
+
+### Relevant deadlines
+If the new VMs must be ready by a certain date, please enter it here.
+- [ ] EOL Date MM/DD/YYYY
+
+### Implementation notes, if any

--- a/.github/ISSUE_TEMPLATE/new_vm.md
+++ b/.github/ISSUE_TEMPLATE/new_vm.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 ### Describe the VM(s) you need
 
-If you do not know the answers to some of these questions, that's okay. Please add the information you do have, and we will work together to gather any other information we need.
+If you do not know the answers to some of these questions, that's okay. Please add the information you do have, and we will work together to gather any other information we need. You can also look at the [documentation](https://github.com/pulibrary/pul-it-handbook/blob/main/services/new_vms_for_devs.md) in pul-it-handbook.
 
 Which project are these VMs for?
 - [ ] Project:
@@ -19,7 +19,7 @@ How many VMs do you need?
 What should the FQDN(s) be? (for example, our-new-project-staging1.princeton.edu):
 - [ ] FQDN:
 
-What resources does each VM need?
+What virtual resources does each VM need?
 - [ ] Number of CPUs per VM:
 - [ ] Amount of memory per VM (in GB):
 - [ ] Amount of storage/disk space per VM (in GB):
@@ -28,11 +28,11 @@ What firewall changes should be made? (for example, port 22 for SSH, etc.)
 - [ ] Port number(s)
 - [ ] Service(s) 
 
-What shared resources should be mounted? (for example, Isilon drives)
-- [ ] Resources to mount:
+What else should we add to each VM? (for example, mount Isilon drives, add NFS server access)
+- [ ] Additional resources:
 
 ### Relevant deadlines
 If the new VMs must be ready by a certain date, please enter it here.
-- [ ] EOL Date MM/DD/YYYY
+- [ ] We need these VMs by: MM/DD/YYYY
 
 ### Implementation notes, if any


### PR DESCRIPTION
Closes #5128.

Creates a template for requesting new VMs. This is not meant to be a required form. It's more of a place to gather whatever information the requester has about a request for new resources.

Builds on [existing documentation](https://github.com/pulibrary/pul-it-handbook/blob/main/services/new_vms_for_devs.md).

