### PR TITLE
updates capistrano version for towerdeploy

### DIFF
--- a/roles/towerdeploy/defaults/main.yml
+++ b/roles/towerdeploy/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for towerdeploy
-cap_version: "3.17.2"
+cap_version: "3.18.0"


### PR DESCRIPTION
Closes #5137.

Update to Capistrano 3.18 to match the recent [update to orcid_princeton](https://github.com/pulibrary/orcid_princeton/pull/165/commits/3952fd792eaa38bee0c990ee34af01e6380c7535).

Should be backwards-compatible.