### PR TITLE
Remove locator from inventory

### DIFF
--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -30,7 +30,6 @@ lib_fs_production
 lib_svn_production
 libwww_production
 loadtest_production
-locator_production
 lockers_and_study_spaces_production
 mediaflux_production
 monitor_backends

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -28,7 +28,6 @@ libstatic_staging
 lib_fs_staging
 lib_svn_staging
 libwww_staging
-locator_staging
 lockers_and_study_spaces_staging
 mediaflux_staging
 mudd_staging

--- a/inventory/by_team/dacs
+++ b/inventory/by_team/dacs
@@ -20,8 +20,6 @@ lib_jobs_production
 lib_jobs_staging
 libwww_production
 libwww_staging
-locator_production
-locator_staging
 lockers_and_study_spaces_production
 lockers_and_study_spaces_staging
 mudd_production


### PR DESCRIPTION
The locator is deprecated and was mostly removed a couple days ago. This just removes it from the inventory.