### PR TITLE
[CheckMK] strip the '.princeton.edu' from inventory for checkmk host names

### DIFF
--- a/playbooks/utils/checkmk_agent.yml
+++ b/playbooks/utils/checkmk_agent.yml
@@ -16,5 +16,14 @@
     #- ../../group_vars/all/checkmk.yml  # this is the likely correct path when prod goes live
     - ../../group_vars/checkmk/vault.yml
 
+  pre_tasks:
+    - name: set stripped agent hostname as fact
+      ansible.builtin.set_fact:
+        checkmk_agent_host_name: "{{ inventory_hostname | regex_search('^[^.]*') }}"
+
+    - name: did that regex work?
+      ansible.builtin.debug:
+        var: checkmk_agent_host_name
+
   roles:
     - role: checkmk.general.agent


### PR DESCRIPTION
Up to now host names in CheckMK have reflected our inventory host names, including the `.princeton.edu` extension. However, the VMs in vSphere/VMware do not have the `.princeton.edu` extension. This discrepancy has interfered with the "piggybacking" functionality which combines data gathered directly from the agent on a VM with data gathered from vSphere. 

Instead of creating a regex rule in CheckMK to map the host names to the vSphere names, this PR would strip the `.princeton.edu` (which is not all that useful) from the host names. I've run this for the ORCID staging project, we can test whether it enables piggybacking or not.
