### PR TITLE
Specifically request error messages for bug reports, with hint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,13 +11,16 @@ assignees: ''
 A clear and concise description of what you expected to happen.
 
 ### Actual behavior
-Include screenshots, or links and browser version if relevant
+Include screenshots, or links and browser version if relevant.
+
+### Error messages
+Include any error messages from STDOUT, STDERR, log files, etc., that you did not include under 'Actual behavior' above.
 
 ### Steps to replicate
 How would someone else make this error happen?
 
 ### Impact of this bug
-E.g. "I can't work until this is fixed" or "I have a workaround"
+E.g. "I can't work until this is fixed" or "I have a workaround".
 
 ### Relevant links and code snippets, if applicable
 


### PR DESCRIPTION
Updates the 'bug report' template by adding a section explicitly calling for errors from log files or STDOUT/STDERR.