### PR TITLE
[checkmk] enable checkmk playbook to run

### DIFF
--- a/playbooks/checkmk.yml
+++ b/playbooks/checkmk.yml
@@ -1,6 +1,9 @@
 ---
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
+# your environment may not have the checkmk collection if this fails.
+#  run `ansible-galaxy collection install checkmk.general --force`
+#  the re-run the playbook
 - name: build the checkmk site
   hosts: pulcheck_{{ runtime_env | default('staging') }}
   remote_user: pulsys
@@ -28,7 +31,8 @@
     #        roles:
     #          - "admin"
     #      run_once: true
-    #
+  post_tasks:
+    - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"


### PR DESCRIPTION
the playbook was failing with the absence of the post_task. We also add
a comment on the playbook on the need to run `ansible-galaxy collection install checkmk.general --force` if the playbook fails to run in a new environment

closes #5161

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
