### PR TITLE
Tidy up alma cleanup playbook

### DIFF
--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -29,15 +29,15 @@
         msg: this playbook will delete "{{ item.path }}"
       loop: "{{ files_to_delete.files }}"
 
-    - name: delete old files
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: absent
-      loop: "{{ files_to_delete.files }}"
-
-  post_tasks:
-    - name: let folks on slack know the state of the directories
-      community.general.slack:
-        token: "{{ vault_tower_slack_token }}"
-        msg: "Ansible has deleted old files from {{ alma_path }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
-        channel: "{{ slack_alerts_channel }}"
+  #   - name: delete old files
+  #     ansible.builtin.file:
+  #       path: "{{ item.path }}"
+  #       state: absent
+  #     loop: "{{ files_to_delete.files }}"
+  # 
+  # post_tasks:
+  #   - name: let folks on slack know the state of the directories
+  #     community.general.slack:
+  #       token: "{{ vault_tower_slack_token }}"
+  #       msg: "Ansible has deleted old files from {{ alma_path }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+  #       channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -4,8 +4,11 @@
   remote_user: pulsys
   become: true
 
+vars_files:
+  - ../../group_vars/all/vault.yml
+
   vars:
-    slack_alerts_channel: infrastructure
+    slack_alerts_channel: ansible-alerts
 
   tasks:
     - set_fact:
@@ -29,15 +32,15 @@
         msg: this playbook will delete "{{ item.path }}"
       loop: "{{ files_to_delete.files }}"
 
-  #   - name: delete old files
-  #     ansible.builtin.file:
-  #       path: "{{ item.path }}"
-  #       state: absent
-  #     loop: "{{ files_to_delete.files }}"
-  # 
-  # post_tasks:
-  #   - name: let folks on slack know the state of the directories
-  #     community.general.slack:
-  #       token: "{{ vault_tower_slack_token }}"
-  #       msg: "Ansible has deleted old files from {{ alma_path }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
-  #       channel: "{{ slack_alerts_channel }}"
+    - name: delete old files
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ files_to_delete.files }}"
+  
+  post_tasks:
+    - name: let folks on slack know the state of the directories
+      community.general.slack:
+        token: "{{ vault_tower_slack_token }}"
+        msg: "Ansible has deleted old files from {{ alma_path }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+        channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -29,8 +29,7 @@
 
     - name: show old files
       ansible.builtin.debug:
-        msg: this playbook will delete "{{ item.path }}"
-      loop: "{{ files_to_delete.files }}"
+        msg: this playbook will delete "{{ files_to_delete.files | map(attribute='path') | list | join(", ") }}"
 
     - name: delete old files
       ansible.builtin.file:
@@ -42,5 +41,5 @@
     - name: let folks on slack know the state of the directories
       community.general.slack:
         token: "{{ vault_tower_slack_token }}"
-        msg: "Ansible has deleted old files from {{ alma_path }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
+        msg: "Ansible has deleted old files from /alma/{{ alma_subdir }} on libsftp_{{ runtime_env | default('staging') }}. The `{{ ansible_mounts[0].mount }}` disk was using {{ disk_usage_s }} or {{ disk_usage_ratio }} of the space, before deleting."
         channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/clean_up_alma_dir.yml
+++ b/playbooks/utils/clean_up_alma_dir.yml
@@ -4,8 +4,8 @@
   remote_user: pulsys
   become: true
 
-vars_files:
-  - ../../group_vars/all/vault.yml
+  vars_files:
+    - ../../group_vars/all/vault.yml
 
   vars:
     slack_alerts_channel: ansible-alerts


### PR DESCRIPTION
With this PR, we see a single list of the files to be deleted in each directory, instead of a section for each file with connection details, etc.

We also tested the playbook in Tower, and it seems to be working well.

Partial fix for https://github.com/pulibrary/princeton_ansible/issues/5178