### PR TITLE
[video_reserves] Allow all traffic to videoreserves-prod.princeton.edu, not just princeton network

### DIFF
--- a/roles/nginxplus/files/conf/http/videoreserves_prod.conf
+++ b/roles/nginxplus/files/conf/http/videoreserves_prod.conf
@@ -42,10 +42,6 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
 #        health_check interval=10 fails=3 passes=2 uri=/talkback/get-in-touch;
-        # allow princeton network
-        include /etc/nginx/conf.d/templates/restrict.conf;
-        # block all
-        deny all;
     }
 
     include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
Previously, we only allowed requests to videoreserves-prod.princeton.edu if you were on the Princeton network.  Other users needed to access the site via a library.princeton.edu proxy pass rule.

We are going to get rid of that proxy pass rule as part of the website migration, so we're telling the load balancer to allow traffic to this domain.

Closes #5189 

I ran this on the prod load balancer today, 22 July 2024