### PR TITLE
implements 'clean' step for yum repos

### DIFF
--- a/playbooks/os_updates.yml
+++ b/playbooks/os_updates.yml
@@ -33,8 +33,8 @@
       when: ansible_os_family == "RedHat"
 
     - name: RedHat | clear local repository
-      ansible.builtin.yum:
-        clean: true
+      ansible.builtin.command:
+        cmd: sudo yum clean all
       when: ansible_os_family == "RedHat"
 
     - name: Ubuntu | remove dependencies that are no longer required
@@ -58,6 +58,12 @@
       register: reboot_required_file
       when: ansible_os_family == "Debian"
 
+    # - name: RedHat | Note RH machines that need reboots
+    #   ansible.builtin.set_fact: needs_reboot=true
+    #   when:
+    #     - ansible_os_family == "RedHat"
+    #     - yum_update_status.changed
+
     - name: RedHat | Reboot if required
       ansible.builtin.reboot:
         msg: "Reboot initiated by Ansible because of yum updates."
@@ -69,6 +75,7 @@
       when: 
         - ansible_os_family == "RedHat"
         - yum_update_status.changed
+        - "'ansible' not in inventory_hostname"
 
     - name: Ubuntu | Reboot if required
       ansible.builtin.reboot:
@@ -87,3 +94,15 @@
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
         channel: "{{ slack_alerts_channel }}"
+
+  post_tasks:
+    - name: notify ops to reboot the ansible servers if needed
+      community.general.slack:
+        token: "{{ vault_pul_slack_token }}"
+        msg: "@ops {{ inventory_hostname }} needs a reboot"
+        channel: "{{ slack_alerts_channel }}"
+      when: 
+        - ansible_os_family == "RedHat"
+        - yum_update_status.changed
+        - "'ansible' in inventory_hostname"
+


### PR DESCRIPTION
Closes #5168.

Since the `yum` module does not have a `clean` option, uses a `command` task instead.

We ran into a problem trying to run this on Tower when the RHEL boxes did get updated - because the Tower job rebooted the VM on which the Tower job was running . . . So this PR now reboots only RH-family VMs that are NOT Tower-related, and sends a slack alert to the ops team to reboot the Ansible machines by hand.
