### PR TITLE
Supports rebooting a VM from Tower

### DIFF
--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -1,18 +1,10 @@
 ---
-- name: List all VMs in the dev vSphere
+- name: Get info on VM, with option to reboot
   hosts: localhost
-  # remote_user: pulsys
-  # become: true
 
   vars_files:
     - ../../group_vars/vsphere/vault.yml
     - ../../group_vars/vsphere/{{ runtime_env | default('staging') }}.yml
-
-  # vars:
-  #   vcenter_host:
-  #   vcenter_username:
-  #   vcenter_password:
-  #   vcenter_validate_certs: false
 
   tasks:
     - name: Gather state of VM to reboot
@@ -21,27 +13,23 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        cluster: "{{ vcenter_cluster }}"
+        show_datacenter: true
+        show_cluster: true
+        show_esxi_hostname: true
         vm_name: "{{ vm_to_reboot }}"
       register: vm_info
 
-    - name: View VM state
+    - name: View host and storage info for VM
       ansible.builtin.debug:
-        var: vm_info
+        msg: The {{ vm_to_reboot }} VM is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host, with storage on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage in vSphere.
 
-    # - name: Reboot a virtual machine using UUID
-    #   community.vmware.vmware_guest_powerstate:
-    #     hostname: "{{ vcenter_hostname }}"
-    #     username: "{{ vcenter_username }}"
-    #     password: "{{ vcenter_password }}"
-    #     validate_certs: false
-    #     datacenter: "{{ vcenter_datacenter }}"
-    #     cluster: "{{ vcenter_cluster }}"
-    #     uuid: "{{ vm_info.uuid }}"
-    #     state: reboot_guest
-    #   register: reboot_status
-
-    # - name: view the status
-    #   ansible.builtin.debug:
-    #     var: reboot_status
+    - name: Reboot the VM if desired
+      community.vmware.vmware_guest_powerstate:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        name: "{{ vm_to_reboot }}"
+        state: reboot-guest
+      register: reboot_status
+      when: vm_action == "reboot"


### PR DESCRIPTION
Follows up on #5176.

Once this is merged, Tower users can view VM details (host/datacenter and storage locations) for any VM in our inventory. By default the Tower template just views details, but a survey gives you the option of rebooting the VM.

So far it only works in the staging environment, but the steps to enable it in production are on Tower, not in this repo.