### PR TITLE
Minimalist playbook to view info from vSphere

### DIFF
--- a/playbooks/utils/vSphere_audit.yml
+++ b/playbooks/utils/vSphere_audit.yml
@@ -1,0 +1,57 @@
+---
+- name: Get info from vSphere
+  hosts: localhost
+
+  vars_files:
+    - ../../group_vars/vsphere/vault.yml
+    - ../../group_vars/vsphere/{{ runtime_env | default('staging') }}.yml
+
+  tasks:
+    - name: Gather info on templates
+      community.vmware.vmware_vm_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        show_datacenter: true
+        show_cluster: true
+        show_esxi_hostname: true
+        vm_type: template
+      register: template_info
+
+    - name: View template info
+      ansible.builtin.debug:
+        var: template_info
+
+    - name: Gather info on hosts
+      community.vmware.vmware_host_facts:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        show_datacenter: true
+        # schema: vsphere
+        # properties:
+        #   - hardware.memorySize
+        #   - something like numberOfVMs?
+      register: host_info
+
+    - name: View host info
+      ansible.builtin.debug:
+        var: host_info
+
+    - name: Gather info on storage
+      community.vmware.vmware_datastore_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        # schema: vsphere
+        # properties:
+        #   - name
+        #   - something like availableSpace?
+      register: storage_info
+
+    - name: View storage availability
+      ansible.builtin.debug:
+        var: storage_info

--- a/playbooks/utils/vSphere_audit.yml
+++ b/playbooks/utils/vSphere_audit.yml
@@ -23,7 +23,7 @@
       ansible.builtin.debug:
         var: template_info
 
-    - name: Gather info on hosts
+    - name: Gather info on ESXi hosts
       community.vmware.vmware_host_facts:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -34,11 +34,11 @@
         # properties:
         #   - hardware.memorySize
         #   - something like numberOfVMs?
-      register: host_info
+      register: esxi_host_info
 
-    - name: View host info
+    - name: View ESXi host info
       ansible.builtin.debug:
-        var: host_info
+        var: esxi_host_info
 
     - name: Gather info on storage
       community.vmware.vmware_datastore_info:


### PR DESCRIPTION
This playbook returns information about:
- templates in vSphere
- hosts in vSphere
- datastores in vSphere
Eventually, this will support creating VMs from Tower.

For now, the playbook only gathers information. We can add more active tasks to it in a branch once this one is merged to main.
