### PR TITLE
[libwww] Don't proxy pass library-staging to repec-staging

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -113,7 +113,7 @@
     }
 
     location /econlib/RePEc/pri {
-        proxy_pass https://repec-staging.princeton.edu/;
+        return 301 https://repec-staging.princeton.edu/;
     }
 
     # lib-vr-staging1


### PR DESCRIPTION
Instead, do a 301 Moved Permanently redirect

Helps with #5150, I ran it on both load balancers today (30 July)