### PR TITLE
[libwww] Don't proxy pass library-prod to repec-prod

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -74,7 +74,7 @@
     }
 
     location /econlib/RePEc/pri {
-        proxy_pass https://repec-prod.princeton.edu/;
+        return 301 https://repec-prod.princeton.edu/;
     }
 
     # lib-vr-prod1


### PR DESCRIPTION
Instead, do a 301 Moved Permanently redirect

This is the prod version of #5213 , I'm running it on the prod load balancer now.

closes #5150 