### PR TITLE
[orangelight-staging] send compressed assets if available and requested by the user's browser

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -59,6 +59,7 @@ server {
         # we expect this to fail because library-staging is behind VPN
         # handle errors using errors.conf
         proxy_intercept_errors on;
+        proxy_http_version 1.1;
         health_check interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
The catalog application servers are already able to handle requests for gzipped assets, which is great, because that can make things much faster for users.

However, before this commit, the load balancer was causing us to lose this feature. Fortunately, telling the load balancer to use HTTP 1.1 (instead of the default 1.0) allows the content negotiation to still happen.

Helps with pulibrary/orangelight#4054

I ran this on the prod load balancers, and confirmed that when I go to catalog-staging.princeton.edu, lighthouse no longer complains about "Enable text compression"