### PR TITLE
[orangelight] send compressed assets if available and requested by the user's browser: qa and prod

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -75,6 +75,7 @@ server {
         add_header Content-Security-Policy "frame-ancestors 'self' https://princeton.libwizard.com;";
         # handle errors using errors.conf
         proxy_intercept_errors on;
+        proxy_http_version 1.1;
         limit_req zone=catalog-prod-ratelimit burst=80 nodelay;
         limit_req_status 429;
         health_check interval=10 fails=2 passes=1 uri=/catalog/991234563506421;

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -46,6 +46,7 @@ server {
         proxy_busy_buffers_size    256k;
         # handle errors using errors.conf
         proxy_intercept_errors on;
+        proxy_http_version 1.1;
         health_check interval=10 fails=3 passes=2 uri=/catalog/1234567;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;


### PR DESCRIPTION
This extends #5218 to the production and qa environments.

The catalog application servers are already able to handle requests for gzipped assets, which is great, because that can make things much faster for users.

However, before this commit, the load balancer was causing us to lose this feature. Fortunately, telling the load balancer to use HTTP 1.1 (instead of the default 1.0) allows the content negotiation to still happen.

Helps with pulibrary/orangelight#4054

I ran this on the prod load balancer today (5 August, 2024)