### PR TITLE
Add redirect for clip.php file.

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -11,6 +11,7 @@
     rewrite ^/eastasian/oclcpinyin(.*)$ https://github.com/pulibrary/oclcpinyin redirect;
     rewrite ^/eastasian/addpinyin-plugin-marcedit(.*)$ https://github.com/pulibrary/addpinyin-marcedit redirect;
     rewrite ^/firestone/renovations https://library.princeton.edu/firestone redirect;
+    rewrite ^/hrc/vod/clip.php?file=(.*)$ https://videoreserves-prod.princeton.edu/hrc/vod/clip.php?file=$1 redirect;
 
     location /mudd-dbs {
         proxy_pass https://lib-mudd-prod.princeton.edu/;

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-staging.conf
@@ -6,6 +6,7 @@
     rewrite ^/eastasian/oclcpinyin(.*)$ https://github.com/pulibrary/oclcpinyin redirect;
     rewrite ^/eastasian/addpinyin-plugin-marcedit(.*)$ https://github.com/pulibrary/addpinyin-marcedit redirect;
     rewrite ^/eastasian/hishi(.*)$ https://catalog-staging.princeton.edu/catalog?utf8=%E2%9C%93&search_field=all_fields&q=%22hishi+collection%22 redirect;
+    rewrite ^/hrc/vod/clip.php?file=(.*)$ https://videoreserves-prod.princeton.edu/hrc/vod/clip.php?file=$1 redirect;
 
     location /mudd-dbs {
         proxy_pass https://lib-mudd-staging.princeton.edu/;


### PR DESCRIPTION
I've learned that web content for course in canvas outside of ARES exists that points at the library.princeton.edu to view reserves content. Putting in a redirect just for the clip.php file as opposed to bring all the proxy rules back. Canvas folks tell me it's not practical for them to update URLs in this part of the system. 