### PR TITLE
[ealapps] Serve ealapps via load balancer to non-princeton IPs

### DIFF
--- a/roles/nginxplus/files/conf/http/eal_prod.conf
+++ b/roles/nginxplus/files/conf/http/eal_prod.conf
@@ -41,10 +41,6 @@ server {
         proxy_read_timeout         2h;
         proxy_intercept_errors on;
 #        health_check interval=10 fails=3 passes=2 uri=/talkback/get-in-touch;
-        # allow princeton network
-        include /etc/nginx/conf.d/templates/restrict.conf;
-        # block all
-        deny all;
     }
 
     include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
Previously, users could access ealapps from outside Princeton via a library.princeton.edu proxy_pass rule.

With the website migration, this proxy_pass rule will no longer exist, so we need to make eal.lib.princeton.edu itself serve traffic from non-princeton IPs.

Thanks to Max for finding this.

I ran this on both prod load balancers today, and confirmed that I can access https://eal.lib.princeton.edu/EALJ/ without the VPN.