### PR TITLE
Add eal_production to inventory by environment

### DIFF
--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -16,6 +16,7 @@ docnow_production
 dpul_production
 dss_production
 dspace_production
+eal_production
 ealapps_production
 ezproxy_production
 figgy_production

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -14,6 +14,7 @@ docnow_staging
 dpul_staging
 dss_staging
 dspace_staging
+eal_staging
 ealapps_staging
 ezproxy_testing
 figgy_staging


### PR DESCRIPTION
- I cannot run the pulsys playbook on this server without adding it to the production inventory.