### PR TITLE
Disable second server for cdh prodigy load balancer config

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
@@ -5,7 +5,9 @@ upstream prodigy {
     least_time header 'inflight';
     zone prodigy 64k;
     server cdh-prodigy1.princeton.edu:80;
-    server cdh-prodigy2.princeton.edu:80;
+#    disabling second server for now
+#    prodigy is not handling switching and sticky isn't working properly
+#    server cdh-prodigy2.princeton.edu:80;
     sticky learn
           create=$upstream_cookie_prodigycookie
           lookup=$cookie_prodigycookie

--- a/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
@@ -4,7 +4,9 @@ proxy_cache_path /data/nginx/test_prodigy/NGINX_cache/ keys_zone=test_prodigycac
 upstream test_prodigy {
     zone prod_prodigy 64k;
     server cdh-test-prodigy1.princeton.edu:80;
-    server cdh-test-prodigy2.princeton.edu:80;
+#    disabling second server for now
+#    prodigy is not handling switching and sticky isn't working properly
+#    server cdh-test-prodigy2.princeton.edu:80;
     sticky learn
           create=$upstream_cookie_test_prodigycookie
           lookup=$cookie_test_prodigycookie


### PR DESCRIPTION
as a short-term fix, we want to only run prodigy from one server because the "sticky" option isn't working properly and it's resulting in our students getting the same tasks twice and total counts to be inconsistent

the "sticky" option seems like it should solve this but it's not working based on the behavior we're seeing