### PR TITLE
[friends] update $base_url for new domain names

### DIFF
--- a/group_vars/friends_of_pul/production.yml
+++ b/group_vars/friends_of_pul/production.yml
@@ -1,6 +1,6 @@
 ---
 php_version: "8.1"
-drupal_ssl_base_path: 'https://fpul.princeton.edu'
+drupal_ssl_base_path: 'https://fpul-migrated.lib.princeton.edu'
 drupal_db_user: 'fpul_prod'
 drupal_db_password: "{{ fpul_db_password | default('change_this') }}"
 drupal_db_name: 'fpul_prod'

--- a/group_vars/friends_of_pul/staging.yml
+++ b/group_vars/friends_of_pul/staging.yml
@@ -1,5 +1,5 @@
 ---
-drupal_ssl_base_path: 'https://fpul-staging.princeton.edu'
+drupal_ssl_base_path: 'https://fpul-staging.lib.princeton.edu'
 
 drupal_db_user: 'fpul_staging'
 drupal_db_password: "{{ fpul_db_password | default('change_this') }}"


### PR DESCRIPTION
Prior to this change, the friends sites displayed no CSS, since the CSS links included the old domain names.

I ran this on staging and prod.