### PR TITLE
Fix inventory to avoid error messages

### DIFF
--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -31,7 +31,7 @@ lib_svn_production
 libwww_production
 loadtest_production
 lockers_and_study_spaces_production
-mediaflux_production
+# mflux_production
 monitor_backends
 mudd_production
 mysql_production
@@ -73,4 +73,3 @@ towerdeploy
 video_reserves_production
 whichiso_production
 zookeeper_production
-

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -29,7 +29,7 @@ lib_fs_staging
 lib_svn_staging
 libwww_staging
 lockers_and_study_spaces_staging
-mediaflux_staging
+mflux_staging
 mudd_staging
 mysql_staging
 nginxplus_staging


### PR DESCRIPTION
Today I ran the `utils/checkmk_agent.yml` playbook and got this set of errors:

```
[WARNING]:  * Failed to parse /Users/alicia/projects/princeton_ansible/inventory/by_environment/production with ini plugin:
/Users/alicia/projects/princeton_ansible/inventory/by_environment/production:34: Section [production:children] includes undefined
group: mediaflux_production
[WARNING]:  * Failed to parse /Users/alicia/projects/princeton_ansible/inventory/by_environment/production with yaml plugin: We
were unable to read either as JSON nor YAML, these are the errors we got from each: JSON: Expecting value: line 1 column 2 (char 1)
Syntax Error while loading YAML.   did not find expected <document start>  The error appears to be in
'/Users/alicia/projects/princeton_ansible/inventory/by_environment/production': line 2, column 1, but may be elsewhere in the file
depending on the exact syntax problem.  The offending line appears to be:  [production:children] abid_production ^ here
[WARNING]: Unable to parse /Users/alicia/projects/princeton_ansible/inventory/by_environment/production as an inventory source
[WARNING]:  * Failed to parse /Users/alicia/projects/princeton_ansible/inventory/by_environment/staging with ini plugin:
/Users/alicia/projects/princeton_ansible/inventory/by_environment/staging:32: Section [staging:children] includes undefined group:
mediaflux_staging
[WARNING]:  * Failed to parse /Users/alicia/projects/princeton_ansible/inventory/by_environment/staging with yaml plugin: We were
unable to read either as JSON nor YAML, these are the errors we got from each: JSON: Expecting value: line 1 column 2 (char 1)
Syntax Error while loading YAML.   did not find expected <document start>  The error appears to be in
'/Users/alicia/projects/princeton_ansible/inventory/by_environment/staging': line 2, column 1, but may be elsewhere in the file
depending on the exact syntax problem.  The offending line appears to be:  [staging:children] abid_staging ^ here
[WARNING]: Unable to parse /Users/alicia/projects/princeton_ansible/inventory/by_environment/staging as an inventory source
```

These errors are caused by a mismatch between the group names in the `all_projects` inventory file `mflux` and the group names used in the `production` and `staging` environments. This PR updates the names and gets rid of the errors.
