### PR TITLE
[mflux] add forwarding headers

### DIFF
--- a/roles/nginxplus/files/conf/http/mflux_ci.conf
+++ b/roles/nginxplus/files/conf/http/mflux_ci.conf
@@ -17,6 +17,8 @@ server {
     location / {
         proxy_pass http://mflux;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_cache mfluxcache;
     }
 }


### PR DESCRIPTION
the java server is not handling the headers like we expect
lets forward the client headers to start
