### PR TITLE
[lockers] add two vms back

### DIFF
--- a/inventory/all_projects/lockers_and_study_spaces
+++ b/inventory/all_projects/lockers_and_study_spaces
@@ -1,6 +1,6 @@
 [lockers_and_study_spaces_staging]
-# lockers-and-study-spaces-staging1.princeton.edu
+lockers-and-study-spaces-staging1.princeton.edu
 lockers-and-study-spaces-staging2.princeton.edu
 [lockers_and_study_spaces_production]
-# lockers-and-study-spaces-prod1.princeton.edu
+lockers-and-study-spaces-prod1.princeton.edu
 lockers-and-study-spaces-prod2.princeton.edu

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/lockers-and-study-spaces/NGINX_cache/ keys_zone=loc
 
 upstream lockers-and-study-spaces-prod {
     zone lockers-and-study-spaces-prod 64k;
-    # server lockers-and-study-spaces-prod1.princeton.edu resolve;
+    server lockers-and-study-spaces-prod1.princeton.edu resolve;
     server lockers-and-study-spaces-prod2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_lockers-and-study-spacesprodcookie

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
@@ -3,7 +3,7 @@ proxy_cache_path /data/nginx/lockers-and-study-spaces-staging/NGINX_cache/ keys_
 
 upstream lockers-and-study-spaces-staging {
     zone lockers-and-study-spaces-staging 64k;
-    # server lockers-and-study-spaces-staging1.princeton.edu resolve;
+    server lockers-and-study-spaces-staging1.princeton.edu resolve;
     server lockers-and-study-spaces-staging2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_lockers-and-study-spacesstagingcookie


### PR DESCRIPTION
we add two new vms back up to the loadbalancer

closes #5263

Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
