### PR TITLE
[special collections] block access outside the princeton network

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-sc-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-sc-prod.conf
@@ -37,6 +37,11 @@ server {
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
         health_check uri=/special-collections/health interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
     }

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -64,6 +64,10 @@
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
     }
 
     location /econlib/RePEc/pri {


### PR DESCRIPTION
This site has been migrated to OIT WDS, so there is no need for it to be public outside our network.

This blocks both versions from off-campus:
* https://lib-sc-prod.princeton.edu/
* https://library-migrated.lib.princeton.edu/special-collections

Based on #5270 