### PR TITLE
Updates the "new kicker" playbook

### DIFF
--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -7,7 +7,7 @@
     - ../../group_vars/vsphere/{{ runtime_env | default('staging') }}.yml
 
   tasks:
-    - name: Gather state of VM to reboot
+    - name: Gather state of VM
       community.vmware.vmware_vm_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -21,7 +21,7 @@
 
     - name: View host and storage info for VM
       ansible.builtin.debug:
-        msg: The {{ vm_to_reboot }} VM is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host, with storage on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage in vSphere.
+        msg: The {{ vm_to_reboot }} VM is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South), with storage on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage in vSphere.
 
     - name: Reboot the VM if desired
       community.vmware.vmware_guest_powerstate:


### PR DESCRIPTION
This playbook can now be run in Tower in staging or in production.

This PR clarifies a task name (you may or may not be rebooting the VM) and adds a reminder about the format of our vCenter host names.