### PR TITLE
[TigerData] Remove fd because it cannot be installed on rocky linux

### DIFF
--- a/roles/mflux/tasks/main.yml
+++ b/roles/mflux/tasks/main.yml
@@ -3,7 +3,6 @@
   ansible.builtin.dnf:
     name:
       - expect
-      - fd-find
       - git
       - java-1.8.0-openjdk
       - python3-pexpect


### PR DESCRIPTION
If fd is needed, it should be reintroduced in a separate pr.