### PR TITLE
adds template and task to override the default systemd logrotate timer

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,2 +1,5 @@
 ---
 # handlers file for roles/common
+- name: reload logrotate timer settings
+  ansible.builtin.command: systemctl daemon-reload
+

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -68,10 +68,8 @@
     dest: "/etc/systemd/system/logrotate.timer.d/override.conf"
     mode: 0644
   when: ansible_service_mgr=="systemd"
-
-- name: common | reload to pick up logrotate timer settings
-  ansible.builtin.command: systemctl daemon-reload
-  when: ansible_service_mgr=="systemd"
+  notify:
+    - reload logrotate timer settings
 
 - name: common | install configured dependencies
   ansible.builtin.package:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -53,11 +53,22 @@
     dest: /etc/vim/vimrc.local
     mode: 0644
 
+- name: common | ensure logrotate timer dir exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/logrotate.timer.d
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
 - name: common | override default logrotate timer
   ansible.builtin.template:
     src: "logrotate_timer.j2"
     dest: "/etc/systemd/system/logrotate.timer.d/override.conf"
     mode: 0644
+
+- name: common | reload to pick up logrotate timer settings
+  ansible.builtin.command: systemctl daemon-reload
 
 - name: common | install configured dependencies
   ansible.builtin.package:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -53,6 +53,12 @@
     dest: /etc/vim/vimrc.local
     mode: 0644
 
+- name: common | override default logrotate timer
+  ansible.builtin.template:
+    src: "logrotate_timer.j2"
+    dest: "/etc/systemd/system/logrotate.timer.d/override.conf"
+    mode: 0644
+
 - name: common | install configured dependencies
   ansible.builtin.package:
     name: '{{ configured_dependencies }}'

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -60,15 +60,18 @@
     mode: 0755
     owner: root
     group: root
+  when: ansible_service_mgr=="systemd"
 
 - name: common | override default logrotate timer
   ansible.builtin.template:
     src: "logrotate_timer.j2"
     dest: "/etc/systemd/system/logrotate.timer.d/override.conf"
     mode: 0644
+  when: ansible_service_mgr=="systemd"
 
 - name: common | reload to pick up logrotate timer settings
   ansible.builtin.command: systemctl daemon-reload
+  when: ansible_service_mgr=="systemd"
 
 - name: common | install configured dependencies
   ansible.builtin.package:

--- a/roles/common/templates/logrotate_timer.j2
+++ b/roles/common/templates/logrotate_timer.j2
@@ -9,7 +9,7 @@ Documentation=man:logrotate(8) man:logrotate.conf(5)
 # after restarting a service
 OnActiveSec=20seconds
 # OnUnitActiveSec sets how often systemd checks logs
-OnUnitActiveSec={{ logrotate_wait_general | default(10minutes) }}
+OnUnitActiveSec={{ logrotate_wait_general | default('10minutes') }}
 AccuracySec=1m
 Persistent=true
 [Install]

--- a/roles/common/templates/logrotate_timer.j2
+++ b/roles/common/templates/logrotate_timer.j2
@@ -1,0 +1,16 @@
+{{ ansible_managed | comment }}
+# This file defines how frequently systemd checks
+# to see if a log file is so large it should be rotated
+[Unit]
+Description=rotation of log files by size
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+[Timer]
+# OnActiveSec sets how long systemd waits to check logs
+# after restarting a service
+OnActiveSec=20seconds
+# OnUnitActiveSec sets how often systemd checks logs
+OnUnitActiveSec={{ logrotate_wait_general | default(10minutes) }}
+AccuracySec=1m
+Persistent=true
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #5256.

Adds an override to all our servers for the systemd logrotate timer. With the default settings in this template, systemd will check the logs to see if they are large enough to warrant rotation (as defined by files in `/etc/logrotate.d`):
- 20 seconds after a service is restarted
- every 10 minutes thereafter

With this setting, even with large amounts of data going to a log, we should retain enough disk space for the service to continue uninterrupted.
