### PR TITLE
Adds a maintenance playbook that just runs the 'common' role

### DIFF
--- a/playbooks/utils/common_only.yml
+++ b/playbooks/utils/common_only.yml
@@ -1,0 +1,18 @@
+---
+- name: Run just the common role, to install tools and common configuration
+  hosts: all
+  # hosts: staging:qa:production
+  remote_user: pulsys
+  become: true
+  vars:
+    running_on_server: true
+
+  pre_tasks:
+    - name: stop playbook if you didn't pass --limit
+      fail:
+        msg: "you must use -l or --limit"
+      when: ansible_limit is not defined
+      run_once: true
+
+  roles:
+    - role: roles/common

--- a/playbooks/utils/common_only.yml
+++ b/playbooks/utils/common_only.yml
@@ -1,4 +1,6 @@
 ---
+# you MUST run this playbook on a host or group with '--limit' for example `ansible-playbook -v ---limit pdc_describe_staging playbooks/utils/common_only.yml`
+#
 - name: Run just the common role, to install tools and common configuration
   hosts: all
   # hosts: staging:qa:production


### PR DESCRIPTION
The `common` role sometimes fails when trying to install new tools or update packages. This PR creates a playbook that just runs the common role, so we can run it across our infrastructure for quicker and easier maintenance.

Long-term, it would be great to run this playbook when we build new infrastructure, and on existing infrastructure on a regular schedule. Then we could remove the `common` role from most of our playbooks. 