### PR TITLE
Swap cdh web production and pre-production servers

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_prod_web.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_web.conf
@@ -1,7 +1,8 @@
 # Ansible managed
 proxy_cache_path /data/nginx/prod_cdhweb/NGINX_cache/ keys_zone=prod_cdhwebcache:10m;
 
-upstream beta_prod_cdhweb {
+# make new version of CDH website live; serving from 3 & 4 for now
+upstream prod_cdhweb {
     least_time header 'inflight';
     zone prod_cdhweb 64k;
     server cdh-web3.princeton.edu;
@@ -12,7 +13,8 @@ upstream beta_prod_cdhweb {
         zone=beta_prod_cdhwebclient_sessions:1m;
 }
 
-upstream prod_cdhweb {
+# keep old version of CDH website live at cdh-beta for the transition period
+upstream beta_prod_cdhweb {
     least_time header 'inflight';
     zone prod_cdhweb 64k;
     server cdh-web1.princeton.edu;


### PR DESCRIPTION
This change makes the new version of the CDH website live and keeps the old version running at cdh-beta in case we need to reference the old site during the transition period.