### PR TITLE
Polishing up the build-a-vm playbook

### DIFF
--- a/group_vars/vsphere/production.yml
+++ b/group_vars/vsphere/production.yml
@@ -5,3 +5,4 @@ vcenter_cluster: "VMCluster"
 vcenter_username: "vmansible"
 vcenter_password: "{{ vault_vcenter_password }}"
 vm_delete_me_folder: "/Library/vm/ToBeDeleted"
+

--- a/group_vars/vsphere/staging.yml
+++ b/group_vars/vsphere/staging.yml
@@ -2,7 +2,6 @@
 vcenter_hostname: "{{ vault_dev_vsphere_hostname }}"
 vcenter_datacenter: "Library-Dev"
 vcenter_cluster: "VMCluster"
+vcenter_username: "vmansible"
 vcenter_password: "{{ vault_vcenter_password }}"
-vm_folder: "Discovered virtual machine"
-vm_template: "template_ubuntu_vm_spring_2024"
 vm_delete_me_folder: "/Library-Dev/vm/ToBeDeleted"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -2,16 +2,19 @@
 #  This playbook will delete a VM and replace it. This is the only warning you will get. Running this playbook has destructive consequences
 #  This playbook should only be run from ansible tower.  No need for detailed instructions of examples here, because you should not run it here.
 #
-- name: replace the {{ replacement_vm }} VM on vSphere
+- name: replace the {{ replacement_vm }} VM on the {{ runtime_env | default('staging') }} vSphere
   hosts: localhost
   remote_user: pulsys
   become: true
+
   vars:
     slack_alerts_channel: "#infrastructure"
+
   vars_files:
     - ../../group_vars/all/vault.yml
     - ../../group_vars/vsphere/vault.yml
     - ../../group_vars/vsphere/{{ runtime_env | default('staging') }}.yml
+
   tasks:
     - name: Gather MAC address of VM to replace
       community.vmware.vmware_vm_info:
@@ -25,22 +28,14 @@
         # show_cluster: true
         vm_name: "{{ replacement_vm }}"
       register: old_vm_info
-      tags: 
-        - 'disk'
-        - remove-old
 
     - name: Print out old VM information
       ansible.builtin.debug:
         var: old_vm_info
-      tags: 
-        - 'disk'
-        - remove-old
 
     - name: Print out disk size in KB
       ansible.builtin.debug:
         msg: "{{ old_vm_info.virtual_machines[0].allocated.storage / 1024 }}"
-      tags: 
-        - 'disk'
 
     - name: Print out old VM information
       ansible.builtin.debug:
@@ -55,7 +50,6 @@
         datacenter: "{{ vcenter_datacenter }}"
         dest_folder: "{{ vm_delete_me_folder }}"
         uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
-      ignore_errors: true
 
     - name: Power off old VM using UUID
       community.vmware.vmware_guest_powerstate:
@@ -64,7 +58,6 @@
         password: "{{ vcenter_password }}"
         validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
-        folder: ToBeDeleted
         uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
         state: powered-off
 
@@ -76,7 +69,7 @@
         validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
         cluster: "{{ vcenter_cluster }}"
-        folder: /{{ vm_folder | default('AnsibleControlledVMs') }}
+        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
         name: "{{ replacement_vm }}"
         state: present
         template: "{{ vm_template | default('template_jammy_spring_2024')}}"
@@ -190,8 +183,6 @@
         uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
         state: absent
         force: true
-      tags:
-        - remove-old
       
     - name: Remove host from ansible tower known hosts
       ansible.builtin.known_hosts:
@@ -201,8 +192,6 @@
       delegate_to: towerdeploy1.princeton.edu
       become: true
       become_user: deploy
-      tags:
-        - known-hosts
 
   post_tasks:
     - name: send information to slack

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -191,7 +191,7 @@
              an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
              {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+             {{ ( new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
       ansible.builtin.debug:
         msg: "{{ msg.split('\n') }}"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -151,8 +151,7 @@
       
     - name: view details for new mac address
       ansible.builtin.debug:
-        var: new_nic.network_info[1].mac_address
-
+        var: new_nic.network_info[0].mac_address
 
     - name: Power the new VM on
       community.vmware.vmware_guest_powerstate:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -16,7 +16,7 @@
     - ../../group_vars/vsphere/{{ runtime_env | default('staging') }}.yml
 
   tasks:
-    - name: Gather MAC address of VM to replace
+    - name: Gather info on VM to replace
       community.vmware.vmware_vm_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -33,15 +33,20 @@
       ansible.builtin.debug:
         var: old_vm_info
 
-    - name: Print out disk size
+    - name: Print out relevant details of old VM
       ansible.builtin.debug:
-        msg: This VM has {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated.
+        msg:
+          - The VM you are replacing has
+          - a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+          - {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+          - {{ old_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+          - {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
 
     - name: Print out warning
       ansible.builtin.debug:
         msg: Ansible will now move and delete {{ old_vm_info.virtual_machines[0].guest_name }}
 
-    - name: Move old VM to the DeleteMe folder
+    - name: Move old VM to the ToBeDeleted folder
       community.vmware.vmware_guest_move:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -162,11 +167,28 @@
         # new VM var does not include UUID; use moid, which is unique in each vCenter instance
         moid: "{{ new_vm_deets.instance.moid }}"
         state: powered-on
-      register: vm_status
 
-    - name: view status of new VM
+    - name: Gather details on new VM
+      community.vmware.vmware_vm_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        show_datacenter: true
+        show_mac_address: true
+        show_allocated: true
+        # show_cluster: true
+        moid: "{{ new_vm_deets.instance.moid }}"
+      register: new_vm_info
+
+    - name: Print out relevant details of new VM
       ansible.builtin.debug:
-        var: vm_status
+        msg:
+          - The VM you just created has
+          - a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+          - {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+          - {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+          - {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
 
     - name: Remove old VM using UUID
       community.vmware.vmware_guest:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -35,7 +35,7 @@
 
     - name: Print out disk size
       ansible.builtin.debug:
-        msg: This VM has "{{ (old_vm_info.virtual_machines[0].allocated.storage | int * 1048576 ) | human_readable }}" GB of disk allocated.
+        msg: This VM has "{{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }}" GB of disk allocated.
 
     - name: Print out old VM information
       ansible.builtin.debug:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -37,6 +37,7 @@
       vars:
         msg: |
              The VM you are replacing has
+             an MOID of {{ old_vm_info.virtual_machines[0].moid }}
              a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
              {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ old_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
@@ -170,7 +171,7 @@
         moid: "{{ new_vm_deets.instance.moid }}"
         state: powered-on
 
-    - name: Gather details on both VMs
+    - name: Gather details on new VM
       community.vmware.vmware_vm_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -183,21 +184,17 @@
         vm_name: "{{ replacement_vm }}"
       register: post_replacement_info
 
-    - name: what's in the info now?
+    - name: Print out relevant details of new VM
+      vars:
+        msg: |
+             The VM you just created has
+             an MOID of {{ new_vm_info.virtual_machines[0].moid }}
+             a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+             {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+             {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
       ansible.builtin.debug:
-        var: post_replacement_info
-
-    # - name: Print out relevant details of VMs
-    #   vars:
-    #     msg: |
-    #          Here is a comparison of the VM you wanted to replace and the VM you just created.
-    #          a mac address of {{ new_vm_info.virtual_machines[*].mac_address[0] }}
-    #          {{ new_vm_info.virtual_machines[*].allocated.cpu }} CPUs
-    #          {{ new_vm_info.virtual_machines[*].allocated.memory | human_readable }} of memory
-    #          {{ new_vm_info.virtual_machines[*].allocated.storage | human_readable }} of disk allocated
-    #   ansible.builtin.debug:
-    #     msg: "{{ msg.split('\n') }}"
-    #   loop: post_replacement_info
+        msg: "{{ msg.split('\n') }}"
     
     - name: Remove old VM using UUID
       community.vmware.vmware_guest:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -33,18 +33,6 @@
       ansible.builtin.debug:
         var: old_vm_info
 
-    - name: Print out relevant details of old VM
-      vars:
-        msg: |
-             The VM you are replacing has
-             an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
-             a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
-             {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ old_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
-             {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-      ansible.builtin.debug:
-        msg: "{{ msg.split('\n') }}"
-
     - name: Print out warning
       ansible.builtin.debug:
         msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement.
@@ -107,10 +95,6 @@
       ansible.builtin.debug:
         var: new_vm_deets
 
-    - name: view automatically added mac address
-      ansible.builtin.debug:
-        var: new_vm_deets.instance.hw_eth0.macaddress
-
     - name: power down the VM so we can mess with the network settings
       community.vmware.vmware_guest_powerstate:
         hostname: "{{ vcenter_hostname }}"
@@ -149,15 +133,6 @@
         device_type: "vmxnet3"
         connected: true
         mac_address: "{{ old_vm_info.virtual_machines[0].mac_address[0] }}"
-      register: new_nic
-
-    - name: view all info for VM with the new NICs
-      ansible.builtin.debug:
-        var: new_nic
-
-    - name: view details for new mac address
-      ansible.builtin.debug:
-        var: new_nic.network_info[0].mac_address
 
     - name: Power the new VM on
       community.vmware.vmware_guest_powerstate:
@@ -184,6 +159,18 @@
         vm_name: "{{ replacement_vm }}"
       register: new_vm_info
 
+    - name: Print out relevant details of old VM
+      vars:
+        msg: |
+             The VM you replaced had
+             an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
+             a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+             {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
+             {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+      ansible.builtin.debug:
+        msg: "{{ msg.split('\n') }}"
+
     - name: Print out relevant details of new VM
       vars:
         msg: |
@@ -191,7 +178,7 @@
              an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
              {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ ( new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
+             {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
       ansible.builtin.debug:
         msg: "{{ msg.split('\n') }}"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -37,7 +37,7 @@
       vars:
         msg: |
              The VM you are replacing has
-             an MOID of {{ old_vm_info.virtual_machines[0].moid }}
+             an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
              {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ old_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
@@ -188,7 +188,7 @@
       vars:
         msg: |
              The VM you just created has
-             an MOID of {{ new_vm_info.virtual_machines[0].moid }}
+             an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
              {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -161,7 +161,7 @@
         password: "{{ vcenter_password }}"
         validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
-        folder: /{{ vm_folder | default('dev-rebootable-vms') }}
+        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
         # new VM var does not include UUID; use moid, which is unique in each vCenter instance
         moid: "{{ new_vm_deets.instance.moid }}"
         state: powered-on
@@ -179,7 +179,7 @@
         validate_certs: false
         datacenter: "{{ vcenter_datacenter }}"
         cluster: "{{ vcenter_cluster }}"
-        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+        folder: "{{ vm_delete_me_folder }}"
         uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
         state: absent
         force: true

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -33,9 +33,9 @@
       ansible.builtin.debug:
         var: old_vm_info
 
-    - name: Print out disk size in KB
+    - name: Print out disk size
       ansible.builtin.debug:
-        msg: "{{ old_vm_info.virtual_machines[0].allocated.storage / 1024 }}"
+        msg: This VM has "{{ (old_vm_info.virtual_machines[0].allocated.storage | int * 1048576 ) | human_readable }}" GB of disk allocated.
 
     - name: Print out old VM information
       ansible.builtin.debug:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -34,13 +34,15 @@
         var: old_vm_info
 
     - name: Print out relevant details of old VM
+      vars:
+        msg: |
+             The VM you are replacing has
+             a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+             {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ old_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+             {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
       ansible.builtin.debug:
-        msg:
-          - The VM you are replacing has
-          - a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
-          - {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-          - {{ old_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
-          - {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+        msg: "{{ msg.split('\n') }}"
 
     - name: Print out warning
       ansible.builtin.debug:
@@ -181,15 +183,15 @@
         moid: "{{ new_vm_deets.instance.moid }}"
       register: new_vm_info
 
-    - name: Print out relevant details of new VM
-      ansible.builtin.debug:
-        msg:
-          - The VM you just created has
-          - a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
-          - {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-          - {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
-          - {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-
+    # - name: Print out relevant details of new VM
+    #   ansible.builtin.debug:
+    #     msg:
+    #       - The VM you just created has
+    #       - a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+    #       - {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+    #       - {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+    #       - {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+    # 
     - name: Remove old VM using UUID
       community.vmware.vmware_guest:
         hostname: "{{ vcenter_hostname }}"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -1,5 +1,5 @@
 ---
-#  This playbook will delete a VM and replace it. This is the only warning you will get. Running this playbook has destructive consequences
+#  This playbook deletes a VM and replaces it from a vSphere template. This is the only warning you will get. Running this playbook has destructive consequences!
 #  This playbook should only be run from ansible tower.  No need for detailed instructions of examples here, because you should not run it here.
 #
 - name: replace the {{ replacement_vm }} VM on the {{ runtime_env | default('staging') }} vSphere
@@ -35,11 +35,11 @@
 
     - name: Print out disk size
       ansible.builtin.debug:
-        msg: This VM has "{{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }}" GB of disk allocated.
+        msg: This VM has {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated.
 
-    - name: Print out old VM information
+    - name: Print out warning
       ansible.builtin.debug:
-        msg: You are planning to delete {{ old_vm_info }}
+        msg: Ansible will now move and delete {{ old_vm_info.virtual_machines[0].guest_name }}
 
     - name: Move old VM to the DeleteMe folder
       community.vmware.vmware_guest_move:
@@ -75,10 +75,10 @@
         template: "{{ vm_template | default('template_jammy_spring_2024')}}"
         disk:
           - size: "{{ (old_vm_info.virtual_machines[0].allocated.storage / 1024) | int }}kb"
-            # this may not be acceptable to our new templates
+            # we are not able to use 'type: thin' with our fall 2024 templates
             # type: thin
             datastore: "{{ old_vm_info.virtual_machines[0].datastore_url }}"
-        # Add another disk from an existing VMDK
+        # TODO: Add another disk from an existing VMDK
         hardware:
           memory_mb: "{{ old_vm_info.virtual_machines[0].allocated.memory | int | default('16384') }}"
           num_cpus: "{{ old_vm_info.virtual_machines[0].allocated.cpu | int | default('2') }}"
@@ -136,8 +136,6 @@
         datacenter: "{{ vcenter_datacenter }}"
         # new VM var does not include UUID; use moid, which is unique in each vCenter instance
         moid: "{{ new_vm_deets.instance.moid }}"
-        # uuid: "{{ new_vm_deets.instance.uuid }}"
-        # name: "{{ replacement_vm }}"
         folder: "{{ old_vm_info.virtual_machines[0].folder }}"
         network_name: "{{ vm_network | default('Virtual Machine Network')}}"
         device_type: "vmxnet3"
@@ -148,7 +146,7 @@
     - name: view all info for VM with the new NICs
       ansible.builtin.debug:
         var: new_nic
-      
+
     - name: view details for new mac address
       ansible.builtin.debug:
         var: new_nic.network_info[0].mac_address
@@ -182,8 +180,8 @@
         uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
         state: absent
         force: true
-      
-    - name: Remove host from ansible tower known hosts
+
+    - name: Remove host from TowerDeploy1 known hosts
       ansible.builtin.known_hosts:
         path: /home/deploy/.ssh/known_hosts
         name: "{{ replacement_vm }}.princeton.edu"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -183,15 +183,17 @@
         moid: "{{ new_vm_deets.instance.moid }}"
       register: new_vm_info
 
-    # - name: Print out relevant details of new VM
-    #   ansible.builtin.debug:
-    #     msg:
-    #       - The VM you just created has
-    #       - a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
-    #       - {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-    #       - {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
-    #       - {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-    # 
+    - name: Print out relevant details of new VM
+      vars:
+        msg: |
+             The VM you just created has
+             a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+             {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
+             {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+      ansible.builtin.debug:
+        msg: "{{ msg.split('\n') }}"
+    
     - name: Remove old VM using UUID
       community.vmware.vmware_guest:
         hostname: "{{ vcenter_hostname }}"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -25,7 +25,7 @@
         show_datacenter: true
         show_mac_address: true
         show_allocated: true
-        # show_cluster: true
+        show_folder: true
         vm_name: "{{ replacement_vm }}"
       register: old_vm_info
 
@@ -170,7 +170,7 @@
         moid: "{{ new_vm_deets.instance.moid }}"
         state: powered-on
 
-    - name: Gather details on new VM
+    - name: Gather details on both VMs
       community.vmware.vmware_vm_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -179,20 +179,25 @@
         show_datacenter: true
         show_mac_address: true
         show_allocated: true
-        # show_cluster: true
-        moid: "{{ new_vm_deets.instance.moid }}"
-      register: new_vm_info
+        show_folder: true
+        vm_name: "{{ replacement_vm }}"
+      register: post_replacement_info
 
-    - name: Print out relevant details of new VM
-      vars:
-        msg: |
-             The VM you just created has
-             a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
-             {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ new_vm_info.virtual_machines[0].allocated.memory | human_readable }} of memory
-             {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+    - name: what's in the info now?
       ansible.builtin.debug:
-        msg: "{{ msg.split('\n') }}"
+        var: post_replacement_info
+
+    # - name: Print out relevant details of VMs
+    #   vars:
+    #     msg: |
+    #          Here is a comparison of the VM you wanted to replace and the VM you just created.
+    #          a mac address of {{ new_vm_info.virtual_machines[*].mac_address[0] }}
+    #          {{ new_vm_info.virtual_machines[*].allocated.cpu }} CPUs
+    #          {{ new_vm_info.virtual_machines[*].allocated.memory | human_readable }} of memory
+    #          {{ new_vm_info.virtual_machines[*].allocated.storage | human_readable }} of disk allocated
+    #   ansible.builtin.debug:
+    #     msg: "{{ msg.split('\n') }}"
+    #   loop: post_replacement_info
     
     - name: Remove old VM using UUID
       community.vmware.vmware_guest:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -47,7 +47,7 @@
 
     - name: Print out warning
       ansible.builtin.debug:
-        msg: Ansible will now move and delete {{ old_vm_info.virtual_machines[0].guest_name }}
+        msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement.
 
     - name: Move old VM to the ToBeDeleted folder
       community.vmware.vmware_guest_move:
@@ -182,7 +182,7 @@
         show_allocated: true
         show_folder: true
         vm_name: "{{ replacement_vm }}"
-      register: post_replacement_info
+      register: new_vm_info
 
     - name: Print out relevant details of new VM
       vars:


### PR DESCRIPTION
The playbook now runs from Tower in either production or staging (there is a Tower Template for each environment for now, because the network names are not consistent across environments). It shows VM disk usage correctly, and it puts the replacement VM into the same folder in vSphere that the old VM was in.

I've removed the tags for now. They were useful for testing, but I think they might be tricky to manage in the long term. We could reinstate them and have multiple Tower Templates build off the same playbook with different tags . . . but let's talk about the use cases. 

When this gets merged, we should update the Tower templates so they no longer ask for a source control branch name. 