### PR TITLE
Give more information about VMs in playbook output

### DIFF
--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -24,11 +24,11 @@
       vars:
         msg: |
              The {{ vm_to_reboot }} VM 
-             is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South), has
-             a mac address of {{ vm_info.virtual_machines[0].mac_address[0] }},
+             is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South),
+             has a mac address of {{ vm_info.virtual_machines[0].mac_address[0] }},
              {{ vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ (vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory, and
-             {{ vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+             {{ (vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory,
+             and {{ vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
              on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage node in vSphere.
       ansible.builtin.debug:
         msg: "{{ msg.split('\n') }}"

--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -19,9 +19,22 @@
         vm_name: "{{ vm_to_reboot }}"
       register: vm_info
 
-    - name: View host and storage info for VM
+    - name: Print out relevant details of VM
+      vars:
+        msg: |
+             The {{ vm_to_reboot }} VM 
+             is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South), has
+             a mac address of {{ vm_info.virtual_machines[0].mac_address[0] }},
+             {{ vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ (vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory, and
+             {{ vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+             on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage node in vSphere.
       ansible.builtin.debug:
-        msg: The {{ vm_to_reboot }} VM is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South), with storage on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage in vSphere.
+        msg: "{{ msg.split('\n') }}"
+
+    # - name: View host and storage info for VM
+    #   ansible.builtin.debug:
+    #     msg: The {{ vm_to_reboot }} VM is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South), with storage on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage in vSphere.
 
     - name: Reboot the VM if desired
       community.vmware.vmware_guest_powerstate:

--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -23,11 +23,11 @@
     - name: Print out relevant details of VM
       vars:
         msg: |
-             The {{ vm_to_reboot }} VM 
-             is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South),
-             has a mac address of {{ vm_info.virtual_machines[0].mac_address[0] }},
+             The {{ vm_to_reboot }} VM
+             is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South)
+             has a mac address of {{ vm_info.virtual_machines[0].mac_address[0] }}
              {{ vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ (vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory,
+             {{ (vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              and {{ vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
              on the {{ vm_info.virtual_machines[0].datastore_url[0].name }} storage node in vSphere.
       ansible.builtin.debug:

--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -16,6 +16,7 @@
         show_datacenter: true
         show_cluster: true
         show_esxi_hostname: true
+        show_allocated: true
         vm_name: "{{ vm_to_reboot }}"
       register: vm_info
 


### PR DESCRIPTION
Now that we know how to gather data from vSphere about CPU, memory, disk space, and more, we can enhance the view provided by our view-details-and-reboot-if-needed playbook. 

The task now returns the host (with note about the location), MAC address, CPU, memory, storage amount, and storage location.