### PR TITLE
Update the veeam backups to show a list of VMs with no tags

### DIFF
--- a/playbooks/utils/veeam_backup_list.yml
+++ b/playbooks/utils/veeam_backup_list.yml
@@ -32,9 +32,7 @@
 
     - name: Find VMs that do not have tags
       ansible.builtin.set_fact:
-        untagged_vms: "{{ vms_and_tags.virtual_machines | selectattr('tags', '==', '') | map(attribute='guest_name') }}"
-      # vms_and_tags.virtual_machines[?folder=='/Library/vm/dev-rebootable-vms'].guest_name works
-      # but vms_and_tags.virtual_machines[?tags==''].guest_name does not
+        untagged_vms: "{{ vms_and_tags.virtual_machines | rejectattr('tags') | map(attribute='guest_name') }}"
 
     - name: show untagged var
       ansible.builtin.debug:

--- a/playbooks/utils/veeam_backup_list.yml
+++ b/playbooks/utils/veeam_backup_list.yml
@@ -18,7 +18,7 @@
         vm_type: vm
       register: vms_and_tags
 
-    - name: Get a list of tags
+    - name: Find all tags
       ansible.builtin.set_fact:
         unique_tags: "{{ vms_and_tags.virtual_machines | map(attribute='tags') | flatten | map(attribute='name') | unique }}"
 
@@ -26,19 +26,11 @@
       ansible.builtin.debug:
         var: unique_tags
 
-    - name: View full data
-      ansible.builtin.debug:
-        var: vms_and_tags
-
-    - name: Find VMs that do not have tags
+    - name: Find VMs without tags
       ansible.builtin.set_fact:
         untagged_vms: "{{ vms_and_tags.virtual_machines | rejectattr('tags') | map(attribute='guest_name') }}"
 
-    - name: show untagged var
-      ansible.builtin.debug:
-        var: untagged_vms
-
-    - name: show names of VMs without tags
+    - name: View VMs without tags
       ansible.builtin.debug:
         msg:
           - Review these VMs - they have no tags now.
@@ -46,18 +38,18 @@
           - If not, add the 'LIB_DONT_BACKUP' tag. 
           - VM names with no tags {{ untagged_vms }}
 
-    - name: Find VMs that have tags
+    - name: Find VMs with tags
       ansible.builtin.set_fact:
         tagged_vms: "{{ vms_and_tags | community.general.json_query(not_null) }}"
       vars:
         not_null: "virtual_machines[?not_null(tags)]"
 
-    - name: create a dict of fields we want from tagged VMs
+    - name: Create a dict of fields we want from tagged VMs
       ansible.builtin.set_fact:
         # build a list of VMs with tags, names, and disk size
         slim_tagged_vms: "{{ tagged_vms | community.general.json_query('[*].{VM_name: guest_name, Tag_name: tags[0].name, Disk_size: allocated.storage}') }}"
 
-    - name: show data for VMs by tag
+    - name: View data on VMs by tag
       ansible.builtin.debug:
         msg:
           - The {{ item }} tag marks these VMs {{ slim_tagged_vms | selectattr('Tag_name', 'equalto', item) | map(attribute='VM_name') }}

--- a/playbooks/utils/veeam_backup_list.yml
+++ b/playbooks/utils/veeam_backup_list.yml
@@ -26,6 +26,28 @@
       ansible.builtin.debug:
         var: unique_tags
 
+    - name: View full data
+      ansible.builtin.debug:
+        var: vms_and_tags
+
+    - name: Find VMs that do not have tags
+      ansible.builtin.set_fact:
+        untagged_vms: "{{ vms_and_tags.virtual_machines | selectattr('tags', '==', '') | map(attribute='guest_name') }}"
+      # vms_and_tags.virtual_machines[?folder=='/Library/vm/dev-rebootable-vms'].guest_name works
+      # but vms_and_tags.virtual_machines[?tags==''].guest_name does not
+
+    - name: show untagged var
+      ansible.builtin.debug:
+        var: untagged_vms
+
+    - name: show names of VMs without tags
+      ansible.builtin.debug:
+        msg:
+          - Review these VMs - they have no tags now.
+          - If we want to back them up, add backup tags.
+          - If not, add the 'LIB_DONT_BACKUP' tag. 
+          - VM names with no tags {{ untagged_vms }}
+
     - name: Find VMs that have tags
       ansible.builtin.set_fact:
         tagged_vms: "{{ vms_and_tags | community.general.json_query(not_null) }}"


### PR DESCRIPTION
We add tags to VMs we want to back up with VEEAM. Each tag reflects the location and OS of the VM plus which day of the week it gets backed up. Best practice is to add a tag for "don't back this VM up" to any VMs we do not want to back up with VEEAM. This way we know for sure that the lack of a backup is intentional, and not an oversight.

This PR expands the VEEAM backup playbook to report a list of VMs that have no tags, so we can audit vSphere, make decisions about which VMs to back up, and keep the tags up to date.
