### PR TITLE
Expand disk

### DIFF
--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -46,10 +46,6 @@
       ansible.builtin.command: sudo lvdisplay
       register: logical_volume
 
-    - name: view the logical_volume
-      ansible.builtin.debug:
-        var: logical_volume
-
     - name: gather the lv_path
       ansible.builtin.set_fact:
         lv_path: "{{ logical_volume.stdout_lines[1] | split | last }}"

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -9,6 +9,9 @@
   vars:
     slack_alerts_channel: infrastructure
 
+  vars_files:
+    - ../../group_vars/all/vault.yml
+
   pre_tasks:
     - name: stop playbook if you didn't use --limit
       ansible.builtin.fail:

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -20,19 +20,23 @@
       run_once: true
 
   tasks:
-    - name: check the starting disk size
+    - name: check the starting_disk_size
       ansible.builtin.command: df -h
       register: starting_disk_size
 
-    - name: check the starting lv size
-      ansible.builtin.set_fact: 
-        starting_lv_size: "{{ starting_disk_size.stdout_lines[2].split()[1] }}"
-
     - name: view the starting_disk_size
       ansible.builtin.debug:
-        var: starting_lv_size
+        var: starting_disk_size
 
-    - name: check the free physical disk size
+    - name: obtain the starting_vm_size
+      ansible.builtin.set_fact:
+        starting_vm_size: "{{ starting_disk_size.stdout_lines[2].split()[1] }}"
+
+    - name: view the starting_vm_size
+      ansible.builtin.debug:
+        var: starting_vm_size
+
+    - name: check the free_physical_disk_size
       ansible.builtin.command: pvs
       register: free_physical_disk_size
 
@@ -54,7 +58,7 @@
       when:
       - physical_disk_size_int == '0'
 
-    - name: gather name of the logical volume
+    - name: gather name of the logical_volume
       ansible.builtin.command: sudo lvdisplay
       register: logical_volume
 
@@ -62,11 +66,11 @@
       ansible.builtin.debug:
         var: ansible_facts
 
-    - name: view the logical volume
+    - name: view the logical_volume
       ansible.builtin.debug:
         var: logical_volume
 
-    - name: gather the logical volume path
+    - name: gather the lv_path
       ansible.builtin.set_fact:
         lv_path: "{{ logical_volume.stdout_lines[1] | split | last }}"
 
@@ -80,13 +84,25 @@
     - name: resize the filesystem to use the newly allocated space
       ansible.builtin.command: sudo resize2fs "{{ lv_path }}"
 
-    - name: check the new disk size
+    - name: check the new_disk_size
       ansible.builtin.command: df -h
       register: new_disk_size
+
+    - name: view the new_disk_size
+      ansible.builtin.debug:
+        var: new_disk_size
+
+    - name: obtain the new_vm_size
+      ansible.builtin.set_fact:
+        new_vm_size: "{{ new_disk_size.stdout_lines[2].split()[1] }}"
+
+    - name: view the new_vm_size
+      ansible.builtin.debug:
+        var: new_vm_size
 
   post_tasks:
   - name: let folks on slack know the disk status
     community.general.slack:
       token: "{{ vault_tower_slack_token }}"
-      msg: "Ansible has successfully updated the disk from `{{ starting_disk_size }}` to `{{ new_disk_size }}` on the `{{ inventory_hostname }}` VM"
+      msg: "Ansible has successfully updated the disk from `{{ starting_vm_size }}` to `{{ new_vm_size }}` on the `{{ inventory_hostname }}` VM"
       channel: "{{ slack_alerts_channel }}"

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -32,10 +32,27 @@
       ansible.builtin.debug:
         var: starting_lv_size
 
+    - name: check the starting disk size with pvs
+      ansible.builtin.command: pvs
+      register: starting_disk_size_pvs
+
+    - name: view the starting_disk_size with pvs
+      ansible.builtin.debug:
+        var: starting_disk_size_pvs
+
+    - name: check the free physical disk size with pvs
+      ansible.builtin.set_fact: 
+        starting_lv_size_pvs: "{{ starting_disk_size_pvs.stdout_lines[1] | split | last }}"
+      ignore_errors: true
+
+    - name: view the starting_lv_size with pvs
+      ansible.builtin.debug:
+        var: starting_lv_size_pvs
+
     - name: End the play if the disk is expanded
       ansible.builtin.meta: end_host
       when:
-      - starting_lv_size == '28G'
+      - starting_lv_size_pvs == '0'
 
     - name: gather name of the logical volume
       ansible.builtin.command: sudo lvdisplay

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -5,10 +5,10 @@
   hosts: all
   remote_user: pulsys
   become: true
-
+#/dev/ubuntu-vg/ubuntu-lv"
   pre_tasks:
     - name: stop playbook if you didn't use --limit
-      fail:
+      ansible.builtin.fail:
         msg: "you must use -l or --limit"
       when: ansible_limit is not defined
       run_once: true
@@ -18,10 +18,31 @@
       ansible.builtin.command: sudo lvdisplay
       register: logical_volume
 
+    - name: view the ansible_facts
+      ansible.builtin.debug:
+        var: ansible_facts
+
     - name: view the logical volume
       ansible.builtin.debug:
         var: logical_volume
-  
+
+    - name: testing var
+      ansible.builtin.set_fact:
+        info: "{{ info | d({})|combine({_key: _val}) }}"
+      loop: "{{ logical_volume.stdout_lines }}"
+      vars:
+        _list: "{{ item.split('\n')|map('trim') }}"
+        _key: "{{ _list.0.split(' ')|last }}"
+        _val: "{{ _list[1:]|select()|map('from_yaml')|combine }}"
+
+    - name: view info
+      ansible.builtin.debug:
+        var: info
+
+    - name: view the specifics from logical volume
+      ansible.builtin.debug:
+        var: logical_volume.stdout_lines
+
     # - name: extend the size of the logical volume
     #   ansible.builtin.command: sudo lvextend -l +100%FREE $LV_PATH
 

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -6,11 +6,11 @@
   remote_user: pulsys
   become: true
 
-  # vars:
-  #   slack_alerts_channel: infrastructure
+  vars:
+    slack_alerts_channel: infrastructure
 
-  # vars_files:
-  #   - ../../group_vars/all/vault.yml
+  vars_files:
+    - ../../group_vars/all/vault.yml
 
   pre_tasks:
     - name: stop playbook if you didn't use --limit

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -24,34 +24,18 @@
       ansible.builtin.command: df -h
       register: starting_disk_size
 
-    - name: view the starting_disk_size
-      ansible.builtin.debug:
-        var: starting_disk_size
-
     - name: obtain the starting_vm_size
       ansible.builtin.set_fact:
         starting_vm_size: "{{ starting_disk_size.stdout_lines[2].split()[1] }}"
-
-    - name: view the starting_vm_size
-      ansible.builtin.debug:
-        var: starting_vm_size
 
     - name: check the free_physical_disk_size
       ansible.builtin.command: pvs
       register: free_physical_disk_size
 
-    - name: view the free_physical_disk_size
-      ansible.builtin.debug:
-        var: free_physical_disk_size
-
     - name: obtain an integer for the free_physical_disk_size
       ansible.builtin.set_fact: 
         physical_disk_size_int: "{{ free_physical_disk_size.stdout_lines[1] | split | last }}"
       ignore_errors: true
-
-    - name: view the physical_disk_size_int
-      ansible.builtin.debug:
-        var: physical_disk_size_int
 
     - name: End the play if the disk is expanded
       ansible.builtin.meta: end_host
@@ -62,10 +46,6 @@
       ansible.builtin.command: sudo lvdisplay
       register: logical_volume
 
-    - name: view the ansible_facts
-      ansible.builtin.debug:
-        var: ansible_facts
-
     - name: view the logical_volume
       ansible.builtin.debug:
         var: logical_volume
@@ -73,10 +53,6 @@
     - name: gather the lv_path
       ansible.builtin.set_fact:
         lv_path: "{{ logical_volume.stdout_lines[1] | split | last }}"
-
-    - name: view lv_path
-      ansible.builtin.debug:
-        var: lv_path
 
     - name: extend the size of the logical volume
       ansible.builtin.command: sudo lvextend -l +100%FREE "{{ lv_path }}"
@@ -88,17 +64,9 @@
       ansible.builtin.command: df -h
       register: new_disk_size
 
-    - name: view the new_disk_size
-      ansible.builtin.debug:
-        var: new_disk_size
-
     - name: obtain the new_vm_size
       ansible.builtin.set_fact:
         new_vm_size: "{{ new_disk_size.stdout_lines[2].split()[1] }}"
-
-    - name: view the new_vm_size
-      ansible.builtin.debug:
-        var: new_vm_size
 
   post_tasks:
   - name: let folks on slack know the disk status

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -1,0 +1,40 @@
+---
+#  This playbook will expand the disk on a new vm
+#     
+- name: expand disk
+  hosts: all
+  remote_user: pulsys
+  become: true
+
+  pre_tasks:
+    - name: stop playbook if you didn't use --limit
+      fail:
+        msg: "you must use -l or --limit"
+      when: ansible_limit is not defined
+      run_once: true
+
+  tasks:
+    - name: gather name of the logical volume
+      ansible.builtin.command: sudo lvdisplay
+      register: logical_volume
+
+    - name: view the logical volume
+      ansible.builtin.debug:
+        var: logical_volume
+  
+    # - name: extend the size of the logical volume
+    #   ansible.builtin.command: sudo lvextend -l +100%FREE $LV_PATH
+
+    # - name: resize the filesystem to use the newly allocated space
+    #   ansible.builtin.command:
+
+    # - name: check the new disk size
+
+    # - name: 
+
+    # - name: 
+
+  # post_tasks:
+    # - name: send information to slack
+      # ansible.builtin.include_tasks:
+        # file: slack_tasks_end_of_playbook.yml

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -6,11 +6,11 @@
   remote_user: pulsys
   become: true
 
-  vars:
-    slack_alerts_channel: infrastructure
+  # vars:
+  #   slack_alerts_channel: infrastructure
 
-  vars_files:
-    - ../../group_vars/all/vault.yml
+  # vars_files:
+  #   - ../../group_vars/all/vault.yml
 
   pre_tasks:
     - name: stop playbook if you didn't use --limit
@@ -24,6 +24,19 @@
       ansible.builtin.command: df -h
       register: starting_disk_size
 
+    - name: check the starting lv size
+      ansible.builtin.set_fact: 
+        starting_lv_size: "{{ starting_disk_size.stdout_lines[2].split()[1] }}"
+
+    - name: view the starting_disk_size
+      ansible.builtin.debug:
+        var: starting_lv_size
+
+    - name: End the play if the disk is expanded
+      ansible.builtin.meta: end_host
+      when:
+      - starting_lv_size == '28G'
+
     - name: gather name of the logical volume
       ansible.builtin.command: sudo lvdisplay
       register: logical_volume
@@ -36,7 +49,7 @@
       ansible.builtin.debug:
         var: logical_volume
 
-    - name: testing var
+    - name: gather the logical volume path
       ansible.builtin.set_fact:
         lv_path: "{{ logical_volume.stdout_lines[1] | split | last }}"
 

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -32,27 +32,27 @@
       ansible.builtin.debug:
         var: starting_lv_size
 
-    - name: check the starting disk size with pvs
+    - name: check the free physical disk size
       ansible.builtin.command: pvs
-      register: starting_disk_size_pvs
+      register: free_physical_disk_size
 
-    - name: view the starting_disk_size with pvs
+    - name: view the free_physical_disk_size
       ansible.builtin.debug:
-        var: starting_disk_size_pvs
+        var: free_physical_disk_size
 
-    - name: check the free physical disk size with pvs
+    - name: obtain an integer for the free_physical_disk_size
       ansible.builtin.set_fact: 
-        starting_lv_size_pvs: "{{ starting_disk_size_pvs.stdout_lines[1] | split | last }}"
+        physical_disk_size_int: "{{ free_physical_disk_size.stdout_lines[1] | split | last }}"
       ignore_errors: true
 
-    - name: view the starting_lv_size with pvs
+    - name: view the physical_disk_size_int
       ansible.builtin.debug:
-        var: starting_lv_size_pvs
+        var: physical_disk_size_int
 
     - name: End the play if the disk is expanded
       ansible.builtin.meta: end_host
       when:
-      - starting_lv_size_pvs == '0'
+      - physical_disk_size_int == '0'
 
     - name: gather name of the logical volume
       ansible.builtin.command: sudo lvdisplay

--- a/playbooks/utils/expand_disk.yml
+++ b/playbooks/utils/expand_disk.yml
@@ -5,7 +5,10 @@
   hosts: all
   remote_user: pulsys
   become: true
-#/dev/ubuntu-vg/ubuntu-lv"
+
+  vars:
+    slack_alerts_channel: infrastructure
+
   pre_tasks:
     - name: stop playbook if you didn't use --limit
       ansible.builtin.fail:
@@ -14,6 +17,10 @@
       run_once: true
 
   tasks:
+    - name: check the starting disk size
+      ansible.builtin.command: df -h
+      register: starting_disk_size
+
     - name: gather name of the logical volume
       ansible.builtin.command: sudo lvdisplay
       register: logical_volume
@@ -28,34 +35,25 @@
 
     - name: testing var
       ansible.builtin.set_fact:
-        info: "{{ info | d({})|combine({_key: _val}) }}"
-      loop: "{{ logical_volume.stdout_lines }}"
-      vars:
-        _list: "{{ item.split('\n')|map('trim') }}"
-        _key: "{{ _list.0.split(' ')|last }}"
-        _val: "{{ _list[1:]|select()|map('from_yaml')|combine }}"
+        lv_path: "{{ logical_volume.stdout_lines[1] | split | last }}"
 
-    - name: view info
+    - name: view lv_path
       ansible.builtin.debug:
-        var: info
+        var: lv_path
 
-    - name: view the specifics from logical volume
-      ansible.builtin.debug:
-        var: logical_volume.stdout_lines
+    - name: extend the size of the logical volume
+      ansible.builtin.command: sudo lvextend -l +100%FREE "{{ lv_path }}"
 
-    # - name: extend the size of the logical volume
-    #   ansible.builtin.command: sudo lvextend -l +100%FREE $LV_PATH
+    - name: resize the filesystem to use the newly allocated space
+      ansible.builtin.command: sudo resize2fs "{{ lv_path }}"
 
-    # - name: resize the filesystem to use the newly allocated space
-    #   ansible.builtin.command:
+    - name: check the new disk size
+      ansible.builtin.command: df -h
+      register: new_disk_size
 
-    # - name: check the new disk size
-
-    # - name: 
-
-    # - name: 
-
-  # post_tasks:
-    # - name: send information to slack
-      # ansible.builtin.include_tasks:
-        # file: slack_tasks_end_of_playbook.yml
+  post_tasks:
+  - name: let folks on slack know the disk status
+    community.general.slack:
+      token: "{{ vault_tower_slack_token }}"
+      msg: "Ansible has successfully updated the disk from `{{ starting_disk_size }}` to `{{ new_disk_size }}` on the `{{ inventory_hostname }}` VM"
+      channel: "{{ slack_alerts_channel }}"


### PR DESCRIPTION
Playbook successfully expands disk. Need a way to handle disks that are already expanded.

```
TASK [view the logical volume] ************************************************************************************************************************************
ok: [sandbox-bd4538.lib.princeton.edu] => {
    "logical_volume": {
        "changed": true,
        "cmd": [
            "sudo",
            "lvdisplay"
        ],
        "delta": "0:00:00.061315",
        "end": "2024-09-16 15:56:45.772973",
        "failed": false,
        "msg": "",
        "rc": 0,
        "start": "2024-09-16 15:56:45.711658",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "  --- Logical volume ---\n  LV Path                /dev/ubuntu-vg/ubuntu-lv\n  LV Name                ubuntu-lv\n  VG Name                ubuntu-vg\n  LV UUID                VBfBWL-Uc6c-x54u-xmYF-16kH-NfbB-uMu9Ft\n  LV Write Access        read/write\n  LV Creation host, time ubuntu-server, 2024-09-06 14:38:46 +0000\n  LV Status              available\n  # open                 1\n  LV Size                <28.00 GiB\n  Current LE             7167\n  Segments               1\n  Allocation             inherit\n  Read ahead sectors     auto\n  - currently set to     256\n  Block device           253:0\n   ",
        "stdout_lines": [
            "  --- Logical volume ---",
            "  LV Path                /dev/ubuntu-vg/ubuntu-lv",
            "  LV Name                ubuntu-lv",
            "  VG Name                ubuntu-vg",
            "  LV UUID                VBfBWL-Uc6c-x54u-xmYF-16kH-NfbB-uMu9Ft",
            "  LV Write Access        read/write",
            "  LV Creation host, time ubuntu-server, 2024-09-06 14:38:46 +0000",
            "  LV Status              available",
            "  # open                 1",
            "  LV Size                <28.00 GiB",
            "  Current LE             7167",
            "  Segments               1",
            "  Allocation             inherit",
            "  Read ahead sectors     auto",
            "  - currently set to     256",
            "  Block device           253:0",
            "   "
        ]
    }
}

TASK [testing var] ************************************************************************************************************************************************
ok: [sandbox-bd4538.lib.princeton.edu]

TASK [view lv_path] ***********************************************************************************************************************************************
ok: [sandbox-bd4538.lib.princeton.edu] => {
    "lv_path": "/dev/ubuntu-vg/ubuntu-lv"
}

TASK [extend the size of the logical volume] **********************************************************************************************************************
fatal: [sandbox-bd4538.lib.princeton.edu]: FAILED! => {"changed": true, "cmd": ["sudo", "lvextend", "-l", "+100%FREE", "/dev/ubuntu-vg/ubuntu-lv"], "delta": "0:00:00.055417", "end": "2024-09-16 15:56:46.378491", "msg": "non-zero return code", "rc": 5, "start": "2024-09-16 15:56:46.323074", "stderr": "  New size (7167 extents) matches existing size (7167 extents).", "stderr_lines": ["  New size (7167 extents) matches existing size (7167 extents)."], "stdout": "", "stdout_lines": []}

PLAY RECAP ********************************************************************************************************************************************************
sandbox-bd4538.lib.princeton.edu : ok=7    changed=2    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0
```