### PR TITLE
Update cdh_test_htr config : add configurations for proxying websockets

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/cdh_test_htr.conf
+++ b/roles/nginxplus/files/conf/http/dev/cdh_test_htr.conf
@@ -44,6 +44,13 @@ server {
         proxy_pass http://cdh-test-htr;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+
+        # enable proxying websockets
+        proxy_http_version 1.1;
+        proxy_set_header    Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
         proxy_cache cdh-test-htrcache;
         # handle errors using errors.conf
         proxy_intercept_errors on;


### PR DESCRIPTION
This application includes an ASGI component, which is proxied by the nginx on our cdh-test-htr VMs. I think these are the configuration changes that are needed to allow nginx to proxy the websockets / ASGI.