### PR TITLE
Downgrading NodeJS to 20.15.1 for TigerData

### DIFF
--- a/group_vars/tigerdata/production.yml
+++ b/group_vars/tigerdata/production.yml
@@ -3,7 +3,7 @@ postgres_host: "lib-postgres-prod1.princeton.edu"
 
 passenger_server_name: "tigerdata-prod.princeton.edu"
 passenger_app_env: "production"
-desired_nodejs_version: "v20.17.0"
+desired_nodejs_version: "v20.15.1"
 
 app_secret_key: '{{ vault_tigerdata_prod_secret_key }}'
 app_db_name: '{{ vault_tigerdata_prod_db_name }}'

--- a/group_vars/tigerdata/qa.yml
+++ b/group_vars/tigerdata/qa.yml
@@ -3,7 +3,7 @@ postgres_host: "lib-postgres-qa1.princeton.edu"
 
 passenger_server_name: "tigerdata-qa.princeton.edu"
 passenger_app_env: "qa"
-desired_nodejs_version: "v20.17.0"
+desired_nodejs_version: "v20.15.1"
 
 app_secret_key: '{{ vault_tigerdata_qa_secret_key }}'
 app_db_name: '{{ vault_tigerdata_qa_db_name }}'

--- a/group_vars/tigerdata/staging.yml
+++ b/group_vars/tigerdata/staging.yml
@@ -4,7 +4,7 @@ postgres_host: "lib-postgres-staging1.princeton.edu"
 passenger_server_name: "tigerdata-staging.princeton.edu"
 passenger_app_env: "staging"
 passenger_extra_config: "{{ lookup('template', 'roles/tigerdata/templates/nginx_extra_config.j2') }}"
-desired_nodejs_version: "v20.17.0"
+desired_nodejs_version: "v20.15.1"
 
 app_secret_key: '{{ vault_tigerdata_staging_secret_key }}'
 app_db_name: '{{ vault_tigerdata_staging_db_name }}'


### PR DESCRIPTION
https://pulmirror.princeton.edu/mirror/node/dist/latest-v20.x/ does not support any releases in the 20.17 series (please see https://github.com/pulibrary/princeton_ansible/pull/5339 and https://github.com/pulibrary/tigerdata-app/pull/923 for reference)