### PR TITLE
[Bibdata-staging][Passenger] Set bibdata-staging.lib to use dev load balancer;templatize dev and prod load balancer IPs

### DIFF
--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -14,6 +14,10 @@ passenger_app_root: "/opt/bibdata/current/public"
 passenger_app_env: "staging"
 passenger_extra_config: "{{ lookup('file', 'roles/bibdata/templates/nginx_extra_config')  }}"
 rails_app_name: "bibdata"
+passenger_real_ip_from:
+  - 172.20.80.13
+  - 172.20.80.14
+  - 172.20.80.19
 rails_app_directory: "bibdata"
 rails_app_symlinks: []
 rails_app_env: "staging"

--- a/roles/passenger/defaults/main.yml
+++ b/roles/passenger/defaults/main.yml
@@ -2,6 +2,15 @@
 passenger_server_name: www.example.com
 passenger_app_root: /opt/rails_app/current/public
 passenger_app_env: production
+passenger_real_ip_from:
+  - 128.112.203.144
+  - 128.112.203.145
+  - 128.112.203.146
+# dev loadbalancer
+passenger_real_ip_from_staging:
+  - 172.20.80.13
+  - 172.20.80.14
+  - 172.20.80.19
 passenger_listen_port: '80'
 
 passenger_root: /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini

--- a/roles/passenger/templates/passenger.j2
+++ b/roles/passenger/templates/passenger.j2
@@ -2,19 +2,17 @@ server {
   listen {{ passenger_listen_port }} default_server;
   server_name {{ passenger_server_name }};
   passenger_enabled {{ passenger_enabled }};
-  passenger_app_env {{ passenger_app_env }};
-  passenger_set_header X-Forwarded-Proto https;
   passenger_set_header X-Forwarded-For $remote_addr;
+  passenger_set_header    X-Real-IP        $remote_addr;
   root {{ passenger_app_root }};
-  set_real_ip_from 128.112.203.144;
-  set_real_ip_from 128.112.203.145;
-  set_real_ip_from 128.112.203.146;
-  real_ip_header X-Real-IP;
+  {% for ip in passenger_real_ip_from %}
+    set_real_ip_from {{ ip }};
+    {% endfor %}
   large_client_header_buffers 4 16k;
 
   access_log /var/log/nginx/access.log custom if=$logging_enabled;
 
-  {{passenger_extra_config}}
+  {{ passenger_extra_config }}
 
   location /nginx_status {
     stub_status;
@@ -25,8 +23,8 @@ server {
 
 # this filters out the load-balancer IPs, so we don't log health checks from them
 map $remote_addr $logging_enabled {
-     "128.112.203.144" 0;
-     "128.112.203.145" 0;
-     "128.112.203.146" 0;
+  {% for ip in passenger_real_ip_from %}
+    "{{ ip }}" 0;
+    {% endfor %}
      default 1;
 }


### PR DESCRIPTION
[Bibdata-staging]Set bibdata-staging.lib to use dev load balancer by providing real IP variable in group_vars/bibdata/staging.yml

[Passenger]templatize dev and prod load balancer IPs make default to be prod load balance IPs. see: roles/passenger/defaults/main.yml Update roles/passenger/templates/passenger.j2