### PR TITLE
Add @cmroughan to list of CDH github keys

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -117,6 +117,7 @@ cdh_github_keys:
   - https://github.com/jerielizabeth.keys
   - https://github.com/laurejt.keys
   - https://github.com/rlskoeser.keys
+  - https://github.com/cmroughan.keys  # CDH post-doc, co-PI on HTR2HPC project
   - https://github.com/haydngreatnews.keys # Haydn Greatnews, contractor (Springload)
   - https://github.com/sarahframe.keys # Sarah Frame, contractor (Springload)
 eal_github_keys:


### PR DESCRIPTION
Adding CDH postdoc @cmroughan to list of CDH keys - she's working with me on the HTR project and it will be helpful for her to have ssh access to the test-htr VMs.