### PR TITLE
[cdh] add dev loadbalancers

### DIFF
--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -36,14 +36,16 @@ cdh-test-web2.princeton.edu
 [cdh_shared_production]
 # these groups allow us to add ops, lib, & CDH keys
 # for the pulsys user
+lib-adc1.princeton.edu
+lib-adc2.princeton.edu
 lib-fs-prod.princeton.edu
 lib-postgres-prod1.princeton.edu
 lib-postgres-prod3.princeton.edu
 lib-solr-prod1.princeton.edu
 lib-solr-prod7.princeton.edu
-lib-adc1.princeton.edu
-lib-adc2.princeton.edu
 [cdh_shared_staging]
+adc-dev1.lib.princeton.edu
+adc-dev2.lib.princeton.edu
 lib-fs-staging.princeton.edu
 lib-postgres-staging1.princeton.edu
 lib-solr-staging1.princeton.edu


### PR DESCRIPTION
this enables the cdh users to have access to the dev loadbalancers

alphabetize the names for production
