### PR TITLE
[TIGERDATA] Making the production mediaflux the production default

### DIFF
--- a/group_vars/tigerdata/production.yml
+++ b/group_vars/tigerdata/production.yml
@@ -74,10 +74,10 @@ sidekiq_worker_threads: 4
 redis_bind_interface: '0.0.0.0'
 
 # TODO - When we remove the flipper app_mediaflux_port app_mediaflux_host should default to production
-app_mediaflux_port: "{{ vault_mediaflux_port }}"
-app_mediaflux_host: "{{ vault_mediaflux_host }}"
-app_mediaflux_alternate_port: "{{ vault_mediaflux_production_port }}"
-app_mediaflux_alternate_host: "{{ vault_mediaflux_production_host }}"
+app_mediaflux_port: "{{ vault_mediaflux_production_port }}"
+app_mediaflux_host: "{{ vault_mediaflux_production_host }}"
+app_mediaflux_alternate_port: "{{ vault_mediaflux_port }}"
+app_mediaflux_alternate_host: "{{ vault_mediaflux_host }}"
 app_mediaflux_domain: "{{ vault_mediaflux_domain }}"
 app_mediaflux_user: "{{ vault_mediaflux_user }}"
 app_mediaflux_password: "{{ vault_mediaflux_password }}"


### PR DESCRIPTION
This has been applied to production.  See https://tigerdata-prod.princeton.edu/mediaflux_info

fixes https://github.com/pulibrary/tigerdata-app/issues/927