### PR TITLE
Migrating libweb2 to the static site

### DIFF
--- a/roles/nginxplus/files/conf/http/static_prod.conf
+++ b/roles/nginxplus/files/conf/http/static_prod.conf
@@ -88,6 +88,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_intercept_errors on;
     }
+    include /etc/nginx/conf.d/templates/libweb2-redirects.conf;
     include /etc/nginx/conf.d/templates/errors.conf;
 }
 

--- a/roles/nginxplus/files/conf/http/static_prod.conf
+++ b/roles/nginxplus/files/conf/http/static_prod.conf
@@ -13,7 +13,7 @@ upstream static-prod {
 
 server {
     listen 80;
-    server_name static-prod.lib.princeton.edu;
+    server_name daviesproject.lib.princeton.edu;
 
     location / {
         return 301 https://$server_name$request_uri;
@@ -40,7 +40,7 @@ server {
 
 server {
     listen 80;
-    server_name daviesproject.lib.princeton.edu;
+    server_name static-prod.lib.princeton.edu;
 
     location / {
         return 301 https://$server_name$request_uri;
@@ -50,22 +50,24 @@ server {
 server {
     listen 443 ssl;
     http2 on;
-    server_name static-prod.lib.princeton.edu;
+    server_name daviesproject.lib.princeton.edu;
 
-    ssl_certificate            /etc/letsencrypt/live/static-prod.lib/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/static-prod.lib/privkey.pem;
+    ssl_certificate            /etc/letsencrypt/live/daviesproject.lib/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/daviesproject.lib/privkey.pem;
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 
     location / {
         proxy_pass http://static-prod;
         proxy_cache static-prodcache;
+        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
-        proxy_intercept_errors on;
-
+        
     }
+
     include /etc/nginx/conf.d/templates/errors.conf;
+
 }
 
 server {
@@ -113,22 +115,20 @@ server {
 server {
     listen 443 ssl;
     http2 on;
-    server_name daviesproject.lib.princeton.edu;
+    server_name static-prod.lib.princeton.edu;
 
-    ssl_certificate            /etc/letsencrypt/live/daviesproject.lib/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/daviesproject.lib/privkey.pem;
+    ssl_certificate            /etc/letsencrypt/live/static-prod.lib/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/static-prod.lib/privkey.pem;
     ssl_session_cache          shared:SSL:1m;
     ssl_prefer_server_ciphers  on;
 
     location / {
         proxy_pass http://static-prod;
         proxy_cache static-prodcache;
-        proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
         proxy_set_header Host $http_host;
-        
+        proxy_intercept_errors on;
+
     }
-
     include /etc/nginx/conf.d/templates/errors.conf;
-
 }

--- a/roles/nginxplus/files/conf/http/static_prod.conf
+++ b/roles/nginxplus/files/conf/http/static_prod.conf
@@ -22,6 +22,15 @@ server {
 
 server {
     listen 80;
+    server_name libweb2.princeton.edu;
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+server {
+    listen 80;
     server_name milberg.lib.princeton.edu;
 
     location / {
@@ -55,6 +64,27 @@ server {
         proxy_set_header Host $http_host;
         proxy_intercept_errors on;
 
+    }
+    include /etc/nginx/conf.d/templates/errors.conf;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name libweb2.princeton.edu;
+
+    ssl_certificate            /etc/letsencrypt/live/libweb2/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/libweb2/privkey.pem;
+    
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    location / {
+        proxy_pass http://static-prod;
+        proxy_cache static-prodcache;
+        health_check interval=10 fails=3 passes=2;
+        proxy_set_header Host $http_host;
+        proxy_intercept_errors on;
     }
     include /etc/nginx/conf.d/templates/errors.conf;
 }

--- a/roles/nginxplus/files/conf/http/templates/libweb2-redirects.conf
+++ b/roles/nginxplus/files/conf/http/templates/libweb2-redirects.conf
@@ -1,0 +1,1 @@
+rewrite http://libweb2.princeton.edu/rbsc2/(.*)$ https://static-prod.lib/princeton.edu/scsites/$request_uri permanent;


### PR DESCRIPTION
Partial fix for #5294. 

Adds a redirect for the old libweb2 URL.
Adds nginxplus config for the new site within libstatic.

Once this is confirmed as working, we can decommission the old infrastructure.