### PR TITLE
Fix configuration for logos in nginxplus CDH error pages

### DIFF
--- a/roles/nginxplus/files/cdh-error.html
+++ b/roles/nginxplus/files/cdh-error.html
@@ -90,7 +90,7 @@
         </p>
         <p>
         <a href="https://cdh.princeton.edu">
-          <img src="CDH_logo.svg" alt="Center for Digital Humanities"/>
+          <img src="/CDH_logo.svg" alt="Center for Digital Humanities"/>
         </a>
         </p>
       </div>

--- a/roles/nginxplus/files/cdh-forbidden.html
+++ b/roles/nginxplus/files/cdh-forbidden.html
@@ -83,7 +83,7 @@
         </p>
         <p>
         <a href="https://cdh.princeton.edu">
-          <img src="CDH_logo.svg" alt="Center for Digital Humanities"/>
+          <img src="/CDH_logo.svg" alt="Center for Digital Humanities"/>
         </a>
         </p>
       </div>

--- a/roles/nginxplus/files/conf/http/dev/cdh_test_htr.conf
+++ b/roles/nginxplus/files/conf/http/dev/cdh_test_htr.conf
@@ -46,7 +46,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
 
         # enable proxying websockets
-        proxy_http_version 1.1;
         proxy_set_header    Host $http_host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/roles/nginxplus/files/conf/http/templates/cdh-errors.conf
+++ b/roles/nginxplus/files/conf/http/templates/cdh-errors.conf
@@ -16,10 +16,10 @@ error_page 403 /cdh-forbidden.html;
 
     location = /CDH_logo.svg {
         ssi on;
-        root /var/local/www/default;
+        alias /var/local/www/default/CDH_logo.svg;
     }
 
     location = /pul_logo_new.svg {
         ssi on;
-        root /var/local/www/default;
+        alias /var/local/www/default/pul_logo_new.svg;
     }


### PR DESCRIPTION
Currently we're getting 404s for the logos included on the nginxplus error pages - I've been ignoring it because it's not really a big deal, but the 404 errors in the logs caused some confusion when we were troubleshooting something else recently.

The PR includes these changes:

- make image paths relative to `/` since error page may occur at a sub url
- use `alias` instead of `root` for configuring error image urls

I tested this change manually on the load balancer. It fixed the display for the CDH logo but not the PUL one - I'm still getting a 404 trying to load that one. I don't understand why, the files and configurations look the same to me.

It's possible to do both images in a single location. I wasn't sure if that would be less readable to you so I left it out, but it would look like this:
```nginx
location ~ /(CDH_logo|pul_logo_new).svg {
       ssi on;
       alias /var/local/www/default/$1.svg;
}
 ```