### PR TITLE
[cdh-prodigy-test] Update nginx config to allow large headers

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
@@ -65,6 +65,10 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        ## increase proxy buffer size to allow large headers
+        proxy_buffer_size 16k;
+        proxy_buffers 4 16k;
+        proxy_busy_buffers_size 32k;
         proxy_cache test_prodigycache;
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;


### PR DESCRIPTION
Updating the nginx config to allow large headers for the cdh prodigy test server.

---
Co-authored-by: Rebecca Sutton Koeser <rlskoeser@users.noreply.github.com>