### PR TITLE
[prancible] BigFix and Rapid7

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -24,11 +24,6 @@ gcp-postgres-prod1 ansible_host=10.240.0.2
 gcp_dataspace_staging1 ansible_host=10.132.0.5
 gcp_oar_staging1 ansible_host=10.132.0.4
 
-[docnow_production]
-community.docnow.io ansible_host=10.140.0.4
-
-[docnow_staging]
-smoketest.docnow.io ansible_host=10.244.0.5
 
 [obsd_httpd_dev]
 dev.pulcloud.io

--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -11,7 +11,6 @@ cantaloupe_production
 cdh_production
 cicognara_production
 derrida_production
-docnow_production
 dpul_production
 dss_production
 dspace_production

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -10,7 +10,6 @@ cantaloupe_staging
 cdh_staging
 cicognara_staging
 derrida_staging
-docnow_staging
 dpul_staging
 dss_staging
 dspace_staging

--- a/playbooks/utils/security_theater.yml
+++ b/playbooks/utils/security_theater.yml
@@ -20,6 +20,13 @@
   - name: Populate package facts
     ansible.builtin.package_facts:
 
+  - name: Import BigFix GPG key
+    ansible.builtin.rpm_key:
+      state: present
+      key: https://software.bigfix.com/download/bes/95/RPM-GPG-KEY-BigFix-9-V2
+    when:
+     - ansible_pkg_mgr == 'dnf'
+
   - name: Create bigfix directory
     ansible.builtin.file:
       path: /etc/opt/BESClient
@@ -37,16 +44,29 @@
       mode: "0600"
     when: "ansible_facts.services['besclient.service'] is not defined"
 
-  - name: Download the bigfix deb file
+  - name: Download the bigfix deb file (Ubuntu)
     ansible.builtin.get_url:
       url: "https://software.bigfix.com/download/bes/100/BESAgent-10.0.7.52-debian6.amd64.deb"
       dest: "/tmp/BESAgent-10.0.7.52-debian6.amd64.deb"
       owner: pulsys
       group: pulsys
       mode: "0644"
-    when: "ansible_facts.services['besclient.service'] is not defined"
+    when:
+     - "ansible_facts.services['besclient.service'] is not defined"
+     - ansible_pkg_mgr == 'apt'
 
-  - name: Download the Falcon sensor deb file
+  - name: Download the bigfix deb file (RedHat)
+    ansible.builtin.get_url:
+      url: "https://software.bigfix.com/download/bes/100/BESAgent-10.0.7.52-rhe6.x86_64.rpm"
+      dest: "/tmp/BESAgent-10.0.7.52-rhel6.x86_64.rpm"
+      owner: pulsys
+      group: pulsys
+      mode: "0644"
+    when:
+     - "ansible_facts.services['besclient.service'] is not defined"
+     - ansible_pkg_mgr == 'dnf'
+
+  - name: Download the Falcon sensor deb file (Ubuntu)
     ansible.builtin.get_url:
       url: "https://isoshare.cpaneldev.princeton.edu/isoShares/Agents/Falcon/Latest/linux/Ubuntu/14_16_18_20_22/falcon-sensor_7.05.0-16004_amd64.deb"
       dest: "/tmp/falcon-sensor_7.05.0-16004_amd64.deb"
@@ -56,20 +76,49 @@
     when:
       - "'falcon-sensor' not in ansible_facts.packages"
 
-  - name: install BESClient agent
+  - name: Download the Falcon sensor rpm file (RedHat)
+    ansible.builtin.get_url:
+      url: "https://isoshare.cpaneldev.princeton.edu/isoShares/Agents/Falcon/Latest/linux/RHEL/Oracle/9/falcon-sensor-7.02.0-15705.el9.x86_64.rpm"
+      dest: "/tmp/falcon-sensor_7.05.0-16004_el9.x86_64.rpm"
+      owner: pulsys
+      group: pulsys
+      mode: "0644"
+    when:
+      - "'falcon-sensor' not in ansible_facts.packages"
+
+  - name: install BESClient agent (Ubuntu)
     ansible.builtin.apt:
       deb: "/tmp/BESAgent-10.0.7.52-debian6.amd64.deb"
-    when: "ansible_facts.services['besclient.service'] is not defined"
+    when:
+      - "ansible_facts.services['besclient.service'] is not defined"
+      - ansible_pkg_mgr == 'apt'
+
+  - name: install BESClient agent (RedHat)
+    ansible.builtin.dnf:
+      name: "/tmp/BESAgent-10.0.7.52-rhel6.x86_64.rpm"
+      state: present
+    when:
+      - "ansible_facts.services['besclient.service'] is not defined"
+      - ansible_pkg_mgr == 'dnf'
 
   - name: Launch the BigFix client
     ansible.builtin.command: /etc/init.d/besclient start
     when: "ansible_facts.services['besclient.service'] is not defined"
 
-  - name: install crowdstrike falcon sensor agent
+  - name: install crowdstrike falcon sensor agent (Ubuntu)
     ansible.builtin.apt:
       deb: "/tmp/falcon-sensor_7.05.0-16004_amd64.deb"
     when:
       - "'falcon-sensor' not in ansible_facts.packages"
+      - ansible_pkg_mgr == 'apt'
+
+  - name: install crowdstrike falcon sensor agent (RedHat)
+    ansible.builtin.dnf:
+      name: "/tmp/falcon-sensor_7.05.0-16004_el9.x86_64.rpm"
+      state: present
+    when:
+      - "'falcon-sensor' not in ansible_facts.packages"
+      - ansible_pkg_mgr == 'dnf'
 
   - name: launch crowdstrike falcon agent
     command: /opt/CrowdStrike/falconctl -s --cid={{ princeton_cid }}

--- a/playbooks/utils/security_theater.yml
+++ b/playbooks/utils/security_theater.yml
@@ -75,6 +75,7 @@
       mode: "0644"
     when:
       - "'falcon-sensor' not in ansible_facts.packages"
+      - ansible_pkg_mgr == 'apt'
 
   - name: Download the Falcon sensor rpm file (RedHat)
     ansible.builtin.get_url:
@@ -85,6 +86,7 @@
       mode: "0644"
     when:
       - "'falcon-sensor' not in ansible_facts.packages"
+      - ansible_pkg_mgr == 'dnf'
 
   - name: install BESClient agent (Ubuntu)
     ansible.builtin.apt:


### PR DESCRIPTION
add keys for BigFix (needed for RHEL based boxes)
Install RHEL for BigFix and Rapid7.
We do not have the keys for CrowdStrike to complete install without
manual intervention.

related to #5347 

Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
