### PR TITLE
adds a new EE with python3.11 for Wapiti reporting

### DIFF
--- a/tower_ees/python_3_11.yml
+++ b/tower_ees/python_3_11.yml
@@ -1,0 +1,52 @@
+---
+# EE definition for general PUL automation
+# to build an EE, run `ansible-builder build`
+
+# builder schema version
+version: 3
+
+images:
+  # build a new image based on this image
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-25/ansible-python-base-rhel8@sha256:ad2b16b052485cb77152854fcfffd60c88f8614a957327fb273d09a58d7be2ad
+    # name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9
+
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.15.7
+  ansible_runner:
+    package_pip: ansible-runner
+  python_interpreter:
+    python_path: "/usr/bin/python3"
+  # galaxy:
+    # includes all collections used in the prancible repo
+    # versions taken from the Ansible 8 inclusion list:
+    # https://github.com/ansible-community/ansible-build-data/blob/main/8/ansible-8.7.0.yaml
+    # collections:
+    # these collections are not in Ansible package
+    # latest versions from Galaxy as of Feb. 2024
+
+  # python packages, stuff you install with 'pip install'
+  python:
+    - six
+    - psutil
+    - wapiti3
+
+  # system packages, stuff you install with 'apt/yum/dnf install'
+  # ansible-builder writes this list into the 'context/bindep.txt' file
+  system:
+    - git
+    - python3-dnf
+    - python3-pip
+options:
+  # default path is /usr/bin/dnf, which does not exist on the base image
+  package_manager_path: /usr/bin/microdnf
+
+# if you need to run more commands on the EE, use this section:
+# additional_build_steps:
+  # items in the list of append_base steps are expressed
+  # as containerfile directives
+  # prepend_base:
+    # - RUN /usr/bin/apt-get update
+  # append_base:
+    # - RUN /usr/bin/python3 -m pip install --upgrade pip


### PR DESCRIPTION
Wapiti requires python 3.10 or 3.11. This EE provides python 3.11.
