### PR TITLE
[videoreserves] Remove database

### DIFF
--- a/group_vars/video_reserves/production.yml
+++ b/group_vars/video_reserves/production.yml
@@ -1,23 +1,3 @@
 ---
-mysql_server: false
-
-mysql_host: "mysql-db-prod1.princeton.edu"
-
-mysql_root_password: "{{ vault_mysql_root_password }}"
-mysql_databases:
-  - name: "{{ video_reserves_db_name }}"
-    encoding: utf8mb4
-    collation: utf8mb4_general_ci
-
-mysql_users:
-  - name: "{{ video_reserves_db_user }}"
-    host: "%"
-    password: "{{ vault_video_reserves_prod_user_password }}"
-    priv: "video_reserves_prod_db.*:ALL"
-
-video_reserves_db_name: "video_reserves_prod_db"
-video_reserves_db_user: "video_reserves_prod_db_user"
-video_reserves_db_password: "{{ vault_video_reserves_prod_user_password }}"
-db_host: "{{ mysql_host }}"
 video_reserves_cert_path: "/etc/apache2/ssl/certs/{{ inventory_hostname }}_chained.pem"
 video_reserves_domain_name: "videoreserves-prod.princeton.edu"

--- a/group_vars/video_reserves/staging.yml
+++ b/group_vars/video_reserves/staging.yml
@@ -1,24 +1,5 @@
 ---
 php_version: "8.1"
-mysql_server: false
 
-mysql_host: "mysql-db-staging1.princeton.edu"
-
-mysql_root_password: "{{ vault_mysql_root_password }}"
-mysql_databases:
-  - name: "{{ video_reserves_db_name }}"
-    encoding: utf8mb4
-    collation: utf8mb4_general_ci
-
-mysql_users:
-  - name: "{{ video_reserves_db_user }}"
-    host: "%"
-    password: "{{ vault_video_reserves_staging_user_password }}"
-    priv: "video_reserves_staging_db.*:ALL"
-
-video_reserves_db_name: "video_reserves_staging_db"
-video_reserves_db_user: "video_reserves_staging_db_user"
-video_reserves_db_password: "{{ vault_video_reserves_staging_user_password }}"
-db_host: "{{ mysql_host }}"
 video_reserves_cert_path: "/etc/apache2/ssl/certs/{{ inventory_hostname }}_chained.pem"
 video_reserves_domain_name: "videoreserves-staging.princeton.edu"

--- a/roles/video_reserves/meta/main.yml
+++ b/roles/video_reserves/meta/main.yml
@@ -16,7 +16,6 @@ galaxy_info:
 dependencies:
   - role: "deploy_user"
   - role: "composer"
-  - role: "mysql"
     # It is possible the ruby_s role is not required
     # Added while removing from the capistrano role
   - role: "ruby_s"

--- a/roles/video_reserves/tasks/main.yml
+++ b/roles/video_reserves/tasks/main.yml
@@ -6,7 +6,6 @@
   notify: restart apache2
   loop:
     - libapache2-mod-php{{ php_version }}
-    - php{{ php_version }}-mysql
 
 - name: video_reserves | create directories for shared files
   ansible.builtin.file:

--- a/roles/video_reserves/templates/config.tpl.j2
+++ b/roles/video_reserves/templates/config.tpl.j2
@@ -3,10 +3,6 @@
 // {{ ansible_managed | comment }}
 // mysql info
 //
-define ('HOST', '{{ app_db_host }}');
-define ('USER', '{{ app_db_user }}');
-define ('PASS', '{{ app_db_password }}');
-define ('DB', '{{ video_reserves_db_name }}');
 define ('APP_URL', 'https://{{ video_reserves_domain_name }}/hrc'); // without trailing slash
 define('CAS_DOMAIN', 'https://{{ video_reserves_domain_name }}');
 define('CERT_PATH', '{{ video_reserves_cert_path }}');


### PR DESCRIPTION
We needed a database for the administrative interface of this application. Now that we have removed this interface, we no longer need a database or mysql dependency.

Helps with PrincetonUniversityLibrary/video_reserves#81

I ran this on staging today, 30 September.