### PR TITLE
[orangelight] Add X-Forwarded-Proto https to the catalog load balancer config

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -63,6 +63,7 @@ server {
         proxy_pass http://catalog-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache catalog-prodcache;
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -44,6 +44,7 @@ server {
         # app_protect_security_log_enable on;
         proxy_pass http://catalog-qa;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache catalog-qacache;
         limit_req zone=catalog-qa-ratelimit burst=20 nodelay;
         proxy_connect_timeout      2h;

--- a/roles/nginxplus/files/conf/http/catalog-staging.conf
+++ b/roles/nginxplus/files/conf/http/catalog-staging.conf
@@ -46,6 +46,7 @@ server {
 #        # app_protect_security_log_enable on;
         proxy_pass http://catalog-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache catalog-stagingcache;
         proxy_connect_timeout      2h;
         proxy_send_timeout         2h;


### PR DESCRIPTION


Without this, login and forms were failing in the catalog.  In the logs we saw: HTTP Origin header (https://catalog-staging.princeton.edu) didn't match request.base_url (http://catalog-staging.princeton.edu)