### PR TITLE
[#5403] Add proxy_set_header X-Forwarded-Proto https; in the dacs nginx conf files

### DIFF
--- a/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
@@ -47,6 +47,7 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
         limit_req zone=allsearch-api-prod-ratelimit burst=20 nodelay;
         proxy_cache allsearch-apicache;

--- a/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
@@ -50,6 +50,7 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
         limit_req zone=allsearch-api-staging-ratelimit burst=20 nodelay;
         # allow princeton network

--- a/roles/nginxplus/files/conf/http/approvals_prod.conf
+++ b/roles/nginxplus/files/conf/http/approvals_prod.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://approvals-prod;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache approvals-prodcache;
         limit_req zone=approvals-prod-ratelimit burst=20 nodelay;
         # handle errors using errors.conf

--- a/roles/nginxplus/files/conf/http/approvals_staging.conf
+++ b/roles/nginxplus/files/conf/http/approvals_staging.conf
@@ -43,6 +43,7 @@ server {
         # app_protect_security_log_enable on;
         proxy_pass http://approvals-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache approvals-stagingcache;
         limit_req zone=approvals-staging-ratelimit burst=20 nodelay;
         # handle errors using errors.conf

--- a/roles/nginxplus/files/conf/http/bibdata_prod.conf
+++ b/roles/nginxplus/files/conf/http/bibdata_prod.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://bibdata-prod;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache bibdataprodcache;
         limit_req zone=bibdata-prod-ratelimit burst=80 nodelay;

--- a/roles/nginxplus/files/conf/http/bibdata_qa.conf
+++ b/roles/nginxplus/files/conf/http/bibdata_qa.conf
@@ -43,6 +43,7 @@ server {
        # # app_protect_security_log_enable on;
         proxy_pass http://bibdata-qa;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_cache bibdata-qacache;
         limit_req zone=bibdata-qa-ratelimit burst=20 nodelay;

--- a/roles/nginxplus/files/conf/http/dev/bibdata_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/bibdata_staging.conf
@@ -45,6 +45,7 @@ server {
      #   # app_protect_security_log_enable on;
         proxy_pass http://bibdata-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
         limit_req zone=bibdata-staging-ratelimit burst=20 nodelay;
         proxy_cache bibdata-stagingcache;

--- a/roles/nginxplus/files/conf/http/dss-prod.conf
+++ b/roles/nginxplus/files/conf/http/dss-prod.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://dss-prod;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache dss-prodcache;
         limit_req zone=dss-prod-ratelimit burst=20 nodelay;
         proxy_connect_timeout      2h;

--- a/roles/nginxplus/files/conf/http/dss-staging.conf
+++ b/roles/nginxplus/files/conf/http/dss-staging.conf
@@ -43,6 +43,7 @@ server {
 #        # app_protect_security_log_enable on;
         proxy_pass http://dss-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache dss-stagingcache;
         limit_req zone=dss-staging-ratelimit burst=20 nodelay;
         proxy_connect_timeout      2h;

--- a/roles/nginxplus/files/conf/http/geaccirc.conf
+++ b/roles/nginxplus/files/conf/http/geaccirc.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://geaccirc-prod;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache geaccirc-prodcache;
         limit_req zone=geaccirc-prod-ratelimit burst=20 nodelay;
         proxy_intercept_errors on;

--- a/roles/nginxplus/files/conf/http/geaccirc_staging.conf
+++ b/roles/nginxplus/files/conf/http/geaccirc_staging.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://geaccirc-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_intercept_errors on;
         proxy_cache geaccirc-stagingcache;
         limit_req zone=geaccirc-staging-ratelimit burst=20 nodelay;

--- a/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://libjobs-prod;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache libjobs-prodcache;
         limit_req zone=libjobs-prod-ratelimit burst=20 nodelay;
         proxy_intercept_errors on;

--- a/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
@@ -42,6 +42,7 @@ server {
         # app_protect_security_log_enable on;
         proxy_pass http://libjobs-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache libjobs-stagingcache;
         limit_req zone=libjobs-staging-ratelimit burst=20 nodelay;
         # health_check;

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
@@ -41,6 +41,7 @@ server {
     location / {
         proxy_pass http://lockers-and-study-spaces-prod;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache lockers-and-study-spacescache;
         limit_req zone=lockers-prod-ratelimit burst=20 nodelay;
         # handle errors using errors.conf

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
@@ -42,6 +42,7 @@ server {
         # app_protect_security_log_enable on;
         proxy_pass http://lockers-and-study-spaces-staging;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_cache lockers-and-study-spaces-stagingcache;
         limit_req zone=lockers-staging-ratelimit burst=20 nodelay;
         # handle errors using errors.conf


### PR DESCRIPTION
closes #5403

Add proxy_set_header X-Forwarded-Proto https; in the dacs nginx conf files
to fix `HTTP Origin header (https://repec-prod.princeton.edu) didn't match request.base_url (http://repec-prod.princeton.edu)`