### PR TITLE
Comment out the dev/staging IPs in the passenger role

### DIFF
--- a/roles/passenger/defaults/main.yml
+++ b/roles/passenger/defaults/main.yml
@@ -6,11 +6,11 @@ passenger_real_ip_from:
   - 128.112.203.144
   - 128.112.203.145
   - 128.112.203.146
-# dev loadbalancer
-passenger_real_ip_from_staging:
-  - 172.20.80.13
-  - 172.20.80.14
-  - 172.20.80.19
+# for staging, use the dev loadbalancer IPs instead:
+# passenger_real_ip_from:
+#   - 172.20.80.13
+#   - 172.20.80.14
+#   - 172.20.80.19
 passenger_listen_port: '80'
 
 passenger_root: /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini


### PR DESCRIPTION
We still don't understand why, but the dev/staging IPs were getting written to the production config by mistake in bibdata. Making this clearer for Future Us.