### PR TITLE
move abid-staging to the dev LBs

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/abid_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/abid_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /var/nginx/abid-staging/ keys_zone=abid-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/abid-staging/ keys_zone=abid-stagingcache:10m;
 
 upstream abid-staging {
     zone abid-staging 64k;


### PR DESCRIPTION
As part of our migration to the dev load balancers, this PR:

- changes the server definitions for abid-staging (the changes to `abid-staging2` - from a routable to a non-routabel IP, and from .princeton.edu to .lib.princeton.edu - are already done)
- moves the site config into the dev subfolder so it gets deployed to the dev LBs