### PR TITLE
Update abid-staging2 inventory entry - it's now in the .lib domain

### DIFF
--- a/inventory/all_projects/abid
+++ b/inventory/all_projects/abid
@@ -1,5 +1,5 @@
 [abid_staging]
-abid-staging2.princeton.edu
+abid-staging2.lib.princeton.edu
 [abid_production]
 abid-prod1.princeton.edu
 abid-prod2.princeton.edu


### PR DESCRIPTION
Updates inventory to reflect the migration of the abid servers to private IPs, the .lib domain, and the staging loadbalancer.