### PR TITLE
[orangelight] Remove catalog-qa1 from the load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -12,7 +12,6 @@ limit_req_zone $external_traffic zone=catalog-qa-ratelimit:10m rate=10r/s;
 
 upstream catalog-qa {
     zone catalog-qa 64k;
-    server catalog-qa1.princeton.edu resolve;
     server catalog-qa2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_catalogqacookie


### PR DESCRIPTION
Something is broken with passenger on catalog-qa1, and the health checks are filling up the disk with errors quickly