### PR TITLE
Update docs in CheckMK playbooks

### DIFF
--- a/playbooks/utils/checkmk_add_local_checks.yml
+++ b/playbooks/utils/checkmk_add_local_checks.yml
@@ -1,16 +1,17 @@
 ---
 # To run the playbook:
-# ansible-playbook playbooks/utils/checkmk_agent.yml --limit=<machine/group> -e checkmk_folder=linux/rdss
-# folder names must be all lower case and should not begin with a slash
-# rule_group environment variable specifies which rule group to apply to the hosts, by default the rails rule group will be applied
+# confirm that the agent is installed already on your machine(s)
+# if it is not, run playbooks/utils/checkmk_agent.yml to install the CheckMK agent
+# rule_group environment variable specifies which rule group to apply to the hosts
+# by default the rails rule group will be applied
 # to run in with the another group, pass '-e rule_group=group_name'
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
-# For example `ansible-playbook playbooks/utils/checkmk_add_rule.yml --ask-vault-pass --limit=pdc-describe-staging2.princeton.edu` 
+# For example `ansible-playbook playbooks/utils/checkmk_add_local_checks.yml --ask-vault-pass --limit=pdc-describe-staging2.princeton.edu` 
 #  will run with the staging runtime environment and the rails rule group on pdc-describe-staging2
 
 - name: Install CheckMk local check scripts on host
-  hosts: staging:qa:production
+  hosts: "{{ runtime_env | default ('staging') }}"
   remote_user: pulsys
   become: true
 

--- a/playbooks/utils/checkmk_add_rule.yml
+++ b/playbooks/utils/checkmk_add_rule.yml
@@ -1,16 +1,17 @@
 ---
-# To run the playbook:
-# ansible-playbook playbooks/utils/checkmk_agent.yml --limit=<machine/group> -e checkmk_folder=linux/rdss
-# folder names must be all lower case and should not begin with a slash
-# rule_group environment variable specifies which rule group to apply to the hosts, by default the rails rule group will be applied
-# to run in with the another group, pass '-e rule_group=group_name'
+# To run this playbook:
+# confirm that the agent is installed already on your machine(s)
+# if it is not, run playbooks/utils/checkmk_agent.yml to install the CheckMK agent
+# rule_group environment variable specifies which rule group to apply to the hosts
+# by default the rails rule group will be applied
+# to apply a different rule group, pass '-e rule_group=group_name'
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
 # For example `ansible-playbook playbooks/utils/checkmk_add_rule.yml --ask-vault-pass --limit=pdc-describe-staging2.princeton.edu` 
 #  will run with the staging runtime environment and the rails rule group on pdc-describe-staging2
 
-- name: Install CheckMk agent on host
-  hosts: staging:qa:production
+- name: Install CheckMk rules on host
+  hosts: "{{ runtime_env | default ('staging') }}"
   remote_user: pulsys
   become: true
 

--- a/playbooks/utils/checkmk_agent.yml
+++ b/playbooks/utils/checkmk_agent.yml
@@ -6,7 +6,7 @@
 # to run in production, pass '-e runtime_env=production'
 
 - name: Install CheckMk agent on host
-  hosts: staging:qa:production
+  hosts: "{{ runtime_env | default ('staging') }}"
   remote_user: pulsys
   become: true
 


### PR DESCRIPTION
When we ran the playbooks to add local checks recently, we noticed that the documentation in the playbooks themselves was mostly copy-pasta.

This PR clarifies the docs in the three CheckMK playbooks. It also changes the `hosts` line for all three, so they will only run in staging by default. 