### PR TITLE
[gitlab] Turn off WAF for now in staging

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/gitlab_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/gitlab_staging.conf
@@ -23,6 +23,7 @@ server {
     listen 443 ssl;
     http2 on;
     server_name gitlab-staging.lib.princeton.edu;
+    app_protect_enable off;
 
     ssl_certificate            /etc/letsencrypt/live/gitlab-staging.lib/fullchain.pem;
     ssl_certificate_key        /etc/letsencrypt/live/gitlab-staging.lib/privkey.pem;


### PR DESCRIPTION
With app_protect enabled, this page never loads because the WAF blocks one of the graphql responses: https://gitlab-staging.lib.princeton.edu/js7389/jane-test