### PR TITLE
Preserves the network when replacing a VM

### DIFF
--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -40,175 +40,175 @@
       ansible.builtin.debug:
         msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement.
 
-    - name: Move old VM to the ToBeDeleted folder
-      community.vmware.vmware_guest_move:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        dest_folder: "{{ vm_delete_me_folder }}"
-        uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
+  #   - name: Move old VM to the ToBeDeleted folder
+  #     community.vmware.vmware_guest_move:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       dest_folder: "{{ vm_delete_me_folder }}"
+  #       uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
 
-    - name: Power off old VM using UUID
-      community.vmware.vmware_guest_powerstate:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
-        state: powered-off
+  #   - name: Power off old VM using UUID
+  #     community.vmware.vmware_guest_powerstate:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
+  #       state: powered-off
 
-    - name: Create a new virtual machine from a template
-      community.vmware.vmware_guest:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        cluster: "{{ vcenter_cluster }}"
-        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
-        name: "{{ replacement_vm }}"
-        state: present
-        template: "{{ vm_template | default('template_jammy_spring_2024')}}"
-        disk:
-          - size: "{{ (old_vm_info.virtual_machines[0].allocated.storage / 1024) | int }}kb"
-            # we are not able to use 'type: thin' with our fall 2024 templates
-            # type: thin
-            datastore: "{{ old_vm_info.virtual_machines[0].datastore_url }}"
-        # TODO: Add another disk from an existing VMDK
-        hardware:
-          memory_mb: "{{ old_vm_info.virtual_machines[0].allocated.memory | int | default('16384') }}"
-          num_cpus: "{{ old_vm_info.virtual_machines[0].allocated.cpu | int | default('2') }}"
-          num_cpu_cores_per_socket: "{{ vm_cpu_cores | default('1') }}"
-          scsi: paravirtual
-          version: latest # Hardware version of virtual machine
-          boot_firmware: "efi"
-        cdrom:
-          - controller_number: 0
-            unit_number: 0
-            state: present
-        networks:
-          - name: "{{ vm_network | default('Virtual Machine Network')}}"
-        wait_for_ip_address: true
-      register: new_vm_deets
+  #   - name: Create a new virtual machine from a template
+  #     community.vmware.vmware_guest:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       cluster: "{{ vcenter_cluster }}"
+  #       folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+  #       name: "{{ replacement_vm }}"
+  #       state: present
+  #       template: "{{ vm_template | default('template_jammy_spring_2024')}}"
+  #       disk:
+  #         - size: "{{ (old_vm_info.virtual_machines[0].allocated.storage / 1024) | int }}kb"
+  #           # we are not able to use 'type: thin' with our fall 2024 templates
+  #           # type: thin
+  #           datastore: "{{ old_vm_info.virtual_machines[0].datastore_url }}"
+  #       # TODO: Add another disk from an existing VMDK
+  #       hardware:
+  #         memory_mb: "{{ old_vm_info.virtual_machines[0].allocated.memory | int | default('16384') }}"
+  #         num_cpus: "{{ old_vm_info.virtual_machines[0].allocated.cpu | int | default('2') }}"
+  #         num_cpu_cores_per_socket: "{{ vm_cpu_cores | default('1') }}"
+  #         scsi: paravirtual
+  #         version: latest # Hardware version of virtual machine
+  #         boot_firmware: "efi"
+  #       cdrom:
+  #         - controller_number: 0
+  #           unit_number: 0
+  #           state: present
+  #       networks:
+  #         - name: "{{ vm_network | default('Virtual Machine Network')}}"
+  #       wait_for_ip_address: true
+  #     register: new_vm_deets
 
-    - name: view new VM details
-      ansible.builtin.debug:
-        var: new_vm_deets
+  #   - name: view new VM details
+  #     ansible.builtin.debug:
+  #       var: new_vm_deets
 
-    - name: power down the VM so we can mess with the network settings
-      community.vmware.vmware_guest_powerstate:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-        moid: "{{ new_vm_deets.instance.moid }}"
-        state: powered-off
+  #   - name: power down the VM so we can mess with the network settings
+  #     community.vmware.vmware_guest_powerstate:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+  #       moid: "{{ new_vm_deets.instance.moid }}"
+  #       state: powered-off
 
-    - name: delete NIC with automatic mac address
-      community.vmware.vmware_guest_network:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-        moid: "{{ new_vm_deets.instance.moid }}"
-        network_name: "{{ vm_network | default('Virtual Machine Network')}}"
-        state: absent
-        mac_address: "{{ new_vm_deets.instance.hw_eth0.macaddress }}"
+  #   - name: delete NIC with automatic mac address
+  #     community.vmware.vmware_guest_network:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+  #       moid: "{{ new_vm_deets.instance.moid }}"
+  #       network_name: "{{ vm_network | default('Virtual Machine Network')}}"
+  #       state: absent
+  #       mac_address: "{{ new_vm_deets.instance.hw_eth0.macaddress }}"
 
-    - name: add NIC with custom mac address
-      community.vmware.vmware_guest_network:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-        moid: "{{ new_vm_deets.instance.moid }}"
-        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
-        network_name: "{{ vm_network | default('Virtual Machine Network')}}"
-        device_type: "vmxnet3"
-        connected: true
-        mac_address: "{{ old_vm_info.virtual_machines[0].mac_address[0] }}"
+  #   - name: add NIC with custom mac address
+  #     community.vmware.vmware_guest_network:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+  #       moid: "{{ new_vm_deets.instance.moid }}"
+  #       folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+  #       network_name: "{{ vm_network | default('Virtual Machine Network')}}"
+  #       device_type: "vmxnet3"
+  #       connected: true
+  #       mac_address: "{{ old_vm_info.virtual_machines[0].mac_address[0] }}"
 
-    - name: Power the new VM on
-      community.vmware.vmware_guest_powerstate:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
-        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-        moid: "{{ new_vm_deets.instance.moid }}"
-        state: powered-on
+  #   - name: Power the new VM on
+  #     community.vmware.vmware_guest_powerstate:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+  #       moid: "{{ new_vm_deets.instance.moid }}"
+  #       state: powered-on
 
-    - name: Gather details on new VM
-      community.vmware.vmware_vm_info:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        show_datacenter: true
-        show_mac_address: true
-        show_allocated: true
-        show_folder: true
-        vm_name: "{{ replacement_vm }}"
-      register: new_vm_info
+  #   - name: Gather details on new VM
+  #     community.vmware.vmware_vm_info:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       show_datacenter: true
+  #       show_mac_address: true
+  #       show_allocated: true
+  #       show_folder: true
+  #       vm_name: "{{ replacement_vm }}"
+  #     register: new_vm_info
 
-    - name: Print out relevant details of old VM
-      vars:
-        msg: |
-             The VM you replaced had
-             an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
-             a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
-             {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
-             {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-      ansible.builtin.debug:
-        msg: "{{ msg.split('\n') }}"
+  #   - name: Print out relevant details of old VM
+  #     vars:
+  #       msg: |
+  #            The VM you replaced had
+  #            an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
+  #            a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+  #            {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+  #            {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
+  #            {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+  #     ansible.builtin.debug:
+  #       msg: "{{ msg.split('\n') }}"
 
-    - name: Print out relevant details of new VM
-      vars:
-        msg: |
-             The VM you just created has
-             an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
-             a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
-             {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-             {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
-             {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-      ansible.builtin.debug:
-        msg: "{{ msg.split('\n') }}"
+  #   - name: Print out relevant details of new VM
+  #     vars:
+  #       msg: |
+  #            The VM you just created has
+  #            an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
+  #            a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+  #            {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+  #            {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
+  #            {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+  #     ansible.builtin.debug:
+  #       msg: "{{ msg.split('\n') }}"
 
-    - name: Remove old VM using UUID
-      community.vmware.vmware_guest:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        cluster: "{{ vcenter_cluster }}"
-        folder: "{{ vm_delete_me_folder }}"
-        uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
-        state: absent
-        force: true
+  #   - name: Remove old VM using UUID
+  #     community.vmware.vmware_guest:
+  #       hostname: "{{ vcenter_hostname }}"
+  #       username: "{{ vcenter_username }}"
+  #       password: "{{ vcenter_password }}"
+  #       validate_certs: false
+  #       datacenter: "{{ vcenter_datacenter }}"
+  #       cluster: "{{ vcenter_cluster }}"
+  #       folder: "{{ vm_delete_me_folder }}"
+  #       uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
+  #       state: absent
+  #       force: true
 
-    - name: Remove host from TowerDeploy1 known hosts
-      ansible.builtin.known_hosts:
-        path: /home/deploy/.ssh/known_hosts
-        name: "{{ replacement_vm }}.princeton.edu"
-        state: "absent"
-      delegate_to: towerdeploy1.princeton.edu
-      become: true
-      become_user: deploy
+  #   - name: Remove host from TowerDeploy1 known hosts
+  #     ansible.builtin.known_hosts:
+  #       path: /home/deploy/.ssh/known_hosts
+  #       name: "{{ replacement_vm }}.princeton.edu"
+  #       state: "absent"
+  #     delegate_to: towerdeploy1.princeton.edu
+  #     become: true
+  #     become_user: deploy
 
-  post_tasks:
-    - name: send information to slack
-      ansible.builtin.include_tasks:
-        file: slack_tasks_end_of_playbook.yml
+  # post_tasks:
+  #   - name: send information to slack
+  #     ansible.builtin.include_tasks:
+  #       file: slack_tasks_end_of_playbook.yml

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -22,10 +22,11 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
-        show_datacenter: true
-        show_mac_address: true
         show_allocated: true
         show_folder: true
+        show_datacenter: true
+        show_mac_address: true
+        show_net: true
         vm_name: "{{ replacement_vm }}"
       register: old_vm_info
 
@@ -182,7 +183,7 @@
              {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
       ansible.builtin.debug:
         msg: "{{ msg.split('\n') }}"
-    
+
     - name: Remove old VM using UUID
       community.vmware.vmware_guest:
         hostname: "{{ vcenter_hostname }}"

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -23,18 +23,24 @@
         password: "{{ vcenter_password }}"
         validate_certs: false
         show_allocated: true
-        show_attribute: true
         show_folder: true
         show_datacenter: true
         show_mac_address: true
-        # show_net does not return the NAME of the network, only the MAC address and IP addresses
-        # show_net: true
         vm_name: "{{ replacement_vm }}"
       register: old_vm_info
 
     - name: Print out old VM information
       ansible.builtin.debug:
         var: old_vm_info
+
+    - name: set the network name to the private network if the IP starts with 172.20
+      ansible.builtin.set_fact:
+        network_name: "VM Network - LibNetPvt"
+      when: old_vm_info.virtual_machines[0].ip_address is match("172.20.*")
+
+    - name: Print the network name
+      ansible.builtin.debug:
+        var: network_name
 
     - name: Print out warning
       ansible.builtin.debug:

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -23,10 +23,12 @@
         password: "{{ vcenter_password }}"
         validate_certs: false
         show_allocated: true
+        show_attribute: true
         show_folder: true
         show_datacenter: true
         show_mac_address: true
-        show_net: true
+        # show_net does not return the NAME of the network, only the MAC address and IP addresses
+        # show_net: true
         vm_name: "{{ replacement_vm }}"
       register: old_vm_info
 

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -38,183 +38,179 @@
         network_name: "VM Network - LibNetPvt"
       when: old_vm_info.virtual_machines[0].ip_address is match("172.20.*")
 
-    - name: Print the network name
-      ansible.builtin.debug:
-        var: network_name
-
     - name: Print out warning
       ansible.builtin.debug:
-        msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement.
+        msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement in the {{ network_name }} network.
 
-  #   - name: Move old VM to the ToBeDeleted folder
-  #     community.vmware.vmware_guest_move:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       dest_folder: "{{ vm_delete_me_folder }}"
-  #       uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
+    - name: Move old VM to the ToBeDeleted folder
+      community.vmware.vmware_guest_move:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        dest_folder: "{{ vm_delete_me_folder }}"
+        uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
 
-  #   - name: Power off old VM using UUID
-  #     community.vmware.vmware_guest_powerstate:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
-  #       state: powered-off
+    - name: Power off old VM using UUID
+      community.vmware.vmware_guest_powerstate:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
+        state: powered-off
 
-  #   - name: Create a new virtual machine from a template
-  #     community.vmware.vmware_guest:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       cluster: "{{ vcenter_cluster }}"
-  #       folder: "{{ old_vm_info.virtual_machines[0].folder }}"
-  #       name: "{{ replacement_vm }}"
-  #       state: present
-  #       template: "{{ vm_template | default('template_jammy_spring_2024')}}"
-  #       disk:
-  #         - size: "{{ (old_vm_info.virtual_machines[0].allocated.storage / 1024) | int }}kb"
-  #           # we are not able to use 'type: thin' with our fall 2024 templates
-  #           # type: thin
-  #           datastore: "{{ old_vm_info.virtual_machines[0].datastore_url }}"
-  #       # TODO: Add another disk from an existing VMDK
-  #       hardware:
-  #         memory_mb: "{{ old_vm_info.virtual_machines[0].allocated.memory | int | default('16384') }}"
-  #         num_cpus: "{{ old_vm_info.virtual_machines[0].allocated.cpu | int | default('2') }}"
-  #         num_cpu_cores_per_socket: "{{ vm_cpu_cores | default('1') }}"
-  #         scsi: paravirtual
-  #         version: latest # Hardware version of virtual machine
-  #         boot_firmware: "efi"
-  #       cdrom:
-  #         - controller_number: 0
-  #           unit_number: 0
-  #           state: present
-  #       networks:
-  #         - name: "{{ vm_network | default('Virtual Machine Network')}}"
-  #       wait_for_ip_address: true
-  #     register: new_vm_deets
+    - name: Create a new virtual machine from a template
+      community.vmware.vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ vcenter_cluster }}"
+        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+        name: "{{ replacement_vm }}"
+        state: present
+        template: "{{ vm_template | default('template_jammy_spring_2024')}}"
+        disk:
+          - size: "{{ (old_vm_info.virtual_machines[0].allocated.storage / 1024) | int }}kb"
+            # we are not able to use 'type: thin' with our fall 2024 templates
+            # type: thin
+            datastore: "{{ old_vm_info.virtual_machines[0].datastore_url }}"
+        # TODO: Add another disk from an existing VMDK
+        hardware:
+          memory_mb: "{{ old_vm_info.virtual_machines[0].allocated.memory | int | default('16384') }}"
+          num_cpus: "{{ old_vm_info.virtual_machines[0].allocated.cpu | int | default('2') }}"
+          num_cpu_cores_per_socket: "{{ vm_cpu_cores | default('1') }}"
+          scsi: paravirtual
+          version: latest # Hardware version of virtual machine
+          boot_firmware: "efi"
+        cdrom:
+          - controller_number: 0
+            unit_number: 0
+            state: present
+        networks:
+          - name: "{{ vm_network | default('Virtual Machine Network')}}"
+        wait_for_ip_address: true
+      register: new_vm_deets
 
-  #   - name: view new VM details
-  #     ansible.builtin.debug:
-  #       var: new_vm_deets
+    - name: view new VM details
+      ansible.builtin.debug:
+        var: new_vm_deets
 
-  #   - name: power down the VM so we can mess with the network settings
-  #     community.vmware.vmware_guest_powerstate:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-  #       moid: "{{ new_vm_deets.instance.moid }}"
-  #       state: powered-off
+    - name: power down the VM so we can mess with the network settings
+      community.vmware.vmware_guest_powerstate:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+        moid: "{{ new_vm_deets.instance.moid }}"
+        state: powered-off
 
-  #   - name: delete NIC with automatic mac address
-  #     community.vmware.vmware_guest_network:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-  #       moid: "{{ new_vm_deets.instance.moid }}"
-  #       network_name: "{{ vm_network | default('Virtual Machine Network')}}"
-  #       state: absent
-  #       mac_address: "{{ new_vm_deets.instance.hw_eth0.macaddress }}"
+    - name: delete NIC with automatic mac address
+      community.vmware.vmware_guest_network:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+        moid: "{{ new_vm_deets.instance.moid }}"
+        network_name: "{{ vm_network | default('Virtual Machine Network')}}"
+        state: absent
+        mac_address: "{{ new_vm_deets.instance.hw_eth0.macaddress }}"
 
-  #   - name: add NIC with custom mac address
-  #     community.vmware.vmware_guest_network:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-  #       moid: "{{ new_vm_deets.instance.moid }}"
-  #       folder: "{{ old_vm_info.virtual_machines[0].folder }}"
-  #       network_name: "{{ vm_network | default('Virtual Machine Network')}}"
-  #       device_type: "vmxnet3"
-  #       connected: true
-  #       mac_address: "{{ old_vm_info.virtual_machines[0].mac_address[0] }}"
+    - name: add NIC with custom mac address
+      community.vmware.vmware_guest_network:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+        moid: "{{ new_vm_deets.instance.moid }}"
+        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+        network_name: "{{ vm_network | default('Virtual Machine Network')}}"
+        device_type: "vmxnet3"
+        connected: true
+        mac_address: "{{ old_vm_info.virtual_machines[0].mac_address[0] }}"
 
-  #   - name: Power the new VM on
-  #     community.vmware.vmware_guest_powerstate:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       folder: "{{ old_vm_info.virtual_machines[0].folder }}"
-  #       # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-  #       moid: "{{ new_vm_deets.instance.moid }}"
-  #       state: powered-on
+    - name: Power the new VM on
+      community.vmware.vmware_guest_powerstate:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        folder: "{{ old_vm_info.virtual_machines[0].folder }}"
+        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+        moid: "{{ new_vm_deets.instance.moid }}"
+        state: powered-on
 
-  #   - name: Gather details on new VM
-  #     community.vmware.vmware_vm_info:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       show_datacenter: true
-  #       show_mac_address: true
-  #       show_allocated: true
-  #       show_folder: true
-  #       vm_name: "{{ replacement_vm }}"
-  #     register: new_vm_info
+    - name: Gather details on new VM
+      community.vmware.vmware_vm_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        show_datacenter: true
+        show_mac_address: true
+        show_allocated: true
+        show_folder: true
+        vm_name: "{{ replacement_vm }}"
+      register: new_vm_info
 
-  #   - name: Print out relevant details of old VM
-  #     vars:
-  #       msg: |
-  #            The VM you replaced had
-  #            an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
-  #            a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
-  #            {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-  #            {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
-  #            {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-  #     ansible.builtin.debug:
-  #       msg: "{{ msg.split('\n') }}"
+    - name: Print out relevant details of old VM
+      vars:
+        msg: |
+             The VM you replaced had
+             an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
+             a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+             {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
+             {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+      ansible.builtin.debug:
+        msg: "{{ msg.split('\n') }}"
 
-  #   - name: Print out relevant details of new VM
-  #     vars:
-  #       msg: |
-  #            The VM you just created has
-  #            an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
-  #            a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
-  #            {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
-  #            {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
-  #            {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
-  #     ansible.builtin.debug:
-  #       msg: "{{ msg.split('\n') }}"
+    - name: Print out relevant details of new VM
+      vars:
+        msg: |
+             The VM you just created has
+             an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
+             a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+             {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
+             {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
+             {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
+      ansible.builtin.debug:
+        msg: "{{ msg.split('\n') }}"
 
-  #   - name: Remove old VM using UUID
-  #     community.vmware.vmware_guest:
-  #       hostname: "{{ vcenter_hostname }}"
-  #       username: "{{ vcenter_username }}"
-  #       password: "{{ vcenter_password }}"
-  #       validate_certs: false
-  #       datacenter: "{{ vcenter_datacenter }}"
-  #       cluster: "{{ vcenter_cluster }}"
-  #       folder: "{{ vm_delete_me_folder }}"
-  #       uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
-  #       state: absent
-  #       force: true
+    - name: Remove old VM using UUID
+      community.vmware.vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ vcenter_datacenter }}"
+        cluster: "{{ vcenter_cluster }}"
+        folder: "{{ vm_delete_me_folder }}"
+        uuid: "{{ old_vm_info.virtual_machines[0].uuid }}"
+        state: absent
+        force: true
 
-  #   - name: Remove host from TowerDeploy1 known hosts
-  #     ansible.builtin.known_hosts:
-  #       path: /home/deploy/.ssh/known_hosts
-  #       name: "{{ replacement_vm }}.princeton.edu"
-  #       state: "absent"
-  #     delegate_to: towerdeploy1.princeton.edu
-  #     become: true
-  #     become_user: deploy
+    - name: Remove host from TowerDeploy1 known hosts
+      ansible.builtin.known_hosts:
+        path: /home/deploy/.ssh/known_hosts
+        name: "{{ replacement_vm }}.princeton.edu"
+        state: "absent"
+      delegate_to: towerdeploy1.princeton.edu
+      become: true
+      become_user: deploy
 
-  # post_tasks:
-  #   - name: send information to slack
-  #     ansible.builtin.include_tasks:
-  #       file: slack_tasks_end_of_playbook.yml
+  post_tasks:
+    - name: send information to slack
+      ansible.builtin.include_tasks:
+        file: slack_tasks_end_of_playbook.yml

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -33,14 +33,14 @@
       ansible.builtin.debug:
         var: old_vm_info
 
-    - name: set the network name to the private network if the IP starts with 172.20
+    - name: set the vm network to the private network if the IP starts with 172.20
       ansible.builtin.set_fact:
-        network_name: "VM Network - LibNetPvt"
+        vm_network: "VM Network - LibNetPvt"
       when: old_vm_info.virtual_machines[0].ip_address is match("172.20.*")
 
     - name: Print out warning
       ansible.builtin.debug:
-        msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement in the {{ network_name }} network.
+        msg: Ansible will now move and power off the current {{ old_vm_info.virtual_machines[0].guest_name }} VM, then create a replacement in the {{ vm_network }} network.
 
     - name: Move old VM to the ToBeDeleted folder
       community.vmware.vmware_guest_move:


### PR DESCRIPTION
Closes #5423.

The basic requirements are met in this branch - see https://ansible-tower.princeton.edu/#/jobs/playbook/7184/output for a run in Tower.  We updated the Tower template survey about which network to put the new VM on - it's not required and there's no default, so if you do nothing, your new VM comes up in the same network as your old VM. 

We could make this even better by updating the `Print out relevant details of old VM` and `Print out relevant details of new VM` tasks to include a line about which network they were/are on.
