### PR TITLE
[PAS] let the load balancer know that the app server is on the .lib network

### DIFF
--- a/roles/nginxplus/files/conf/http/slavery-staging.conf
+++ b/roles/nginxplus/files/conf/http/slavery-staging.conf
@@ -11,7 +11,7 @@ limit_req_zone $external_traffic zone=slavery-staging-ratelimit:10m rate=10r/s;
 
 upstream slavery-staging {
     zone slavery-staging 64k;
-    server slavery-staging1.princeton.edu resolve;
+    server slavery-staging1.lib.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_slaverystagingcookie
           lookup=$cookie_slaverystagingcookie


### PR DESCRIPTION
I ran this on both load balancer machines.  Before this PR, trying to go to https://slavery-staging.princeton.edu/ just gave the "Something went wrong"