### PR TITLE
[recap] Set prod php_version to 8.3

### DIFF
--- a/group_vars/recap/common.yml
+++ b/group_vars/recap/common.yml
@@ -1,5 +1,4 @@
 ---
-php_version: "8.1"
 drupal_ssl_base_path: 'https://{{ recap_base_url }}'
 
 ### Uncomment this to force a dump file to be imported

--- a/group_vars/recap/production.yml
+++ b/group_vars/recap/production.yml
@@ -1,4 +1,5 @@
 ---
+php_version: "8.3"
 recap_base_url: 'recap.princeton.edu'
 
 drupal_db_user: 'recap_prod'

--- a/group_vars/recap/staging.yml
+++ b/group_vars/recap/staging.yml
@@ -1,4 +1,5 @@
 ---
+php_version: "8.1"
 recap_base_url: 'recap-staging.princeton.edu'
 
 drupal_db_user: 'recap_staging'


### PR DESCRIPTION
Previously, the playbook was installing php 8.3 but php-8.1-gd, so when composer tried to check for the gd extension from PHP 8.3, it failed

Closes https://github.com/pulibrary/recap/issues/269