### PR TITLE
updates vSphere name of private network; prod & staging now match

### DIFF
--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -35,7 +35,7 @@
 
     - name: set the vm network to the private network if the IP starts with 172.20
       ansible.builtin.set_fact:
-        vm_network: "VM Network - LibNetPvt"
+        vm_network: "VM Network - ip4-library-servers"
       when: old_vm_info.virtual_machines[0].ip_address is match("172.20.*")
 
     - name: Print out warning
@@ -170,6 +170,7 @@
              The VM you replaced had
              an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+             in the {{ network_name }} network
              {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              {{ old_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
@@ -182,6 +183,7 @@
              The VM you just created has
              an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
+             in the {{ network_name }} network
              {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated


### PR DESCRIPTION
Up until now, the name of the private network was different in our vSphere prod and vSphere staging environments. @jkazmier-PUL updated vSphere so the name is the same in both envs, and it also matches OIT's designation. 

This PR updates the name of the network in the replace-a-vm playbook.
It also adds the network to the output comparing the old VM to its replacement.
