### PR TITLE
[Nomad] Fix Consul DNS & Nomad SELinux Mount Settings

### DIFF
--- a/group_vars/nomad_cluster.yml
+++ b/group_vars/nomad_cluster.yml
@@ -27,3 +27,15 @@ deploy_user_uid: 1004
 nomad_podman_version: '0.5.2'
 nomad_server_consul_token: "{{ vault_nomad_server_consul_token }}"
 nomad_client_consul_token: "{{ vault_nomad_client_consul_token }}"
+nomad_plugins:
+  nomad-driver-podman:
+    config:
+      volumes:
+        enabled: true
+        selinuxlabel: "z"
+      extra_labels:
+        - "job_name"
+        - "task_group_name"
+        - "task_name"
+        - "namespace"
+        - "node_name"

--- a/roles/pul_nomad/tasks/main.yml
+++ b/roles/pul_nomad/tasks/main.yml
@@ -215,16 +215,14 @@
     - "consul_node_role == 'client'"
     - created_agent_token_client
 
+# We need to get DNSMasq's 127.0.0.1 above the Princeton nameservers, but
+# NetworkManager manages DNS on RedHat machines. This updates the connection to
+# prepend the DNS server.
 - name: 'pul_nomad | Configure DNS for consul'
   become: true
-  ansible.builtin.lineinfile:
-    path: /etc/resolv.conf
-    regexp: ^nameserver 127.0.0.1
-    line: nameserver 127.0.0.1
-    create: true
-    owner: root
-    group: root
-    mode: u=rw,g=r,o=r
+  ansible.builtin.shell: '/bin/nmcli connection modify {{ ansible_default_ipv4.interface }} ipv4.dns "127.0.0.1" && /bin/nmcli connection up {{ ansible_default_ipv4.interface }}'
+  when:
+    - "ansible_os_family == 'RedHat'"
   tags:
     - notest
 


### PR DESCRIPTION
This fixes two things:

1. Consul DNS wasn't working after restart, because NetworkManager was overriding `resolv.conf`, making it so DNSMasq wasn't being used. This configures NetworkManager instead of resolv.conf

2. Sets Nomad's SELinux label so that it's effectively disabled for locally mounted files. Without this any templates that were being written by nomad configs didn't have permission to be read.