### PR TITLE
adds an EE with the CrowdStrike collection

### DIFF
--- a/tower_ees/security-tools-ee.yml
+++ b/tower_ees/security-tools-ee.yml
@@ -1,0 +1,55 @@
+---
+# EE definition for our 'security-theater' playbook
+# to build an EE, run `ansible-builder build`
+
+# builder schema version
+version: 3
+
+images:
+  # build a new image based on this image
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel8:1.0.0-543
+    # name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9
+
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.15.7
+  ansible_runner:
+    package_pip: ansible-runner
+  python_interpreter:
+    python_path: "/usr/bin/python3"
+  galaxy:
+    # includes all collections used in the prancible repo
+    # versions taken from the Ansible 8 inclusion list:
+    # https://github.com/ansible-community/ansible-build-data/blob/main/8/ansible-8.7.0.yaml
+    collections:
+      - name: community.general
+        version: 7.5.2
+    # these collections are not in Ansible package
+    # latest versions from Galaxy as of Oct. 2024
+      - name: crowdstrike.falcon
+        version: 4.6.0
+
+  # python packages, stuff you install with 'pip install'
+  python:
+    - six
+    - psutil
+
+  # system packages, stuff you install with 'apt/yum/dnf install'
+  # ansible-builder writes this list into the 'context/bindep.txt' file
+  system:
+    - git
+    - python3-dnf
+    - python3-pip
+options:
+  # default path is /usr/bin/dnf, which does not exist on the base image
+  package_manager_path: /usr/bin/microdnf
+
+# if you need to run more commands on the EE, use this section:
+# additional_build_steps:
+  # items in the list of append_base steps are expressed
+  # as containerfile directives
+  # prepend_base:
+    # - RUN /usr/bin/apt-get update
+  # append_base:
+    # - RUN /usr/bin/python3 -m pip install --upgrade pip


### PR DESCRIPTION
Creates a new EE for the security playbook.
Installs the crowdstrike.falcon collection and necessary tools. 
Omits some other collections we don't need for that playbook.