### PR TITLE
[Nomad] Don't bind interfaces for dnsmasq.

### DIFF
--- a/roles/pul_nomad/files/dnsmasq.conf
+++ b/roles/pul_nomad/files/dnsmasq.conf
@@ -131,7 +131,7 @@ group=dnsmasq
 # To listen only on localhost and do not receive packets on other
 # interfaces, bind only to lo device. Comment out to bind on single
 # wildcard socket.
-bind-interfaces
+# bind-interfaces
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.


### PR DESCRIPTION
It's unnecessary, and things break if on boot up the interface doesn't exist yet.

The specific breakage is that Consul queries don't work with this option after a reboot (like from patch monday/tuesday), until you reboot `dnsmasq`.