### PR TITLE
[dpul-collections] Add solr base url environment variable

### DIFF
--- a/group_vars/nomad/dpulc/staging.yml
+++ b/group_vars/nomad/dpulc/staging.yml
@@ -19,6 +19,7 @@ dpul_c_nomad_env_vars:
   DB_PASSWORD: '{{ dpul_c_db_password }}'
   POSTGRES_HOST: '{{ dpul_c_postgres_host }}'
   SECRET_KEY_BASE: '{{ vault_dpul_c_secret_key_base }}'
+  SOLR_BASE_URL: 'http://lib-solr8d-staging.princeton.edu:8983'
   SOLR_URL: 'http://lib-solr8d-staging.princeton.edu:8983/solr/dpulc-staging'
   FIGGY_DATABASE_URL: 'ecto://dpulc_staging:{{ dpul_c_production_figgy_db_password }}@{{ dpul_c_production_figgy_db_host }}/{{ dpul_c_production_figgy_db_name }}'
   BASIC_AUTH_USERNAME: '{{ dpul_c_basic_auth_username }}'


### PR DESCRIPTION
leave solr_url for now, it won't be used when we deploy the new code and
we can remove it after

refs pulibrary/dpul-collections#104