### PR TITLE
Removed pdc-describe-prod2 from the load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
@@ -4,7 +4,7 @@ proxy_cache_path /data/nginx/pdc-describe-prod/NGINX_cache/ keys_zone=pdc-descri
 upstream pdc-describe-prod {
     zone pdc-describe-prod 64k;
     server pdc-describe-prod1.princeton.edu resolve;
-    server pdc-describe-prod2.princeton.edu resolve;
+    # server pdc-describe-prod2.princeton.edu resolve;
     server pdc-describe-prod3.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_pdcdescribeprodcookie
@@ -39,7 +39,7 @@ server {
 #    ssl_session_cache          shared:SSL:1m;
 #    ssl_prefer_server_ciphers  on;
 
-    # Redirect top level traffic to /describe 
+    # Redirect top level traffic to /describe
     # until the top level has content.
 #    location / {
 #        return 302 https://$server_name/describe/;


### PR DESCRIPTION
Removes `pdc-describe-prod2` from the load balancer so that it stops taking new jobs and lets the `prod1` and `prod3` take care of new jobs.

See https://github.com/pulibrary/pdc_describe/issues/1983

