### PR TITLE
[NGINXPLUS] Updating oawaiver to point at health.json for health check

### DIFF
--- a/roles/nginxplus/files/conf/http/oawaiver-prod.conf
+++ b/roles/nginxplus/files/conf/http/oawaiver-prod.conf
@@ -46,7 +46,7 @@ server {
         proxy_cache oawaiver-prodcache;
         # handle errors using errors.conf
         proxy_intercept_errors on;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
     }
 
     include /etc/nginx/conf.d/templates/errors.conf;

--- a/roles/nginxplus/files/conf/http/oawaiver-staging.conf
+++ b/roles/nginxplus/files/conf/http/oawaiver-staging.conf
@@ -39,7 +39,7 @@ server {
         proxy_cache oawaiver-stagingcache;
         # handle errors using errors.conf
         proxy_intercept_errors on;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         # block all


### PR DESCRIPTION
fixes #5108

It did mark OAWAIVER as unhealthy when I deployed https://github.com/pulibrary/oawaiver/pull/216
![Screenshot 2024-11-04 at 11 48 20 AM](https://github.com/user-attachments/assets/980b3b69-6e29-478a-b4b3-3809ff4d75e9)

And back to healthy when I deployed main:
![Screenshot 2024-11-04 at 11 50 14 AM](https://github.com/user-attachments/assets/5e96d5c7-0663-4fc2-8d84-284b008a9505)
