### PR TITLE
[bibdata] add health.json for health check uri

### DIFF
--- a/roles/nginxplus/files/conf/http/bibdata_prod.conf
+++ b/roles/nginxplus/files/conf/http/bibdata_prod.conf
@@ -50,7 +50,7 @@ server {
         proxy_read_timeout         2h;
         # handle errors using errors.conf
         proxy_intercept_errors on;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
    }
 
    include /etc/nginx/conf.d/templates/errors.conf;

--- a/roles/nginxplus/files/conf/http/bibdata_qa.conf
+++ b/roles/nginxplus/files/conf/http/bibdata_qa.conf
@@ -52,7 +52,7 @@ server {
         proxy_read_timeout         2h;
         # handle errors using errors.conf
         proxy_intercept_errors on;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
         # allow princeton network
         include /etc/nginx/conf.d/templates/restrict.conf;
         include /etc/nginx/conf.d/templates/htc_restrict.conf;

--- a/roles/nginxplus/files/conf/http/dev/bibdata_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/bibdata_staging.conf
@@ -54,7 +54,7 @@ server {
         proxy_read_timeout         2h;
         # handle errors using errors.conf
         proxy_intercept_errors on;
-        health_check interval=10 fails=3 passes=2;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
    }
 
    include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
Checked against [bibdata branch intentionally breaking configuration](https://github.com/pulibrary/bibdata/compare/main...health-monitor-fail) and it successfully did not serve the broken server

![image](https://github.com/user-attachments/assets/452c1b5a-a0aa-476c-8b2b-d21f359af3b5)

Successfully run on all load balancers - 2 dev, 2 prod
