### PR TITLE
[lib_jobs] Add health checks against health endpoint

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
@@ -45,7 +45,7 @@ server {
         proxy_cache libjobs-prodcache;
         limit_req zone=libjobs-prod-ratelimit burst=20 nodelay;
         proxy_intercept_errors on;
-        # health_check;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
     }
 
     include /etc/nginx/conf.d/templates/errors.conf;

--- a/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
@@ -45,7 +45,7 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_cache libjobs-stagingcache;
         limit_req zone=libjobs-staging-ratelimit burst=20 nodelay;
-        # health_check;
+        health_check uri=/health.json interval=10 fails=3 passes=2;
         # allow princeton network
         # allow 128.112.0.0/16;
         # allow 140.180.0.0/16;


### PR DESCRIPTION
Deploying bad branch to staging leads nginx to serve only the good branch

![image](https://github.com/user-attachments/assets/6ad759c8-9373-4b5c-9bc2-f9cd9ca8bdd4)

Staging version run on production load balancer - not run with production change against load balancer yet.
Closes #5107