### PR TITLE
[PDC_DESCRIBE] Adds server back to the load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
@@ -4,7 +4,7 @@ proxy_cache_path /data/nginx/pdc-describe-prod/NGINX_cache/ keys_zone=pdc-descri
 upstream pdc-describe-prod {
     zone pdc-describe-prod 64k;
     server pdc-describe-prod1.princeton.edu resolve;
-    # server pdc-describe-prod2.princeton.edu resolve;
+    server pdc-describe-prod2.princeton.edu resolve;
     server pdc-describe-prod3.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_pdcdescribeprodcookie


### PR DESCRIPTION
Re-adds PDC Describe server 2 back to the load balancer so that it starts serving web requests again.

We had removed it on https://github.com/pulibrary/princeton_ansible/pull/5491 because we wanted to prevent it from taking more background jobs, but now that the Sidekiq queue on that server has been cleared it is safe to add the server back to the load balancer.

Closes https://github.com/pulibrary/pdc_describe/issues/1983