### PR TITLE
Add options for managing VMs

### DIFF
--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -13,10 +13,11 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
-        show_datacenter: true
-        show_cluster: true
-        show_esxi_hostname: true
         show_allocated: true
+        show_cluster: true
+        show_datacenter: true
+        show_esxi_hostname: true
+        show_mac_address: true
         vm_name: "{{ vm_to_reboot }}"
       register: vm_info
 
@@ -26,6 +27,7 @@
              The {{ vm_to_reboot }} VM
              is on the {{ vm_info.virtual_machines[0].esxi_hostname }} host (a = Forrestal, b = New South)
              has a mac address of {{ vm_info.virtual_machines[0].mac_address[0] }}
+             an IP address of {{ vm_info.virtual_machines[0].ip_address }} (128.112.x = public network, 172.20.x = private network)
              {{ vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ (vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              and {{ vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated
@@ -47,3 +49,25 @@
         state: reboot-guest
       register: reboot_status
       when: vm_action == "reboot"
+
+    - name: Power on the VM if desired
+      community.vmware.vmware_guest_powerstate:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        name: "{{ vm_to_reboot }}"
+        state: powered-on
+      register: reboot_status
+      when: vm_action == "power-on"
+
+    - name: Power off the VM if desired
+      community.vmware.vmware_guest_powerstate:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        name: "{{ vm_to_reboot }}"
+        state: powered-off
+      register: reboot_status
+      when: vm_action == "power-off"

--- a/playbooks/utils/vm_reboot.yml
+++ b/playbooks/utils/vm_reboot.yml
@@ -50,16 +50,16 @@
       register: reboot_status
       when: vm_action == "reboot"
 
-    - name: Power on the VM if desired
+    - name: Restart stuck VM if desired
       community.vmware.vmware_guest_powerstate:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
         name: "{{ vm_to_reboot }}"
-        state: powered-on
+        state: restarted
       register: reboot_status
-      when: vm_action == "power-on"
+      when: vm_action == "restart if stuck"
 
     - name: Power off the VM if desired
       community.vmware.vmware_guest_powerstate:


### PR DESCRIPTION
Sometimes a VM gets into a weird state (mostly this seems to happen to Windows VMs) and using the `reboot guest OS` option does not work.

This PR offers two new options for interacting with VMs:
- power off, for a VM we don't need any more
- restart, which is the equivalent of powering a VM off and then on again

We need to update the survey on the Tower template to include these two options and make it clear that `restart` is only for stuck VMs.

Also alphabetizes the fields we pull from vSphere and includes the IP of the VM in the output. 