### PR TITLE
upgrades mailcatcher version

### DIFF
--- a/group_vars/oawaiver/staging.yml
+++ b/group_vars/oawaiver/staging.yml
@@ -6,7 +6,7 @@ running_on_server: true
 install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.1.0/gems/mailcatcher-0.9.0/bin/mailcatcher"
+mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.1.0/gems/mailcatcher-0.10.0/bin/mailcatcher"
 
 # Apache Solr
 oawaiver_solr_core: "oawaiver-staging"


### PR DESCRIPTION
Our staging oawaiver machines were sending warnings about mailcatcher being down. Investigation showed that the init script was looking for mailcatcher 0.9.0, while the locally installed gem was 0.10.0. 

