### PR TITLE
Streamline vm replace

### DIFF
--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -105,17 +105,6 @@
       ansible.builtin.debug:
         var: new_vm_deets
 
-    # - name: power down the VM so we can mess with the network settings
-    #   community.vmware.vmware_guest_powerstate:
-    #     hostname: "{{ vcenter_hostname }}"
-    #     username: "{{ vcenter_username }}"
-    #     password: "{{ vcenter_password }}"
-    #     validate_certs: false
-    #     datacenter: "{{ vcenter_datacenter }}"
-    #     # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-    #     moid: "{{ new_vm_deets.instance.moid }}"
-    #     state: powered-off
-
     - name: delete NIC with automatic mac address
       community.vmware.vmware_guest_network:
         hostname: "{{ vcenter_hostname }}"
@@ -175,6 +164,7 @@
              The VM you replaced had
              an UUID of {{ old_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ old_vm_info.virtual_machines[0].mac_address[0] }}
+             an IP address of {{ old_vm_info.virtual_machines[0].ip_address }}
              in the {{ vm_network }} network
              {{ old_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ (old_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
@@ -189,6 +179,7 @@
              an UUID of {{ new_vm_info.virtual_machines[0].uuid }}
              a mac address of {{ new_vm_info.virtual_machines[0].mac_address[0] }}
              in the {{ vm_network }} network
+             an IP address of {{ new_vm_info.virtual_machines[0].ip_address }}
              {{ new_vm_info.virtual_machines[0].allocated.cpu }} CPUs
              {{ (new_vm_info.virtual_machines[0].allocated.memory | int / 1024) }} GB of memory
              {{ new_vm_info.virtual_machines[0].allocated.storage | human_readable }} of disk allocated

--- a/playbooks/utils/replace_vm_host.yml
+++ b/playbooks/utils/replace_vm_host.yml
@@ -77,7 +77,7 @@
         cluster: "{{ vcenter_cluster }}"
         folder: "{{ old_vm_info.virtual_machines[0].folder }}"
         name: "{{ replacement_vm }}"
-        state: present
+        state: powered-off
         template: "{{ vm_template | default('template_jammy_spring_2024')}}"
         disk:
           - size: "{{ (old_vm_info.virtual_machines[0].allocated.storage / 1024) | int }}kb"
@@ -105,16 +105,16 @@
       ansible.builtin.debug:
         var: new_vm_deets
 
-    - name: power down the VM so we can mess with the network settings
-      community.vmware.vmware_guest_powerstate:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ vcenter_datacenter }}"
-        # new VM var does not include UUID; use moid, which is unique in each vCenter instance
-        moid: "{{ new_vm_deets.instance.moid }}"
-        state: powered-off
+    # - name: power down the VM so we can mess with the network settings
+    #   community.vmware.vmware_guest_powerstate:
+    #     hostname: "{{ vcenter_hostname }}"
+    #     username: "{{ vcenter_username }}"
+    #     password: "{{ vcenter_password }}"
+    #     validate_certs: false
+    #     datacenter: "{{ vcenter_datacenter }}"
+    #     # new VM var does not include UUID; use moid, which is unique in each vCenter instance
+    #     moid: "{{ new_vm_deets.instance.moid }}"
+    #     state: powered-off
 
     - name: delete NIC with automatic mac address
       community.vmware.vmware_guest_network:


### PR DESCRIPTION
Because of [this bug](https://github.com/ansible-collections/community.vmware/issues/2124), we can't bring up a new VM with a custom MAC address. But we were able to streamline the replace-a-vm playbook a bit.

Also adds more debugging output to help when things go wrong.