### PR TITLE
[nginxplus] enable waf logging

### DIFF
--- a/roles/nginxplus/templates/etc_nginx.conf.j2
+++ b/roles/nginxplus/templates/etc_nginx.conf.j2
@@ -63,6 +63,8 @@ http {
     keepalive_timeout  65;
     app_protect_enable on;
     app_protect_security_log_enable on;
+    app_protect_security_log "/etc/app_protect/conf/log_default.json" /var/log/app_protect/security.log;
+
     # app_protect_security_log log_all;
 
     #gzip  on;


### PR DESCRIPTION
our waf is currently not logging. This will enable logs to be written
under the app_protect directory

addresses #5565
