### PR TITLE
turn app protect off and WAF logging on for Future Us on gitlab servers

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/gitlab_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/gitlab_staging.conf
@@ -23,7 +23,6 @@ server {
     listen 443 ssl;
     http2 on;
     server_name gitlab-staging.lib.princeton.edu;
-    app_protect_enable off;
 
     ssl_certificate            /etc/letsencrypt/live/gitlab-staging.lib/fullchain.pem;
     ssl_certificate_key        /etc/letsencrypt/live/gitlab-staging.lib/privkey.pem;
@@ -31,6 +30,8 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
+        app_protect_enable off;
+        app_protect_security_log_enable on;
         proxy_pass https://gitlab-staging;
         proxy_cache gitlabstagingcache;
         proxy_set_header Connection $http_connection;

--- a/roles/nginxplus/files/conf/http/gitlab_prod.conf
+++ b/roles/nginxplus/files/conf/http/gitlab_prod.conf
@@ -30,6 +30,8 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
+        app_protect_enable off;
+        app_protect_security_log_enable on;
         proxy_pass https://gitlab;
         proxy_cache gitlabcache;
         proxy_set_header Connection $http_connection;


### PR DESCRIPTION
Related to #5561.

Production gitlab was complaining about fetching files. Compared to staging (which was fine) we discovered that we had inconsistent settings for the WAF.
