### PR TITLE
Add a check to make sure we don't block ourselves using the denylist

### DIFF
--- a/.github/workflows/deny_host_check.yml
+++ b/.github/workflows/deny_host_check.yml
@@ -1,0 +1,12 @@
+---
+name: Deny Host Validation
+on: [push, pull_request]
+jobs:
+  deny_host_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install prereqs
+        run: sudo apt-get install libtest-more-utf8-perl libnet-ip-perl libscalar-list-utils-perl libfindbin-libs-perl
+      - name: Run test
+        run: prove roles/denyhost/checks

--- a/roles/denyhost/checks/valid_ips.t
+++ b/roles/denyhost/checks/valid_ips.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+# Before running, do the following to install dependencies:
+# cpan -T Test::More Net::IP List::Util FindBin
+
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Net::IP;
+use List::Util qw/any/;
+use FindBin;
+
+sub is_local_address {
+    my $ip = Net::IP->new(shift);
+    my @local_ranges = (
+        new Net::IP('10/8'),
+        new Net::IP('172.16/12'),
+        new Net::IP('192.168/16')
+    );
+    return unless $ip;
+    return any { $ip->overlaps($_) } @local_ranges;
+}
+
+sub can_deny_ip {
+    !is_local_address(shift);
+}
+
+sub ip_range_from_line {
+    shift =~ /^\s*\-\s*([\d\.\/]+)/;
+    return $1;
+}
+
+subtest 'denyhost list is valid', sub {
+    my $file = "$FindBin::Bin/../vars/main.yml";
+    open my $fh, $file or die "Could not open $file: $!";
+
+    while( my $line = <$fh>)  {
+        my $ip = ip_range_from_line($line);
+        if ($ip) {
+            diag "Checking $ip";
+            ok(can_deny_ip($ip), "IP $ip can be blocked");
+        }
+    }
+    close $fh;
+};
+
+subtest 'coherence checks', sub {
+    plan tests => 5;
+    ok can_deny_ip('5.255.231.73'), 'It can deny a crawler';
+    ok !can_deny_ip('192.168.0.1'), 'It cannot deny an IP addresses in the RFC 1918 range';
+    is ip_range_from_line('      - 122.234.0.0/16'),
+        '122.234.0.0/16',
+        'It can parse a line containing an IP address';
+    is ip_range_from_line(' #     - 122.234.0.0/16'),
+        undef,
+        'It does not parse a commented line';
+    is ip_range_from_line('- name: AS4808 China Unicom Beijing Province Network | (Description See Ticket TASK0129270)'),
+        undef,
+        'It does not parse ticket numbers or other non-IP numeric data';
+}
+


### PR DESCRIPTION
We accidentally blocked ourselves at the firewall level in #5582 (fixed in #5583).  This adds a check to CI to alert us if we're about to do that again.