### PR TITLE
[orangelight] Make it harder for the load balancer healthcheck to take the catalog down

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -81,7 +81,7 @@ server {
         proxy_http_version 1.1;
         limit_req zone=catalog-prod-ratelimit burst=80 nodelay;
         limit_req_status 429;
-        health_check uri=/health.json interval=10 fails=3 passes=2;
+        health_check uri=/health.json interval=10 fails=5 passes=1;
         if ($http_user_agent ~ (Bytespider) ) {
           return 403;
         }


### PR DESCRIPTION
We observed a pattern:
1. While we had heavy bot traffic, the healthcheck would fail or timeout when the load balancer contacted it
2. In the nginx dashboard, we saw that these healthcecks would cause the VM to be taken out of the rotation.
3. The two remaining application servers had to deal with an increased amount of bot traffic with their friend down.
4. Their healthcheck started failing too.

This PR only partially helps with this issue, by increasing the number of healthchecks required before taking a VM out of rotation, and reducing the number of healthchecks required before adding it back.

A better fix would be to increase the amount of time before a request times out, and adding more application servers to handle the load.