### PR TITLE
[orangelight] increase the passenger max pool size

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -122,3 +122,4 @@ rails_app_vars:
     value: "{{ vault_ol_libanswers_client_secret }}"
 sneakers_worker_name: orangelight-sneakers
 sneakers_workers: EventHandler
+passenger_max_pool_size: 15


### PR DESCRIPTION
This increases the number of simultaneous requests that passenger will work on. The tradeoff is that more simultaneous requests will require more memory to process.

According to the passenger documentation, we could safely process about 28 simultaneous requests (rather than our current 6) with the current memory usage patterns and memory available on the boxes:
https://www.phusionpassenger.com/library/config/nginx/optimization/#tuning-the-application-process-and-thread-count

Perhaps this could make the catalog more resilient to large spikes in bot traffic?

Creating as a draft PR so that we can discuss.  I ran this on catalog3 today (December 4)