### PR TITLE
[Nomad] Prune podman containers nightly.

### DIFF
--- a/roles/pul_nomad/files/auto_update_override.conf
+++ b/roles/pul_nomad/files/auto_update_override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPost=
+ExecStartPost=/usr/bin/podman image prune -a -f

--- a/roles/pul_nomad/handlers/main.yml
+++ b/roles/pul_nomad/handlers/main.yml
@@ -1,2 +1,5 @@
 ---
 # handlers file for pul_nomad
+- name: reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/roles/pul_nomad/tasks/main.yml
+++ b/roles/pul_nomad/tasks/main.yml
@@ -102,12 +102,46 @@
   when:
     - "ansible_os_family == 'RedHat'"
 
-- name: 'nomad-node | Keep Podman up'
+- name: 'pul_nomad | Keep Podman up'
   when:
     - "nomad_node_role == 'client'"
     - "ansible_os_family == 'RedHat'"
   ansible.builtin.service:
     name: "podman.socket"
+    state: "started"
+    enabled: true
+
+- name: 'pul_nomad | Create podman update override dir'
+  ansible.builtin.file:
+    path: /etc/systemd/system/podman-auto-update.service.d
+    state: directory
+  tags: podman_conf
+  when:
+    - "nomad_node_role == 'client'"
+    - "ansible_os_family == 'RedHat'"
+
+- name: 'pul_nomad | Prune podman containers nightly'
+  ansible.builtin.copy:
+    src: 'auto_update_override.conf'
+    dest: /etc/systemd/system/podman-auto-update.service.d/override.conf
+  when:
+    - "nomad_node_role == 'client'"
+    - "ansible_os_family == 'RedHat'"
+  tags:
+    - notest
+    - podman_conf
+  notify:
+    - reload systemd
+
+- name: 'pul_nomad | Configure nightly prune timer'
+  when:
+    - "nomad_node_role == 'client'"
+    - "ansible_os_family == 'RedHat'"
+  tags:
+    - notest
+    - podman_conf
+  ansible.builtin.service:
+    name: "podman-auto-update.timer"
     state: "started"
     enabled: true
 


### PR DESCRIPTION
We were filling up disk with unused images.

Pulled from https://github.com/hashicorp/nomad-driver-podman/issues/363 and https://github.com/dani-garcia/vaultwarden/discussions/4362

Closes #5602 