### PR TITLE
Increase passenger thread count to 30

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -36,6 +36,7 @@ passenger_extra_config: '{{ lookup("file", "roles/orangelight/templates/nginx_ex
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 passenger_ruby: "/usr/local/bin/ruby"
+passenger_max_pool_size: 30
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.0"
 pg_hba_contype: "host"
@@ -122,4 +123,3 @@ rails_app_vars:
     value: "{{ vault_ol_libanswers_client_secret }}"
 sneakers_worker_name: orangelight-sneakers
 sneakers_workers: EventHandler
-passenger_max_pool_size: 15


### PR DESCRIPTION
After analyzing our resource usage on our Orangelight webservers we decided to increase the Passenger thread count to 30 to handle more requests with the available resources.