### PR TITLE
[allsearch api] compile ruby with the YJIT in staging

### DIFF
--- a/group_vars/allsearch_api/common.yml
+++ b/group_vars/allsearch_api/common.yml
@@ -1,6 +1,6 @@
 ---
 install_ruby_from_source: true
-ruby_version_override: "ruby-3.3.0"
+ruby_version_override: "ruby-3.3.6"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 

--- a/group_vars/allsearch_api/staging.yml
+++ b/group_vars/allsearch_api/staging.yml
@@ -1,5 +1,6 @@
 ---
 rails_app_env: staging
+ruby_yjit: true
 allsearch_api_secret_key: '{{vault_allsearch_api_staging_secret_key}}'
 
 postgres_host: lib-postgres-staging1.princeton.edu

--- a/roles/ruby_s/defaults/main.yml
+++ b/roles/ruby_s/defaults/main.yml
@@ -5,3 +5,4 @@ ruby_version_default: "ruby-3.1.3"
 ubuntu_ruby_version: "{{ ubuntu_ruby_version_override | default(ubuntu_ruby_version_default) }}"
 ubuntu_ruby_version_default: "ruby2.7"
 install_path: /opt/install
+ruby_yjit: false

--- a/roles/ruby_s/tasks/install_from_source.yml
+++ b/roles/ruby_s/tasks/install_from_source.yml
@@ -1,4 +1,10 @@
 ---
+- name: ruby_s | install the rust compiler to compile Ruby YJIT
+  ansible.builtin.apt:
+    name: rustc
+    state: present
+  when: ruby_yjit
+
 - name: ruby_s | lookup download path and checksum from ruby-lang release index
   ansible.builtin.shell: curl https://cache.ruby-lang.org/pub/ruby/index.txt | grep {{ ruby_version }}.tar.gz
   register: ruby_index_line


### PR DESCRIPTION
Recent versions of Ruby 3.3 will automatically compile the yjit if they notice that the rust compiler is installed.

Rails 7.2 (which Allsearch API uses) automatically uses the YJIT if it is available.

Trying this out to see if it boosts performance at all (which we can monitor in the datadog APM).

One way to check if the YJIT is installed is with the following shell command:

```
ruby -e 'puts "YJIT is#{defined?(RubyVM::YJIT) ? "" : " not"} installed"'
```