### PR TITLE
[nginxplus] remove restart task

### DIFF
--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -49,13 +49,6 @@
   vars_files:
     - ../group_vars/nginxplus/main.yml
 
-  tasks:
-    - name: nginxplus | restart nginx for realsies
-      service:
-        name: nginx
-        state: restarted
-      tags: always
-
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:


### PR DESCRIPTION
our nginxplus is now more resilient to crashes thanks to this work https://github.com/pulibrary/princeton_ansible/pull/5557

the tasks within the role call for nginxplus to be reloaded

closes #5607
