### PR TITLE
[Pulfalight] Add nginx stats & logs for pulfalight to Datadog.

### DIFF
--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -161,3 +161,18 @@ datadog_checks:
           - 'http_service:pulfalight'
           - 'http_service_type:health'
           - 'http_service_check:smtp'
+datadog_typed_checks:
+  - type: nginx
+    configuration:
+      init_config:
+      instances:
+        - nginx_status_url: http://localhost:80/nginx_status/
+      logs:
+        - type: file
+          path: /var/log/nginx/access.log
+          source: nginx
+          service: pulfalight
+        - type: file
+          path: /var/log/nginx/error.log
+          source: nginx
+          service: pulfalight

--- a/roles/nginxplus/files/conf/http/pulfalight-prod.conf
+++ b/roles/nginxplus/files/conf/http/pulfalight-prod.conf
@@ -35,6 +35,8 @@ server {
        proxy_pass http://pulfalight-prod;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Proto https;
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Real-IP $remote_addr;
        proxy_cache pulfalight-stagingcache;
        proxy_connect_timeout      2h;
        proxy_send_timeout         2h;

--- a/roles/passenger/templates/passenger.j2
+++ b/roles/passenger/templates/passenger.j2
@@ -23,6 +23,7 @@ server {
 
 # this filters out the load-balancer IPs, so we don't log health checks from them
 map $remote_addr $logging_enabled {
+  "127.0.0.1" 0;
   {% for ip in passenger_real_ip_from %}
     "{{ ip }}" 0;
     {% endfor %}


### PR DESCRIPTION
This does a few things:

1. Adds nginx logs
1. Filters local health checks out of nginx logs (for all apps).
1. Forwards the real IP so they don't get filtered, and we can group on them in DataDog.

Refs pulibrary/pulfalight#1469