### PR TITLE
Comment out deploy_id_rsa_private_key in bibdata commons so that we can run the bibdata playbook successfully

### DIFF
--- a/group_vars/bibdata/common.yml
+++ b/group_vars/bibdata/common.yml
@@ -24,5 +24,6 @@ bibdata_admin_netids:
   - rl8282
   - tpend
   - bd4538
-deploy_id_rsa_private_key: "{{  lookup('file', '../roles/lib_sftp/files/id_rsa')  }}\n"
+# The playbook is failing because of https://github.com/pulibrary/princeton_ansible/issues/4938
+# deploy_id_rsa_private_key: "{{  lookup('file', '../roles/lib_sftp/files/id_rsa')  }}\n"
 alma_api_limit: 150000


### PR DESCRIPTION
See related sftp ticket: https://github.com/pulibrary/princeton_ansible/issues/4938