### PR TITLE
Figgy worker boxes appear to have more capacity for sidekiq threads

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -1,5 +1,6 @@
 ---
 sidekiq_worker_name: figgy-workers
+sidekiq_worker_threads: 10
 rails_app_site_config_services:
   - nginx
   - "{{ sidekiq_worker_name }}"

--- a/roles/sidekiq_worker/tasks/main.yml
+++ b/roles/sidekiq_worker/tasks/main.yml
@@ -7,6 +7,8 @@
   notify: 
     - 'systemctl daemon-reload'
     - 'restart sidekiq worker'
+  tags:
+    - sidekiq-worker-threads
 
 - name: Keep workers running
   service:


### PR DESCRIPTION
And we have a backed-up queue.

This has been run already on most of figgy's workers.
