### PR TITLE
[MFLUX] Add roles for users to query

### DIFF
--- a/roles/mflux/tasks/custom-roles.yml
+++ b/roles/mflux/tasks/custom-roles.yml
@@ -9,35 +9,11 @@
 - name: Mflux | role pu-lib-developer grant access
   ansible.builtin.command: java -Dmf.host=localhost -Dmf.transport=http -Dmf.domain=system -Dmf.user=manager -Dmf.password="{{ mflux_manager_password }}" -Dmf.port=80 -jar /opt/mediaflux/bin/aterm.jar --app exec actor.grant :type role :name "pu-lib:developer" {{ item }}
   loop:
-    - ':perm < :access "ACCESS" :resource -type "dictionary:namespace" "princeton:" >'
-    - ':perm < :access "ADMINISTER" :resource -type "dictionary:namespace" "princeton.tigerdata:" >'
-    - ':perm < :access "MODIFY" :resource -type "dictionary:namespace" "princeton.tigerdata:" >'
-    - ':perm < :access "ACCESS" :resource -type "dictionary:namespace" "princeton:" >'
-    - ':perm < :access "ADMINISTER" :resource -type "dictionary:namespace" "princeton:" >'
-    - ':perm < :access "MODIFY" :resource -type "dictionary:namespace" "princeton:" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.doc.namespace.create" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.doc.namespace.destroy" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.doc.namespace.rename" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.doc.namespace.update" >'
-    - ':perm < :access "MODIFY" :resource -type "service" "asset.doc.type.create" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.doc.type.reindex" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.doc.type.rename" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.tag.type.create" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.tag.type.set" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.tag.type.soft.destroy" >'
-    - ':perm < :access "ACCESS" :resource -type "service" "asset.test.check" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.test.create" >'
-    - ':perm < :access "MODIFY" :resource -type "service" "asset.test.import" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "asset.test.modify" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "dictionary.namespace.create" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "dictionary.namespace.destroy" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "dictionary.namespace.modify" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "dictionary.namespace.rename" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "xodb.stats.*" >'
-    - ':perm < :access "ADMINISTER" :resource -type "service" "xodb.transaction.rate.max" >'
     - ':role -type "role" "asset-accumulator"'
+    - ':role -type "role" "desktop-experimental"'
 
 - name: Mflux | grant princeton domain custom pu-lib:developer
   ansible.builtin.command: java -Dmf.host=localhost -Dmf.transport=http -Dmf.domain=system -Dmf.user=manager -Dmf.password="{{ mflux_manager_password }}" -Dmf.port=80 -jar /opt/mediaflux/bin/aterm.jar --app exec actor.grant :type domain :name princeton :role -type role {{ item }}
   loop:
      - pu-lib:developer
+     - standard-user

--- a/roles/mflux/tasks/docker.yml
+++ b/roles/mflux/tasks/docker.yml
@@ -41,5 +41,18 @@
 - name: Mflux | import ldap-config tasks
   ansible.builtin.import_tasks: ldap-config.yml
 
-# - name: Mflux | Allow SHA1
+- name: Mflux | role create dictionary namespaces
+  ansible.builtin.command: java -Dmf.host=localhost -Dmf.transport=http -Dmf.domain=system -Dmf.user=manager -Dmf.password="{{ mflux_manager_password }}" -Dmf.port=80 -jar /opt/mediaflux/bin/aterm.jar --app exec	dictionary.namespace.create :namespace {{ item }} :ifexists ignore
+  loop:
+    - "princeton"
+    - "princeton.tigerdata"
+
+# Run the custom roles configuration tasks
+- name: Mflux | import custom-roles tasks
+  ansible.builtin.import_tasks: custom-roles.yml
+
 # Remove SHA1 from /etc/crypto-policies/back-ends/java.config
+- name: Mflux | Allow SHA1
+  ansible.builtin.replace:
+    path: /etc/crypto-policies/back-ends/java.config
+    regexp: 'SHA1'


### PR DESCRIPTION
Makes sure the docker development instance can run the content queries when logged in via the cas user

Create a new instance and published it with this code `ansible-playbook playbooks/mflux-docker.yml --ask-vault-pass -e platform_base=arm64 -e docker_base_image=rockylinux:9 -e docker_tag=cas-login` for folks to use on thier machines