### PR TITLE
[nginxplus] fail2ban blacklight filter

### DIFF
--- a/roles/nginxplus/files/fail2ban/nginx-bad-httpbots.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-bad-httpbots.conf
@@ -1,0 +1,8 @@
+i[nginx-f_inclusive]
+enabled = true
+port    = http,https
+filter  = nginx-f_inclusive
+logpath = /var/log/nginx/access.log
+maxretry = 3
+findtime = 3600
+bantime  = 3600

--- a/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
@@ -1,3 +1,4 @@
 [Definition]
 failregex = ^\{\"remote_ip\"\: \"<ADDR>\".{45,80}\"uri\"\:.{4,}?(?:\&?f(?:_inclusive)?%%5B.{5,}?){20,}
+nginx-f_inclusive.conf
 ignoreregex =

--- a/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
@@ -1,4 +1,3 @@
-nginx-f_inclusive.conf
 [Definition]
-failregex = ^\{\"remote_ip\"\: \"<HOST>\".*?\"uri\"\:.+?([\&]?f(_inclusive)?%%5B.*?){8,}
+failregex = ^\{\"remote_ip\"\: \"<HOST>\".*?\"uri\"\:.+?([\&]?f(_inclusive)?%%5B.*?){20,}
 ignoreregex =

--- a/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
@@ -1,4 +1,4 @@
 nginx-f_inclusive.conf
 [Definition]
-failregex = ^<HOST> .+?([&?]f(_inclusive)?%%5B.*?){8,}
+failregex = ^\{\"remote_ip\"\: \"<HOST>\".*?\"uri\"\:.+?([\&]?f(_inclusive)?%%5B.*?){8,}
 ignoreregex =

--- a/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
@@ -1,3 +1,3 @@
 [Definition]
-failregex = ^\{\"remote_ip\"\: \"<HOST>\".*?\"uri\"\:.+?([\&]?f(_inclusive)?%%5B.*?){20,}
+failregex = ^\{\"remote_ip\"\: \"<ADDR>\".{45,80}\"uri\"\:.{4,}?(?:\&?f(?:_inclusive)?%%5B.{5,}?){20,}
 ignoreregex =

--- a/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
@@ -1,0 +1,4 @@
+nginx-f_inclusive.conf
+[Definition]
+failregex = ^<HOST> .+?([&?]f(_inclusive)?%%5B.*?){8,}
+ignoreregex =

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -56,6 +56,14 @@
   when: running_on_server
   notify: restart fail2ban
 
+- name: Nginxplus | Add nginx-bad-httpbots restriction
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-bad-httpbots.conf"
+    dest: "/etc/fail2ban/jail.d/nginx-bad-httpbots.conf"
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Nginxplus | Add nginx-limit-req fail2ban configuration
   ansible.builtin.copy:
     src: "fail2ban/nginx-limit-req.conf"
@@ -65,6 +73,14 @@
     mode: "0644"
   when: running_on_server
   notify: restart fail2ban
+
+- name: Nginxplus | Add solr facet filter
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-f_inclusive.conf"
+    dest: "/etc/fail2ban/filter.d/nginx-f_inclusive.conf"
+    owner: root
+    group: root
+    mode: "0644"
 
 - name: Nginxplus | start and enable fail2ban
   ansible.builtin.service:

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -34,7 +34,9 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
-  with_items: "{{ unwanted_fail2ban_files['files'] }}"
+  loop: "{{ unwanted_fail2ban_files['files'] }}"
+  when: running_on_server
+  notify: restart fail2ban
 
 - name: Nginxplus | Add nginx-badbots filter
   ansible.builtin.copy:
@@ -63,6 +65,8 @@
     owner: root
     group: root
     mode: "0644"
+  when: running_on_server
+  notify: restart fail2ban
 
 - name: Nginxplus | Add nginx-limit-req fail2ban configuration
   ansible.builtin.copy:

--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -68,6 +68,14 @@
   when: running_on_server
   notify: restart fail2ban
 
+- name: Nginxplus | Add nginx-bad-httpbots restriction
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-bad-httpbots.conf"
+    dest: "/etc/fail2ban/jail.d/nginx-bad-httpbots.conf"
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Nginxplus | Add nginx-limit-req fail2ban configuration
   ansible.builtin.copy:
     src: "fail2ban/nginx-limit-req.conf"
@@ -77,6 +85,14 @@
     mode: "0644"
   when: running_on_server
   notify: restart fail2ban
+
+- name: Nginxplus | Add solr facet filter
+  ansible.builtin.copy:
+    src: "fail2ban/nginx-f_inclusive.conf"
+    dest: "/etc/fail2ban/filter.d/nginx-f_inclusive.conf"
+    owner: root
+    group: root
+    mode: "0644"
 
 - name: Nginxplus | Add solr facet filter
   ansible.builtin.copy:


### PR DESCRIPTION
we have had queries that have a large number of facets. This filter will
look for 8 of these for blacklight. It works with blacklight 7. IPs
found will be banned

Co-authored-by: Jason Casden <cazzerson@users.noreply.github.com>
Co-authored-by: David Romani <unc-david-romani@users.noreply.github.com>
