### PR TITLE
[nginxplus] add new bots

### DIFF
--- a/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
@@ -1,6 +1,6 @@
 [Definition]
 
-badbots = 360Spider|claudebot
+badbots = 360Spider|claudebot|OAI-SearchBot|GPTBot
 
 failregex = (?i)<HOST> -.*"(GET|POST|HEAD).*HTTP.*(?:%(badbots)s).*"$
 


### PR DESCRIPTION
we have found these bots in our logs and add them to the list of bots
that fail2ban will filter out

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
Co-authored-by: Angel Ruiz <aruiz1789@users.noreply.github.com>
Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
Co-authored-by: Denzil Phillips <dphillips-39@users.noreply.github.com>
Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: James R. Griffin III <jrgriffiniii@users.noreply.github.com>
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
Co-authored-by: Kevin Reiss <kevinreiss@users.noreply.github.com>
Co-authored-by: Max Kadel <maxkadel@users.noreply.github.com>
Co-authored-by: Ryan Laddusaw <rladdusaw@users.noreply.github.com>
