### PR TITLE
[fail2ban/nginxplus] Change format of fail2ban match

### DIFF
--- a/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
@@ -2,6 +2,6 @@
 
 badbots = 360Spider|claudebot|OAI-SearchBot|GPTBot
 
-failregex = (?i)<HOST> -.*"(GET|POST|HEAD).*HTTP.*(?:%(badbots)s).*"$
+failregex = (?i)\{\"remote_ip\"\: \"<HOST>\".*?\"user_agent\"\:.*?(?:%(badbots)s).*$
 
 ignoreregex =


### PR DESCRIPTION
Previously, we were trying to match CLF formatted logs in access.log.  But our access log is in a JSON format, so we needed to adjust the fail2ban failregex accordingl[fail2ban/nginxplus] Change format of fail2ban match

Previously, we were trying to match CLF formatted logs in access.log.  But our access log is in a JSON format, so we needed to adjust the fail2ban failregex accordingly