### PR TITLE
[nginxplus] upgrade to jammy

### DIFF
--- a/inventory/all_projects/_orphans
+++ b/inventory/all_projects/_orphans
@@ -20,6 +20,8 @@ libserv144.princeton.edu # veridian server
 # libserv144 is the old postgres4
 # it now hosts Princeton Periodicals and Blue Mountain
 [unknown]
+lib-adc1.princeton.edu
+lib-adc2.princeton.edu
 libphp-prod.princeton.edu
 pulsearch-db.princeton.edu # running Ubuntu 12.04!!!
 [ask_phillippe]

--- a/inventory/all_projects/nginxplus
+++ b/inventory/all_projects/nginxplus
@@ -1,6 +1,6 @@
 [nginxplus_production]
-lib-adc1.princeton.edu
-lib-adc2.princeton.edu
+adc-prod1.princeton.edu
+adc-prod2.princeton.edu
 [nginxplus_staging]
 adc-dev1.lib.princeton.edu
 adc-dev2.lib.princeton.edu


### PR DESCRIPTION
move the focal vms to the orphaned group. This will remain here for another 30 days and go through the decommissioning process.

related to #5670 

The migration is needed since focal end of life is in the spring of 2025. [More here](https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/6)
