### PR TITLE
[nginxplus] add more bots

### DIFF
--- a/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
@@ -1,6 +1,6 @@
 [Definition]
 
-badbots = 360Spider|claudebot|OAI-SearchBot|GPTBot
+badbots = 360Spider|AI2Bot|Amazonbot|Applebot|Applebot-Extended|Bytespider|CCBot|ChatGPT-User|Claudebot|DuckAssistBot|Diffbot|FacebookBot|Google-Extended|GPTBot|Meta-ExternalAgent|OAI-SearchBot|YouBot
 
 failregex = (?i)\{\"remote_ip\"\: \"<HOST>\".*?\"user_agent\"\:.*?(?:%(badbots)s).*$
 


### PR DESCRIPTION
adding more bots to to be banned by fail2ban. This list was taken from a
combination of the code4lib bots channel and from [Dark Visitors](https://darkvisitors.com/agents)


