### PR TITLE
[nginxplus] revert back to physical hardware

### DIFF
--- a/inventory/all_projects/_orphans
+++ b/inventory/all_projects/_orphans
@@ -2,8 +2,6 @@
 [issue_tracker]
 issuetracker-prod1.princeton.edu
 [load_balancers]
-lib-adc1.princeton.edu
-lib-adc2.princeton.edu
 [smb_serve]
 lib-smb-serve.princeton.edu
 # are we using both 'studio_proc' and 'studio_processors'?

--- a/inventory/all_projects/nginxplus
+++ b/inventory/all_projects/nginxplus
@@ -1,6 +1,8 @@
 [nginxplus_production]
 adc-prod1.princeton.edu
 adc-prod2.princeton.edu
+lib-adc1.princeton.edu
+lib-adc2.princeton.edu
 [nginxplus_staging]
 adc-dev1.lib.princeton.edu
 adc-dev2.lib.princeton.edu


### PR DESCRIPTION
we cannot determine why the virtual loadbalancers kept yoyoing with the
new vms

this reverts to the physical hardware

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
Co-authored-by: Angel Ruiz <aruiz1789@users.noreply.github.com>
Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
Co-authored-by: Denzil Phillips <dphillips-39@users.noreply.github.com>
Co-authored-by: Anna Headley <hackartisan@users.noreply.github.com>
Co-authored-by: Carolyn Cole <carolyncole@users.noreply.github.com>
Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>
Co-authored-by: Kevin Reiss <kevinreiss@users.noreply.github.com>
Co-authored-by: Max Kadel <maxkadel@users.noreply.github.com>
