### PR TITLE
[catalog] reduce the number of passenger processes in staging and qa

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -36,7 +36,6 @@ passenger_extra_config: '{{ lookup("file", "roles/orangelight/templates/nginx_ex
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 passenger_ruby: "/usr/local/bin/ruby"
-passenger_max_pool_size: 30
 install_ruby_from_source: true
 pg_hba_contype: "host"
 pg_hba_method: "md5"

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -26,6 +26,7 @@ postgres_host: "lib-postgres-prod1.princeton.edu"
 postgres_port: "5432"
 ruby_version_override: "ruby-3.1.0"
 rails_app_env: "production"
+passenger_max_pool_size: 30
 scsb_auth_key: "{{ vault_scsb_auth_key }}"
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -28,6 +28,7 @@ postgres_admin_user: "postgres"
 postgres_host: "lib-postgres-qa1.princeton.edu"
 ruby_version_override: "ruby-3.1.0"
 rails_app_env: "qa"
+passenger_max_pool_size: 8
 scsb_auth_key: "{{ vault_scsb_auth_key }}"
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -29,6 +29,7 @@ postgres_host: "lib-postgres-staging1.princeton.edu"
 ruby_version_override: "ruby-3.3.6"
 ruby_yjit: true
 rails_app_env: "staging"
+passenger_max_pool_size: 8
 scsb_auth_key: "{{ vault_scsb_auth_key }}"
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:


### PR DESCRIPTION
Staging and qa have less traffic and less memory than the production boxes, so it is appropriate to have fewer passenger processes.

This helps, but does not totally resolve, an alert in CheckMK that complains about overcommitting memory.  We have determined that this is not actually a problem -- the overcommitted memory does not end up getting used, so we don't run into OOM issues.