### PR TITLE
[nginxplus] move cache location

### DIFF
--- a/roles/nginxplus/files/conf/http/abid_prod.conf
+++ b/roles/nginxplus/files/conf/http/abid_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/abid/NGINX_cache/ keys_zone=abidcache:10m;
+proxy_cache_path /var/cache/nginx/abid/ keys_zone=abidcache:10m;
 
 upstream abid {
     zone abid 64k;

--- a/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/allsearch-api/NGINX_cache/ keys_zone=allsearch-apicache:10m;
+proxy_cache_path /var/cache/nginx/allsearch-api/ keys_zone=allsearch-apicache:10m;
 
 map $limit $external_traffic {
     0 "";
@@ -33,7 +33,7 @@ server {
     listen 443 ssl;
     http2 on;
     server_name allsearch-api.princeton.edu;
-    
+
     client_max_body_size 8m;
 
     ssl_certificate            /etc/letsencrypt/live/allsearch-api/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch-api_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/allsearch-api-staging/NGINX_cache/ keys_zone=allsearch-api-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/allsearch-api-staging/ keys_zone=allsearch-api-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";
@@ -33,7 +33,7 @@ server {
     listen 443 ssl;
     http2 on;
     server_name allsearch-api-staging.princeton.edu;
-  
+
     client_max_body_size 8m;
 
     ssl_certificate            /etc/letsencrypt/live/allsearch-api-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/allsearch_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/allsearch/NGINX_cache/ keys_zone=allsearchcache:10m;
+proxy_cache_path /var/cache/nginx/allsearch/ keys_zone=allsearchcache:10m;
 
 map $limit $external_traffic {
     0 "";
@@ -33,7 +33,7 @@ server {
     listen 443 ssl;
     http2 on;
     server_name allsearch.princeton.edu;
-    
+
     client_max_body_size 8m;
 
     ssl_certificate            /etc/letsencrypt/live/allsearch/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/allsearch_staging.conf
+++ b/roles/nginxplus/files/conf/http/allsearch_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/allsearch-staging/NGINX_cache/ keys_zone=allsearch-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/allsearch-staging/ keys_zone=allsearch-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";
@@ -33,7 +33,7 @@ server {
     listen 443 ssl;
     http2 on;
     server_name allsearch-staging.princeton.edu;
-  
+
     client_max_body_size 8m;
 
     ssl_certificate            /etc/letsencrypt/live/allsearch-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/ansible-tower_prod.conf
+++ b/roles/nginxplus/files/conf/http/ansible-tower_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/ansible-tower/NGINX_cache/ keys_zone=ansible-towercache:10m;
+proxy_cache_path /var/cache/nginx/ansible-tower/ keys_zone=ansible-towercache:10m;
 
 upstream ansible-tower {
     zone ansible-tower 64k;
@@ -41,7 +41,7 @@ server {
         proxy_cache ansible-towercache;
         proxy_intercept_errors on;
         health_check interval=10 fails=3 passes=2;
-        
+
         location /websocket/ {
           proxy_pass https://ansible-tower;
           #attempt to enable websocket

--- a/roles/nginxplus/files/conf/http/approvals_prod.conf
+++ b/roles/nginxplus/files/conf/http/approvals_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/approvals-prod/NGINX_cache/ keys_zone=approvals-prodcache:10m;
+proxy_cache_path /var/cache/nginx/approvals-prod/ keys_zone=approvals-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/approvals_staging.conf
+++ b/roles/nginxplus/files/conf/http/approvals_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/approvals-staging/NGINX_cache/ keys_zone=approvals-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/approvals-staging/ keys_zone=approvals-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/bibdata_prod.conf
+++ b/roles/nginxplus/files/conf/http/bibdata_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/bibdata-prod/NGINX_cache/ keys_zone=bibdataprodcache:10m;
+proxy_cache_path /var/cache/nginx/bibdata-prod/ keys_zone=bibdataprodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/bibdata_qa.conf
+++ b/roles/nginxplus/files/conf/http/bibdata_qa.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/bibdata-qa/NGINX_cache/ keys_zone=bibdata-qacache:10m;
+proxy_cache_path /var/cache/nginx/bibdata-qa/ keys_zone=bibdata-qacache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/byzantine-tsp_prod.conf
+++ b/roles/nginxplus/files/conf/http/byzantine-tsp_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/byzantine-prod/NGINX_cache/ keys_zone=byzantine-prodcache:10m;
+proxy_cache_path /var/cache/nginx/byzantine-prod/ keys_zone=byzantine-prodcache:10m;
 
 upstream byzantine-tsp-prod {
     zone byzantine-tsp-prod 64k;

--- a/roles/nginxplus/files/conf/http/byzantine_prod.conf
+++ b/roles/nginxplus/files/conf/http/byzantine_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/byzantine/NGINX_cache/ keys_zone=byzantinecache:10m;
+proxy_cache_path /var/cache/nginx/byzantine/ keys_zone=byzantinecache:10m;
 
 upstream byzantine {
     zone byzantine 64k;

--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/catalog-prod/NGINX_cache/ keys_zone=catalog-prodcache:10m;
+proxy_cache_path /var/cache/nginx/catalog-prod/ keys_zone=catalog-prodcache:10m;
 
 include /etc/nginx/conf.d/templates/rate-limit-allow-list.conf;
 
@@ -60,7 +60,7 @@ server {
     ssl_certificate            /etc/letsencrypt/live/catalog/fullchain.pem;
     ssl_certificate_key        /etc/letsencrypt/live/catalog/privkey.pem;
     ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;    
+    ssl_prefer_server_ciphers  on;
     app_protect_enable off;
 
     location / {

--- a/roles/nginxplus/files/conf/http/catalog-qa.conf
+++ b/roles/nginxplus/files/conf/http/catalog-qa.conf
@@ -1,6 +1,6 @@
 # This is an ansible_managed file. Any changes made will be overwritten
 # when the role is run again
-proxy_cache_path /data/nginx/catalog-qa/NGINX_cache/ keys_zone=catalog-qacache:10m;
+proxy_cache_path /var/cache/nginx/catalog-qa/ keys_zone=catalog-qacache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/cdh_prod_derrida.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_derrida.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/cdh_derrida/NGINX_cache/ keys_zone=cdh_derridacache:10m;
+proxy_cache_path /var/cache/nginx/cdh_derrida/ keys_zone=cdh_derridacache:10m;
 
 upstream cdh_derrida {
     zone cdh_derrida 64k;

--- a/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_geniza.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/geniza_prod/NGINX_cache/ keys_zone=geniza_prodcache:10m;
+proxy_cache_path /var/cache/nginx/geniza_prod/ keys_zone=geniza_prodcache:10m;
 
 map $http_upgrade $connection_upgrade {
   default upgrade;

--- a/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_prodigy.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/prodigy/NGINX_cache/ keys_zone=prodigycache:10m;
+proxy_cache_path /var/cache/nginx/prodigy/ keys_zone=prodigycache:10m;
 
 upstream prodigy {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/cdh_prod_prosody.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_prosody.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/prosody/NGINX_cache/ keys_zone=prosodycache:10m;
+proxy_cache_path /var/cache/nginx/prosody/ keys_zone=prosodycache:10m;
 
 upstream prosody {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/cdh_prod_shakespeareandco.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_shakespeareandco.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/shxco_prod/NGINX_cache/ keys_zone=shxco_prodcache:10m;
+proxy_cache_path /var/cache/nginx/shxco_prod/ keys_zone=shxco_prodcache:10m;
 
 upstream shxco_prod {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/cdh_prod_web.conf
+++ b/roles/nginxplus/files/conf/http/cdh_prod_web.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/prod_cdhweb/NGINX_cache/ keys_zone=prod_cdhwebcache:10m;
+proxy_cache_path /var/cache/nginx/prod_cdhweb/ keys_zone=prod_cdhwebcache:10m;
 
 # make new version of CDH website live; serving from 3 & 4 for now
 upstream prod_cdhweb {

--- a/roles/nginxplus/files/conf/http/cdh_test_derrida.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_derrida.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_derrida/NGINX_cache/ keys_zone=test_derridacache:10m;
+proxy_cache_path /var/cache/nginx/test_derrida/ keys_zone=test_derridacache:10m;
 
 upstream test_derrida {
     zone prod_derrida 64k;

--- a/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_geniza.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_geniza/NGINX_cache/ keys_zone=test_genizacache:10m;
+proxy_cache_path /var/cache/nginx/test_geniza/ keys_zone=test_genizacache:10m;
 
 upstream test_geniza {
     zone prod_geniza 64k;

--- a/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prodigy.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_prodigy/NGINX_cache/ keys_zone=test_prodigycache:10m;
+proxy_cache_path /var/cache/nginx/test_prodigy/ keys_zone=test_prodigycache:10m;
 
 upstream test_prodigy {
     zone prod_prodigy 64k;

--- a/roles/nginxplus/files/conf/http/cdh_test_prosody.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prosody.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_prosody/NGINX_cache/ keys_zone=test_prosodycache:10m;
+proxy_cache_path /var/cache/nginx/test_prosody/ keys_zone=test_prosodycache:10m;
 
 upstream test_prosody {
     zone prod_prosody 64k;

--- a/roles/nginxplus/files/conf/http/cdh_test_sandbox.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_sandbox.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_sandbox/NGINX_cache/ keys_zone=test_sandboxwebcache:10m;
+proxy_cache_path /var/cache/nginx/test_sandbox/ keys_zone=test_sandboxwebcache:10m;
 
 upstream test_cdhsandbox {
     zone test_cdhsandbox 64k;

--- a/roles/nginxplus/files/conf/http/cdh_test_shakespeareandco.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_shakespeareandco.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_shxco/NGINX_cache/ keys_zone=test_shxcocache:10m;
+proxy_cache_path /var/cache/nginx/test_shxco/ keys_zone=test_shxcocache:10m;
 
 upstream test_shxco {
     zone prod_shxco 64k;

--- a/roles/nginxplus/files/conf/http/cdh_test_web.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_web.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/test_cdhweb/NGINX_cache/ keys_zone=test_cdhwebcache:10m;
+proxy_cache_path /var/cache/nginx/test_cdhweb/ keys_zone=test_cdhwebcache:10m;
 
 upstream test_cdhweb {
     zone test_cdhweb 64k;

--- a/roles/nginxplus/files/conf/http/checkmk_prod.conf
+++ b/roles/nginxplus/files/conf/http/checkmk_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/checkmk-prod/NGINX_cache/ keys_zone=checkmk-prodcache:10m;
+proxy_cache_path /var/cache/nginx/checkmk-prod/ keys_zone=checkmk-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/datacommons.conf
+++ b/roles/nginxplus/files/conf/http/datacommons.conf
@@ -1,6 +1,6 @@
 # Ansible managed
-proxy_cache_path /data/nginx/discovery-prod/NGINX_cache/ keys_zone=discovery-prodcache:10m;
-proxy_cache_path /data/nginx/describe-prod/NGINX_cache/ keys_zone=describe-prodcache:10m;
+proxy_cache_path /var/cache/nginx/discovery-prod/ keys_zone=discovery-prodcache:10m;
+proxy_cache_path /var/cache/nginx/describe-prod/ keys_zone=describe-prodcache:10m;
 # Note that the URL datacommons.princeton.edu will be the front end for several
 # applications that run on different hosts. PDC Discovery and PDC Describe to start,
 # but this will grow over time as the data curation service expands.

--- a/roles/nginxplus/files/conf/http/datacommons_staging.conf
+++ b/roles/nginxplus/files/conf/http/datacommons_staging.conf
@@ -1,6 +1,6 @@
 # Ansible managed
-proxy_cache_path /data/nginx/discovery-staging/NGINX_cache/ keys_zone=discovery-stagingcache:10m;
-proxy_cache_path /data/nginx/describe-staging/NGINX_cache/ keys_zone=describe-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/discovery-staging/ keys_zone=discovery-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/describe-staging/ keys_zone=describe-stagingcache:10m;
 # Note that the URL datacommons-staging.princeton.edu will be the front end for several
 # applications that run on different hosts. PDC Discovery and PDC Describe to start,
 # but this will grow over time as the data curation service expands.

--- a/roles/nginxplus/files/conf/http/diglib.conf
+++ b/roles/nginxplus/files/conf/http/diglib.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/diglib/NGINX_cache/ keys_zone=diglibcache:10m;
+proxy_cache_path /var/cache/nginx/diglib/ keys_zone=diglibcache:10m;
 
 upstream libserv71base {
     zone diglib 64k;

--- a/roles/nginxplus/files/conf/http/dpul-prod.conf
+++ b/roles/nginxplus/files/conf/http/dpul-prod.conf
@@ -1,6 +1,6 @@
 # This config file is {{ ansible_managed }} and will be replaced if role is
 # rerun
-proxy_cache_path /data/nginx/dpul-prod/NGINX_cache/ keys_zone=dpul-prodcache:10m;
+proxy_cache_path /var/cache/nginx/dpul-prod/ keys_zone=dpul-prodcache:10m;
 
 upstream dpul-prod {
     zone dpul-prod 64k;

--- a/roles/nginxplus/files/conf/http/dpul-staging.conf
+++ b/roles/nginxplus/files/conf/http/dpul-staging.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/dpul-staging/NGINX_cache/ keys_zone=dpul-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/dpul-staging/ keys_zone=dpul-stagingcache:10m;
 
 upstream dpul-staging {
     zone dpul-staging 64k;

--- a/roles/nginxplus/files/conf/http/dss-prod.conf
+++ b/roles/nginxplus/files/conf/http/dss-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/dss-prod/NGINX_cache/ keys_zone=dss-prodcache:10m;
+proxy_cache_path /var/cache/nginx/dss-prod/ keys_zone=dss-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/dss-staging.conf
+++ b/roles/nginxplus/files/conf/http/dss-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/dss-staging/NGINX_cache/ keys_zone=dss-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/dss-staging/ keys_zone=dss-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/eal_prod.conf
+++ b/roles/nginxplus/files/conf/http/eal_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/eal/NGINX_cache/ keys_zone=ealcache:10m;
+proxy_cache_path /var/cache/nginx/eal/ keys_zone=ealcache:10m;
 
 upstream eal {
     zone eal 64k;

--- a/roles/nginxplus/files/conf/http/ealapps_prod.conf
+++ b/roles/nginxplus/files/conf/http/ealapps_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/eal-apps-prod/NGINX_cache/ keys_zone=eal-apps-prodcache:10m;
+proxy_cache_path /var/cache/nginx/eal-apps-prod/ keys_zone=eal-apps-prodcache:10m;
 
 upstream eal-apps-prod {
     zone eal-apps-prod 64k;

--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/figgy/NGINX_cache/ keys_zone=figgycache:10m;
+proxy_cache_path /var/cache/nginx/figgy/ keys_zone=figgycache:10m;
 
 upstream figgy {
     least_time last_byte inflight;

--- a/roles/nginxplus/files/conf/http/figgy-staging.conf
+++ b/roles/nginxplus/files/conf/http/figgy-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/figgy-staging/NGINX_cache/ keys_zone=figgy-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/figgy-staging/ keys_zone=figgy-stagingcache:10m;
 
 upstream figgy-staging {
     least_time last_byte inflight;

--- a/roles/nginxplus/files/conf/http/fpul-prod.conf
+++ b/roles/nginxplus/files/conf/http/fpul-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/fpul-prod/NGINX_cache/ keys_zone=fpul-prodcache:10m;
+proxy_cache_path /var/cache/nginx/fpul-prod/ keys_zone=fpul-prodcache:10m;
 
 upstream fpul-prod {
     zone fpul-prod 64k;

--- a/roles/nginxplus/files/conf/http/geaccirc.conf
+++ b/roles/nginxplus/files/conf/http/geaccirc.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/geaccirc-prod/NGINX_cache/ keys_zone=geaccirc-prodcache:10m;
+proxy_cache_path /var/cache/nginx/geaccirc-prod/ keys_zone=geaccirc-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/geaccirc_staging.conf
+++ b/roles/nginxplus/files/conf/http/geaccirc_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/geaccirc-staging/NGINX_cache/ keys_zone=geaccirc-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/geaccirc-staging/ keys_zone=geaccirc-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/gitlab_prod.conf
+++ b/roles/nginxplus/files/conf/http/gitlab_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/gitlab/NGINX_cache/ keys_zone=gitlabcache:10m;
+proxy_cache_path /var/cache/nginx/gitlab/ keys_zone=gitlabcache:10m;
 
 upstream gitlab {
     zone gitlab 64k;

--- a/roles/nginxplus/files/conf/http/iiif-staging.conf
+++ b/roles/nginxplus/files/conf/http/iiif-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/iiifstaging/NGINX_cache/ keys_zone=iiifstagingcache:10m;
+proxy_cache_path /var/cache/nginx/iiifstaging/ keys_zone=iiifstagingcache:10m;
 
 upstream iiifstaging {
     zone iiifstaging 512k;

--- a/roles/nginxplus/files/conf/http/imagecat_prod.conf
+++ b/roles/nginxplus/files/conf/http/imagecat_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/imagecat_prod/NGINX_cache/ keys_zone=imagecat_prodcache:10m;
+proxy_cache_path /var/cache/nginx/imagecat_prod/ keys_zone=imagecat_prodcache:10m;
 
 upstream imagecat_prod {
     zone imagecat_prod 64k;

--- a/roles/nginxplus/files/conf/http/imagecat_staging.conf
+++ b/roles/nginxplus/files/conf/http/imagecat_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/imagecat_staging/NGINX_cache/ keys_zone=imagecat_stagingcache:10m;
+proxy_cache_path /var/cache/nginx/imagecat_staging/ keys_zone=imagecat_stagingcache:10m;
 
 upstream imagecat_staging {
     zone imagecat_staging 64k;

--- a/roles/nginxplus/files/conf/http/issuetracker.conf
+++ b/roles/nginxplus/files/conf/http/issuetracker.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/issuetracker/NGINX_cache/ keys_zone=issuetrackercache:10m;
+proxy_cache_path /var/cache/nginx/issuetracker/ keys_zone=issuetrackercache:10m;
 
 upstream issuetracker {
     zone issuetracker 64k;

--- a/roles/nginxplus/files/conf/http/lae-prod.conf
+++ b/roles/nginxplus/files/conf/http/lae-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lae-prod/NGINX_cache/ keys_zone=laeprodcache:10m;
+proxy_cache_path /var/cache/nginx/lae-prod/ keys_zone=laeprodcache:10m;
 
 include /etc/nginx/conf.d/templates/rate-limit-allow-list.conf;
 

--- a/roles/nginxplus/files/conf/http/lae-staging.conf
+++ b/roles/nginxplus/files/conf/http/lae-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lae-staging/NGINX_cache/ keys_zone=lae-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/lae-staging/ keys_zone=lae-stagingcache:10m;
 
 include /etc/nginx/conf.d/templates/rate-limit-allow-list.conf;
 

--- a/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/libjobs-prod/NGINX_cache/ keys_zone=libjobs-prodcache:10m;
+proxy_cache_path /var/cache/nginx/libjobs-prod/ keys_zone=libjobs-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/libjobs-staging/NGINX_cache/ keys_zone=libjobs-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/libjobs-staging/ keys_zone=libjobs-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/lib-sc-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-sc-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lib-sc-prod/NGINX_cache/ keys_zone=lib-sc-prodcache:10m;
+proxy_cache_path /var/cache/nginx/lib-sc-prod/ keys_zone=lib-sc-prodcache:10m;
 
 upstream lib-sc-prod {
     zone lib-sc-prod 64k;

--- a/roles/nginxplus/files/conf/http/lib-sc-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-sc-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lib-sc-staging/NGINX_cache/ keys_zone=lib-sc-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/lib-sc-staging/ keys_zone=lib-sc-stagingcache:10m;
 
 upstream lib-sc-staging {
     zone lib-sc-staging 64k;

--- a/roles/nginxplus/files/conf/http/lib-solr-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lib-solr-staging/NGINX_cache/ keys_zone=lib-solr-stagingcache:10m levels=1:2 inactive=3h max_size=20g;
+proxy_cache_path /var/cache/nginx/lib-solr-staging/ keys_zone=lib-solr-stagingcache:10m levels=1:2 inactive=3h max_size=20g;
 
 map $request_method $upstream {
     POST post-upstream;

--- a/roles/nginxplus/files/conf/http/lib-solr8-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8-prod.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/lib-solr8-prod/NGINX_cache/ keys_zone=lib-solr8-prodcache:10m;
+proxy_cache_path /var/cache/nginx/lib-solr8-prod/ keys_zone=lib-solr8-prodcache:10m;
 
 upstream lib-solr8-prod {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/lib-solr8-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8-staging.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/lib-solr8-staging/NGINX_cache/ keys_zone=lib-solr8-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/lib-solr8-staging/ keys_zone=lib-solr8-stagingcache:10m;
 
 upstream lib-solr8-staging {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/lib-solr8d-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr8d-staging.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/lib-solr8d-staging/NGINX_cache/ keys_zone=lib-solr8d-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/lib-solr8d-staging/ keys_zone=lib-solr8d-stagingcache:10m;
 
 upstream lib-solr8d-staging {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/lib-solr9-prod/NGINX_cache/ keys_zone=lib-solr9-prodcache:10m;
+proxy_cache_path /var/cache/nginx/lib-solr9-prod/ keys_zone=lib-solr9-prodcache:10m;
 
 upstream lib-solr9-prod {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/lib-solr9-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-staging.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/lib-solr9-staging/NGINX_cache/ keys_zone=lib-solr9-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/lib-solr9-staging/ keys_zone=lib-solr9-stagingcache:10m;
 
 upstream lib-solr9-staging {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/libimages.conf
+++ b/roles/nginxplus/files/conf/http/libimages.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/iiif/NGINX_cache/ keys_zone=iiifcache:10m;
+proxy_cache_path /var/cache/nginx/iiif/ keys_zone=iiifcache:10m;
 
 upstream iiif {
     zone iiif 512k;

--- a/roles/nginxplus/files/conf/http/library-prod.conf
+++ b/roles/nginxplus/files/conf/http/library-prod.conf
@@ -1,6 +1,6 @@
 # This is an {{ ansible_managed }} file. Any changes made will be overwritten
 # when the role is run again
-proxy_cache_path /data/nginx/library-prod/NGINX_cache/ keys_zone=library-prodcache:10m levels=1:2 inactive=3h max_size=10g;
+proxy_cache_path /var/cache/nginx/library-prod/ keys_zone=library-prodcache:10m levels=1:2 inactive=3h max_size=10g;
 limit_req_zone $binary_remote_addr zone=libweb_ip_rate_limit:10m rate=5r/s;
 
 upstream library-prod {

--- a/roles/nginxplus/files/conf/http/library-solr-prod.conf
+++ b/roles/nginxplus/files/conf/http/library-solr-prod.conf
@@ -1,6 +1,6 @@
 # ansible managed
 
-proxy_cache_path /data/nginx/library-solr-prod/NGINX_cache/ keys_zone=library-solr-prodcache:10m;
+proxy_cache_path /var/cache/nginx/library-solr-prod/ keys_zone=library-solr-prodcache:10m;
 
 upstream library-solr-prod {
     zone library-solr-prod 64k;

--- a/roles/nginxplus/files/conf/http/library-solr-staging.conf
+++ b/roles/nginxplus/files/conf/http/library-solr-staging.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/library-solr-staging/NGINX_cache/ keys_zone=library-solr-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/library-solr-staging/ keys_zone=library-solr-stagingcache:10m;
 
 upstream library-solr-staging {
     zone library-solr-staging 64k;

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lockers-and-study-spaces/NGINX_cache/ keys_zone=lockers-and-study-spacescache:10m;
+proxy_cache_path /var/cache/nginx/lockers-and-study-spaces/ keys_zone=lockers-and-study-spacescache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lockers-and-study-spaces-staging/NGINX_cache/ keys_zone=lockers-and-study-spaces-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/lockers-and-study-spaces-staging/ keys_zone=lockers-and-study-spaces-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/lrp.conf
+++ b/roles/nginxplus/files/conf/http/lrp.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/lrp/NGINX_cache/ keys_zone=lrpcache:10m;
+proxy_cache_path /var/cache/nginx/lrp/ keys_zone=lrpcache:10m;
 
 upstream lrp {
     zone lrp 64k;

--- a/roles/nginxplus/files/conf/http/maps-prod.conf
+++ b/roles/nginxplus/files/conf/http/maps-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/maps-prod/NGINX_cache/ keys_zone=maps-prodcache:10m;
+proxy_cache_path /var/cache/nginx/maps-prod/ keys_zone=maps-prodcache:10m;
 
 upstream maps-prod {
     least_time header 'inflight';

--- a/roles/nginxplus/files/conf/http/maps-staging.conf
+++ b/roles/nginxplus/files/conf/http/maps-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/maps-staging/NGINX_cache/ keys_zone=maps-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/maps-staging/ keys_zone=maps-stagingcache:10m;
 
 upstream maps-staging {
     zone maps-staging 64k;

--- a/roles/nginxplus/files/conf/http/mflux_ci.conf
+++ b/roles/nginxplus/files/conf/http/mflux_ci.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/mflux/NGINX_cache/ keys_zone=mfluxcache:10m;
+proxy_cache_path /var/cache/nginx/mflux/ keys_zone=mfluxcache:10m;
 
 upstream mflux {
     zone mflux 64k;

--- a/roles/nginxplus/files/conf/http/oawaiver-prod.conf
+++ b/roles/nginxplus/files/conf/http/oawaiver-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/oawaiver-prod/NGINX_cache/ keys_zone=oawaiver-prodcache:10m;
+proxy_cache_path /var/cache/nginx/oawaiver-prod/ keys_zone=oawaiver-prodcache:10m;
 
 upstream oawaiver-prod {
     zone oawaiver-prod 64k;

--- a/roles/nginxplus/files/conf/http/oawaiver-staging.conf
+++ b/roles/nginxplus/files/conf/http/oawaiver-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/oawaiver-staging/NGINX_cache/ keys_zone=oawaiver-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/oawaiver-staging/ keys_zone=oawaiver-stagingcache:10m;
 
 upstream oawaiver-staging {
     zone oawaiver-staging 64k;

--- a/roles/nginxplus/files/conf/http/ojs-prod.conf
+++ b/roles/nginxplus/files/conf/http/ojs-prod.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/ojs-prod/NGINX_cache/ keys_zone=ojs-prodcache:10m;
+proxy_cache_path /var/cache/nginx/ojs-prod/ keys_zone=ojs-prodcache:10m;
 
 upstream ojs-prod1 {
     zone ojs-prod 64k;

--- a/roles/nginxplus/files/conf/http/ojs-staging.conf
+++ b/roles/nginxplus/files/conf/http/ojs-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/ojs-staging/NGINX_cache/ keys_zone=ojs-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/ojs-staging/ keys_zone=ojs-stagingcache:10m;
 
 upstream ojs-staging1 {
     zone ojs-staging 64k;

--- a/roles/nginxplus/files/conf/http/orcid_prod.conf
+++ b/roles/nginxplus/files/conf/http/orcid_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pdc-orcid-prod/NGINX_cache/ keys_zone=pdc-orcid-prodcache:10m;
+proxy_cache_path /var/cache/nginx/pdc-orcid-prod/ keys_zone=pdc-orcid-prodcache:10m;
 
 upstream orcid-prod {
     zone orcid-prod 64k;

--- a/roles/nginxplus/files/conf/http/orcid_staging.conf
+++ b/roles/nginxplus/files/conf/http/orcid_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pdc-orcid-staging/NGINX_cache/ keys_zone=pdc-orcid-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/pdc-orcid-staging/ keys_zone=pdc-orcid-stagingcache:10m;
 
 upstream orcid-staging {
     zone orcid-staging 64k;

--- a/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pdc-describe-prod/NGINX_cache/ keys_zone=pdc-describe-prodcache:10m;
+proxy_cache_path /var/cache/nginx/pdc-describe-prod/ keys_zone=pdc-describe-prodcache:10m;
 
 upstream pdc-describe-prod {
     zone pdc-describe-prod 64k;

--- a/roles/nginxplus/files/conf/http/pdc-describe_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pdc-describe-staging/NGINX_cache/ keys_zone=pdc-describe-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/pdc-describe-staging/ keys_zone=pdc-describe-stagingcache:10m;
 
 upstream pdc-describe-staging {
     zone pdc-describe-staging 64k;

--- a/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pdc-discovery-prod/NGINX_cache/ keys_zone=pdc-discovery-prodcache:10m;
+proxy_cache_path /var/cache/nginx/pdc-discovery-prod/ keys_zone=pdc-discovery-prodcache:10m;
 
 upstream pdc-discovery-prod {
     zone pdc-discovery-prod 64k;

--- a/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pdc-discovery-staging/NGINX_cache/ keys_zone=pdc-discovery-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/pdc-discovery-staging/ keys_zone=pdc-discovery-stagingcache:10m;
 
 upstream pdc-discovery-staging {
     zone pdc-discovery-staging 64k;

--- a/roles/nginxplus/files/conf/http/pudl_prod.conf
+++ b/roles/nginxplus/files/conf/http/pudl_prod.conf
@@ -1,4 +1,4 @@
-proxy_cache_path /data/nginx/pudl/NGINX_cache/ keys_zone=pudlcachhhhhe:10m;
+proxy_cache_path /var/cache/nginx/pudl/ keys_zone=pudlcachhhhhe:10m;
 
 server {
     listen 80;

--- a/roles/nginxplus/files/conf/http/pulcheck_staging.conf
+++ b/roles/nginxplus/files/conf/http/pulcheck_staging.conf
@@ -1,6 +1,6 @@
 # Ansible managed
 #
-proxy_cache_path /data/nginx/pulcheck-staging/NGINX_cache/ keys_zone=pulcheck-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/pulcheck-staging/ keys_zone=pulcheck-stagingcache:10m;
 
 upstream pulcheck-staging {
     zone pulcheck-staging 64k;

--- a/roles/nginxplus/files/conf/http/pulfa_old.conf
+++ b/roles/nginxplus/files/conf/http/pulfa_old.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pulfa/NGINX_cache/ keys_zone=pulfacache:10m;
+proxy_cache_path /var/cache/nginx/pulfa/ keys_zone=pulfacache:10m;
 
 upstream libserv35 {
     zone pulfa 64k;

--- a/roles/nginxplus/files/conf/http/pulfalight-prod.conf
+++ b/roles/nginxplus/files/conf/http/pulfalight-prod.conf
@@ -1,5 +1,5 @@
 #### Ansible managed
-proxy_cache_path /data/nginx/pulfalight-prod/NGINX_cache/ keys_zone=pulfalight-prodcache:10m;
+proxy_cache_path /var/cache/nginx/pulfalight-prod/ keys_zone=pulfalight-prodcache:10m;
 
 upstream pulfalight-prod {
     least_time last_byte inflight;

--- a/roles/nginxplus/files/conf/http/pulfalight-qa.conf
+++ b/roles/nginxplus/files/conf/http/pulfalight-qa.conf
@@ -1,5 +1,5 @@
 #### Ansible managed
-proxy_cache_path /data/nginx/pulfalight-qa/NGINX_cache/ keys_zone=pulfalight-qacache:10m;
+proxy_cache_path /var/cache/nginx/pulfalight-qa/ keys_zone=pulfalight-qacache:10m;
 
 upstream pulfalight-qa {
     zone pulfalight-qa 64k;

--- a/roles/nginxplus/files/conf/http/pulfalight-staging.conf
+++ b/roles/nginxplus/files/conf/http/pulfalight-staging.conf
@@ -1,5 +1,5 @@
 #### Ansible managed
-proxy_cache_path /data/nginx/pulfalight-staging/NGINX_cache/ keys_zone=pulfalight-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/pulfalight-staging/ keys_zone=pulfalight-stagingcache:10m;
 
 upstream pulfalight-staging {
     zone pulfalight-staging 64k;

--- a/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
+++ b/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/pulmonitor-staging/NGINX_cache/ keys_zone=pulmonitor-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/pulmonitor-staging/ keys_zone=pulmonitor-stagingcache:10m;
 
 upstream pulmonitor-staging {
     zone pulmonitor-staging 64k;

--- a/roles/nginxplus/files/conf/http/recap-prod.conf
+++ b/roles/nginxplus/files/conf/http/recap-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/recap-prod/NGINX_cache/ keys_zone=recap-prodcache:10m;
+proxy_cache_path /var/cache/nginx/recap-prod/ keys_zone=recap-prodcache:10m;
 
 upstream recap-prod {
     zone recap-prod 128k;

--- a/roles/nginxplus/files/conf/http/recap-staging.conf
+++ b/roles/nginxplus/files/conf/http/recap-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/recap-staging/NGINX_cache/ keys_zone=recap-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/recap-staging/ keys_zone=recap-stagingcache:10m;
 
 upstream recap-staging {
     zone recap-staging 64k;

--- a/roles/nginxplus/files/conf/http/repec-prod.conf
+++ b/roles/nginxplus/files/conf/http/repec-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/repec-prod/NGINX_cache/ keys_zone=repec-prodcache:10m;
+proxy_cache_path /var/cache/nginx/repec-prod/ keys_zone=repec-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/repec-staging.conf
+++ b/roles/nginxplus/files/conf/http/repec-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/repec-staging/NGINX_cache/ keys_zone=repec-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/repec-staging/ keys_zone=repec-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/researchdata_prod.conf
+++ b/roles/nginxplus/files/conf/http/researchdata_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/researchdata_prod/NGINX_cache/ keys_zone=researchdata_prodcache:10m;
+proxy_cache_path /var/cache/nginx/researchdata_prod/ keys_zone=researchdata_prodcache:10m;
 
 upstream researchdata_prod {
     zone researchdata_prod 128k;

--- a/roles/nginxplus/files/conf/http/researchdata_staging.conf
+++ b/roles/nginxplus/files/conf/http/researchdata_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/researchdata-staging/NGINX_cache/ keys_zone=researchdata-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/researchdata-staging/ keys_zone=researchdata-stagingcache:10m;
 
 upstream researchdata-staging {
     zone researchdata-staging 64k;

--- a/roles/nginxplus/files/conf/http/slavery-dev.conf
+++ b/roles/nginxplus/files/conf/http/slavery-dev.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/slavery-dev/NGINX_cache/ keys_zone=slavery-devcache:10m;
+proxy_cache_path /var/cache/nginx/slavery-dev/ keys_zone=slavery-devcache:10m;
 
 upstream slavery-dev {
     zone slavery-dev 64k;

--- a/roles/nginxplus/files/conf/http/slavery-prod.conf
+++ b/roles/nginxplus/files/conf/http/slavery-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/slavery-prod/NGINX_cache/ keys_zone=slavery-prodcache:10m;
+proxy_cache_path /var/cache/nginx/slavery-prod/ keys_zone=slavery-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/slavery-staging.conf
+++ b/roles/nginxplus/files/conf/http/slavery-staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/slavery-staging/NGINX_cache/ keys_zone=slavery-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/slavery-staging/ keys_zone=slavery-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/static_prod.conf
+++ b/roles/nginxplus/files/conf/http/static_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/static-prod/NGINX_cache/ keys_zone=static-prodcache:10m;
+proxy_cache_path /var/cache/nginx/static-prod/ keys_zone=static-prodcache:10m;
 
 upstream static-prod {
     zone static-prod 64K;

--- a/roles/nginxplus/files/conf/http/static_tables_prod.conf
+++ b/roles/nginxplus/files/conf/http/static_tables_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/static-tables-prod/NGINX_cache/ keys_zone=static-tables-prodcache:10m;
+proxy_cache_path /var/cache/nginx/static-tables-prod/ keys_zone=static-tables-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/static_tables_staging.conf
+++ b/roles/nginxplus/files/conf/http/static_tables_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/static-tables-staging/NGINX_cache/ keys_zone=static-tables-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/static-tables-staging/ keys_zone=static-tables-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/svn-prod.conf
+++ b/roles/nginxplus/files/conf/http/svn-prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/svn-production/NGINX_cache/ keys_zone=svn-productioncache:10m;
+proxy_cache_path /var/cache/nginx/svn-production/ keys_zone=svn-productioncache:10m;
 
 upstream svn-production {
     zone svn-production 64k;

--- a/roles/nginxplus/files/conf/http/svn-staging.conf
+++ b/roles/nginxplus/files/conf/http/svn-staging.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/svn-staging/NGINX_cache/ keys_zone=svn-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/svn-staging/ keys_zone=svn-stagingcache:10m;
 
 upstream svn-staging {
     zone svn-staging 64k;

--- a/roles/nginxplus/files/conf/http/tigerdata_prod.conf
+++ b/roles/nginxplus/files/conf/http/tigerdata_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/tigerdata-prod/NGINX_cache/ keys_zone=tigerdata-prodcache:10m;
+proxy_cache_path /var/cache/nginx/tigerdata-prod/ keys_zone=tigerdata-prodcache:10m;
 
 upstream tigerdata-prod {
     zone tigerdata-prod 64k;

--- a/roles/nginxplus/files/conf/http/tigerdata_qa.conf
+++ b/roles/nginxplus/files/conf/http/tigerdata_qa.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/tigerdata-qa/NGINX_cache/ keys_zone=tigerdata-qacache:10m;
+proxy_cache_path /var/cache/nginx/tigerdata-qa/ keys_zone=tigerdata-qacache:10m;
 
 upstream tigerdata-qa {
     zone tigerdata-qa 64k;

--- a/roles/nginxplus/files/conf/http/towerdeploy_prod.conf
+++ b/roles/nginxplus/files/conf/http/towerdeploy_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/towerdeploy/NGINX_cache/ keys_zone=towerdeploycache:10m;
+proxy_cache_path /var/cache/nginx/towerdeploy/ keys_zone=towerdeploycache:10m;
 
 upstream towerdeploy {
     zone towerdeploy 64k;

--- a/roles/nginxplus/files/conf/http/veridian-sites.conf
+++ b/roles/nginxplus/files/conf/http/veridian-sites.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed | comment }}
-proxy_cache_path /data/nginx/veridian/NGINX_cache/ keys_zone=veridiancache:10m;
+proxy_cache_path /var/cache/nginx/veridian/ keys_zone=veridiancache:10m;
 
 upstream veridian {
     zone veridian 64k;

--- a/roles/nginxplus/files/conf/http/videoreserves_prod.conf
+++ b/roles/nginxplus/files/conf/http/videoreserves_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/videoreserves-prod/NGINX_cache/ keys_zone=videoreserves-prodcache:10m;
+proxy_cache_path /var/cache/nginx/videoreserves-prod/ keys_zone=videoreserves-prodcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/videoreserves_staging.conf
+++ b/roles/nginxplus/files/conf/http/videoreserves_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/videoreserves-staging/NGINX_cache/ keys_zone=videoreserves-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/videoreserves-staging/ keys_zone=videoreserves-stagingcache:10m;
 
 map $limit $external_traffic {
     0 "";

--- a/roles/nginxplus/files/conf/http/whichiso_prod.conf
+++ b/roles/nginxplus/files/conf/http/whichiso_prod.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/whichiso/NGINX_cache/ keys_zone=whichisocache:10m;
+proxy_cache_path /var/cache/nginx/whichiso/ keys_zone=whichisocache:10m;
 
 upstream whichiso-prod {
     zone whichiso 64k;

--- a/roles/nginxplus/files/conf/http/whichiso_staging.conf
+++ b/roles/nginxplus/files/conf/http/whichiso_staging.conf
@@ -1,5 +1,5 @@
 # Ansible managed
-proxy_cache_path /data/nginx/whichiso-staging/NGINX_cache/ keys_zone=whichiso-stagingcache:10m;
+proxy_cache_path /var/cache/nginx/whichiso-staging/ keys_zone=whichiso-stagingcache:10m;
 
 upstream whichiso-staging {
     zone whichiso-staging 64k;


### PR DESCRIPTION
upstream nginx caches at `/var/cache/nginx` we move the location of our
caches here. This allows us to add new sites without having to first
create the path at `/data/nginx/<site_name>`

related #5670

closes #3714
