### PR TITLE
[ruby_s] Run make in parallel

### DIFF
--- a/roles/ruby_s/tasks/cleanup.yml
+++ b/roles/ruby_s/tasks/cleanup.yml
@@ -12,7 +12,7 @@
     name: ruby*
     state: absent
 
-- name: ruby_s | remove ruby ruby dependencies
+- name: ruby_s | remove ruby dependencies
   ansible.builtin.command: apt-get -y autoremove
 
 - name: ruby_s | remove the Brightbox repository

--- a/roles/ruby_s/tasks/install_from_source.yml
+++ b/roles/ruby_s/tasks/install_from_source.yml
@@ -60,7 +60,7 @@
   ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && ./configure --enable-shared
 
 - name: ruby_s | make ruby
-  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make
+  ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make -j8
 
 - name: ruby_s | install ruby
   ansible.builtin.shell: cd {{ install_path }}/{{ ruby_version }} && make install


### PR DESCRIPTION
I installed a new ruby version (3.3.6 with YJIT) on both dss-staging1 and dss-staging2. I used this commit for dss-staging2, but not dss-staging1 for the sake of comparison. Running the playbook took:
  * 15:53.25 on dss-staging1 without this commit
  * 9:55.20 on dss-staging2 with this commit