### PR TITLE
Updated the copy module to include a notify to restart fail2ban service.

### DIFF
--- a/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
+++ b/roles/nginxplus/tasks/prerequisites/install-prerequisites.yml
@@ -43,6 +43,8 @@
     owner: root
     group: root
     mode: "0644"
+  when: running_on_server
+  notify: restart fail2ban
 
 - name: Nginxplus | Add nginx-badbots restriction
   ansible.builtin.copy:
@@ -51,6 +53,8 @@
     owner: root
     group: root
     mode: "0644"
+  when: running_on_server
+  notify: restart fail2ban
 
 - name: Nginxplus | Add nginx-limit-req fail2ban configuration
   ansible.builtin.copy:
@@ -59,6 +63,8 @@
     owner: root
     group: root
     mode: "0644"
+  when: running_on_server
+  notify: restart fail2ban
 
 - name: Nginxplus | start and enable fail2ban
   ansible.builtin.service:


### PR DESCRIPTION
Updated the copy module to include a "notify" to restart fail2ban service when changing the fail2ban config files.

The dev environments had a pending fail2ban config change at: /etc/fail2ban/filter.d/nginx-badbots.conf

Which trigged an automatic restart of the fail2ban service when running the playbook: active (running) since Mon 2025-01-06 15:22:06 UTC; 41s ago

