### PR TITLE
[ealapps] Use image from ghcr registry instead of quay

### DIFF
--- a/roles/ealapps/meta/main.yml
+++ b/roles/ealapps/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
+        - jammy
 dependencies:
   - role: "deploy_user"
   - role: "mysql"

--- a/roles/ealapps/molecule/default/molecule.yml
+++ b/roles/ealapps/molecule/default/molecule.yml
@@ -9,8 +9,8 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "sleep infinity"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/roles/ealapps/tasks/main.yml
+++ b/roles/ealapps/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: ealapps | grant permissions on deploy user
+- name: Ealapps | grant permissions on deploy user
   ansible.builtin.file:
     path: "{{ apache_doc_root }}"
     state: directory
@@ -7,16 +7,16 @@
     group: "{{ deploy_user }}"
     follow: false
     recurse: true
-    mode: 0775
+    mode: "0775"
   changed_when: false
 
-- name: ealapps | create directories for shared files
+- name: Ealapps | create directories for shared files
   ansible.builtin.file:
     path: '{{ capistrano_base_dir }}/{{ item }}'
     state: 'directory'
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
-    mode: 0755
+    mode: "0755"
   changed_when: false
   loop:
     - '{{ capistrano_directory }}/shared/EALJ'
@@ -25,17 +25,17 @@
     - '{{ capistrano_directory }}/shared/connections'
     - '{{ capistrano_directory }}/shared/newtitles/files'
 
-- name: ealapps | grant temp subdirectories different permissions
+- name: Ealapps | grant temp subdirectories different permissions
   ansible.builtin.file:
     path: '{{ capistrano_base_dir }}/{{ capistrano_directory }}/shared/EALJ/temp'
     state: directory
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
-    mode: 0777
+    mode: "0777"
     recurse: true
   changed_when: false
 
-- name: ealapps | add connection file
+- name: Ealapps | add connection file
   ansible.builtin.template:
     src: connection_mysql.php.j2
     dest: "{{ apache_doc_root }}/shared/connections/connection_mysql.php"
@@ -44,7 +44,7 @@
     mode: '0644'
   when: running_on_server
 
-- name: ealapps | Install required php modules
+- name: Ealapps | Install required php modules
   ansible.builtin.apt:
     name: "{{ item }}"
     state: present
@@ -59,40 +59,40 @@
     - php{{ php_version }}-xml
     - sendmail
 
-- name: ealapp | Make repos git safe
+- name: Ealapp | Make repos git safe
   ansible.builtin.command: git config --global --add safe.directory "{{ apache_doc_root }}"
   become: true
   changed_when: false
 
-- name: ealapps | Add ealapp
+- name: Ealapps | Add ealapp
   ansible.builtin.template:
     src: "apache2-site.conf.j2"
     dest: "/etc/apache2/sites-available/000-ealapp.conf"
-    mode: 0644
+    mode: "0644"
   notify: restart apache
   become: true
 
-- name: ealapps | enable apache2 sites
+- name: Ealapps | enable apache2 sites
   command: "a2ensite 000-ealapp.conf"
   become: true
   register: apache2_enabled
   changed_when: '"Enabling site" in apache2_enabled.stdout'
 
-- name: ealapps | disable the default apache2 site
+- name: Ealapps | disable the default apache2 site
   command: "a2dissite 000-default"
   become: true
   register: apache2_disable
   changed_when: '"disabled." in apache2_disable.stdout'
 
-- name: ealapps | create empty newtitles file
+- name: Ealapps | create empty newtitles file
   copy:
     content: ""
     dest: /var/www/ealapps/shared/newtitles/files/newtitles.cron.xml
     force: false
     owner: deploy
-    mode: 0644
+    mode: "0644"
 
-- name: ealapps | add newtitles cron job
+- name: Ealapps | add newtitles cron job
   ansible.builtin.cron:
     name: "generate newtitles.cron.xml"
     weekday: "1-5"
@@ -100,8 +100,10 @@
     hour: "1"
     user: deploy
     job: "cd /var/www/ealapps/current/newtitles; php newtitles.cron.php >  /var/www/ealapps/shared/newtitles/files/newtitles.cron.xml 2> /dev/null"
+  when:
+    - running_on_server
 
-- name: ealapps | enable mailcatcher in php.ini
+- name: Ealapps | enable mailcatcher in php.ini
   ansible.builtin.lineinfile:
     dest: "/etc/php/{{ php_version }}/apache2/php.ini"
     regexp: ";?sendmail_path"

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -10,14 +10,15 @@
     - python3-dev
 
 - name: MySQL | Install MariaDB key
-  ansible.builtin.apt_key:
-    url: https://mariadb.org/mariadb_release_signing_key.asc
-    state: present
+  ansible.builtin.get_url:
+    url: https://supplychain.mariadb.com/mariadb-keyring-2019.gpg
+    dest: /etc/apt/trusted.gpg.d/mariadb-keyring-2019.gpg
+    mode: '0644'
   register: install_app_key
 
 - name: MySQL | Install MariaDB repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://mirrors.accretive-networks.net/mariadb/repo/10.6/ubuntu {{ ansible_distribution_release }} main"
+    repo: "deb [arch=amd64,arm64] https://dlm.mariadb.com/repo/mariadb-server/11.rolling/repo/ubuntu {{ ansible_distribution_release }} main"
     state: present
     validate_certs: false
   when: install_app_key.changed

--- a/roles/php/molecule/default/molecule.yml
+++ b/roles/php/molecule/default/molecule.yml
@@ -9,8 +9,8 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "sleep infinity"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/roles/php/molecule/default/verify.yml
+++ b/roles/php/molecule/default/verify.yml
@@ -3,8 +3,8 @@
   hosts: all
   become: true
   vars:
-    - php_version: '8.3'
-    - php_webserver: 'apache2'
+    - php_version: "8.3"
+    - php_webserver: "apache2"
   tasks:
     - name: Php | Verify required Ubuntu dependencies are installed
       ansible.builtin.apt:
@@ -18,10 +18,18 @@
       ansible.builtin.apt_repository:
         repo: "ppa:ondrej/php"
         state: present
+        codename: "{{ ansible_distribution_release }}"
       changed_when: false
 
     - name: Php | Verify PHP packages are installed
       ansible.builtin.apt:
-        name: ["php{{ php_version }}", "php{{ php_version }}-dev", "php{{ php_version }}-curl", "php{{ php_version }}-gd", "php{{ php_version }}-zip"]
+        name:
+          [
+            "php{{ php_version }}",
+            "php{{ php_version }}-dev",
+            "php{{ php_version }}-curl",
+            "php{{ php_version }}-gd",
+            "php{{ php_version }}-zip",
+          ]
         state: present
       changed_when: false

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -31,6 +31,7 @@
   ansible.builtin.apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: true
+    codename: "{{ ansible_distribution_release }}"
     state: present
 
 - name: Php | install php


### PR DESCRIPTION
The ppa from ondrej defaults to Debian sid. We cleaned up the role to tie it to jammy or whatever version of ubuntu. 