### PR TITLE
[Lib Jobs] Upgrade ruby to 3.4.1

### DIFF
--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -20,7 +20,7 @@ install_ruby_from_source: true
 passenger_ruby: /usr/local/bin/ruby
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
-ruby_version_override: "ruby-3.3.6"
+ruby_version_override: "ruby-3.4.1"
 ubuntu_ruby_version_default: "ruby-3.1.2"
 # admin users
 lib_jobs_admin_netids:


### PR DESCRIPTION
[Previously was upgraded to 3.3.6](https://github.com/pulibrary/princeton_ansible/pull/5695/files#diff-ae5fbc1cda18cdbaba672b09e350eba48bf2cd04fdd48fc5a8968b1eb430fc88R23)
