### PR TITLE
[nginx] exclude apt cache from idempotence check

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -25,6 +25,7 @@
 - name: Nginx | Refresh apt cache
   ansible.builtin.apt:
     update_cache: true
+  tags: molecule-idempotence-notest
 
 - name: Nginx | Install Nginx
   ansible.builtin.apt:


### PR DESCRIPTION
This step can be a bit flaky in an idempotence check.  For example: https://github.com/pulibrary/princeton_ansible/actions/runs/12656596039/job/35269514546

My guess is that some package version was updated between when `molecule converge` ran and `molecule idempotence` ran, which led to this step being "changed".

We can exclude a step from running during the idempotence checks with the molecule-idempotence-notest tag, hopefully this helps!