### PR TITLE
Changed vars from list to dictionaries in playbooks

### DIFF
--- a/playbooks/Gitlab.yml
+++ b/playbooks/Gitlab.yml
@@ -7,10 +7,10 @@
   remote_user: pulsys
   become: true
   vars:
-    - post_install: |
-        Things left to do:
-        - comment out `AllowUsers pulsys` as `/etc/ssh/sshd_config`
-        - Restart the openssh-server `sudo systemctl restart sshd`
+    post_install: |
+      Things left to do:
+      - comment out `AllowUsers pulsys` as `/etc/ssh/sshd_config`
+      - Restart the openssh-server `sudo systemctl restart sshd`
   vars_files:
     - ../group_vars/gitlab/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/gitlab/vault.yml

--- a/playbooks/aws_group_access.yml
+++ b/playbooks/aws_group_access.yml
@@ -17,8 +17,8 @@
   hosts: localhost
   gather_facts: false
   vars:
-    - pul_user: "{{ pul_group }}"
-    - dev_user: "{{ dev_user }}"
+    pul_user: "{{ pul_group }}"
+    dev_user: "{{ dev_user }}"
   tasks:
     - name: check for "{{ pul_group }}"
       community.aws.iam_access_key_info:

--- a/playbooks/byzantine.yml
+++ b/playbooks/byzantine.yml
@@ -6,12 +6,12 @@
   remote_user: pulsys
   become: true
   vars:
-    - force_settings: true
-    - drupal_git_repo: ''
-    - post_install: |
-        Possible Things left to do:
-        - run a cap for byzantine
-        - where needed, make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)
+    force_settings: true
+    drupal_git_repo: ''
+    post_install: |
+      Possible Things left to do:
+      - run a cap for byzantine
+      - where needed, make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)
   vars_files:
     - ../group_vars/byzantine/common.yml
     - ../group_vars/byzantine/{{ runtime_env | default('staging') }}.yml

--- a/playbooks/ezproxy.yml
+++ b/playbooks/ezproxy.yml
@@ -7,9 +7,9 @@
   remote_user: pulsys
   become: true
   vars:
-    - post_install: |
-        Possible Things left to do:
-        - run a cap for ezproxy
+    post_install: |
+      Possible Things left to do:
+      - run a cap for ezproxy
   vars_files:
     - ../group_vars/ezproxy/{{ runtime_env | default('testing') }}.yml
     - ../group_vars/ezproxy/vault.yml

--- a/playbooks/figgy_db_migration.yml
+++ b/playbooks/figgy_db_migration.yml
@@ -34,10 +34,10 @@
 # where leader_db_host is defined for all pgsql machines
 # to the vars_files: section
   vars:
-    - deploy_user: "pulsys"
-    - file_path: "/mnt/diglibdata1/postgreslog/migrate"
-    - dest_file_path: "/var/lib/migrate"
-    - backup_time: "{{ ansible_date_time.date }}"
+    deploy_user: "pulsys"
+    file_path: "/mnt/diglibdata1/postgreslog/migrate"
+    dest_file_path: "/var/lib/migrate"
+    backup_time: "{{ ansible_date_time.date }}"
   vars_files:
     - ../group_vars/{{ project_name }}/{{ app_runtime_env | default(runtime_env) | default('staging') }}.yml
     # - ../group_vars/{{ project_name }}/main.yml  # some roles have this

--- a/playbooks/friends_of_pul.yml
+++ b/playbooks/friends_of_pul.yml
@@ -6,12 +6,12 @@
   remote_user: pulsys
   become: true
   vars:
-    - force_settings: true
-    - drupal_git_repo: ''
-    - post_install: |
-        Possible Things left to do:
-        - run a cap for friends_of_pul
-        - where needed make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)
+    force_settings: true
+    drupal_git_repo: ''
+    post_install: |
+      Possible Things left to do:
+      - run a cap for friends_of_pul
+      - where needed make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)
   vars_files:
     - ../group_vars/friends_of_pul/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/friends_of_pul/common.yml

--- a/playbooks/lib_jobs.yml
+++ b/playbooks/lib_jobs.yml
@@ -6,7 +6,7 @@
   remote_user: pulsys
   become: true
   vars:
-  - post_install: |
+    post_install: |
       Possible Things left to do:
       - deploy lib_jobs and aspace_helpers
   vars_files:

--- a/playbooks/lib_sftp.yml
+++ b/playbooks/lib_sftp.yml
@@ -10,10 +10,10 @@
   remote_user: pulsys
   become: true
   vars:
-    - force_settings: true
-    - drupal_git_repo: ''
-    - post_install: |
-        Look the README for additional steps to allow mkhome directory
+    force_settings: true
+    drupal_git_repo: ''
+    post_install: |
+      Look the README for additional steps to allow mkhome directory
 
   pre_tasks:
     - set_fact:

--- a/playbooks/libruby.yml
+++ b/playbooks/libruby.yml
@@ -7,7 +7,7 @@
   remote_user: pulsys
   become: true
   vars:
-    - ignore_error: true
+    ignore_error: true
   vars_files:
   roles:
     - role: deploy_user

--- a/playbooks/libwww.yml
+++ b/playbooks/libwww.yml
@@ -6,9 +6,9 @@
   remote_user: pulsys
   become: true
   vars:
-    - force_settings: true
-    - drupal_git_repo: ''
-    - post_install: |
+    force_settings: true
+    drupal_git_repo: ''
+    post_install: |
         Possible Things left to do:
         - run a cap for pul_library_drupal, discoveryutils
         - where needed make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)

--- a/playbooks/mysql_db_migration.yml
+++ b/playbooks/mysql_db_migration.yml
@@ -24,9 +24,9 @@
   remote_user: pulsys
   become: true
   vars:
-    - deploy_user: "pulsys"
-    - file_path: "/var/lib/migrate"
-    - now: "{{ ansible_date_time.date }}"
+    deploy_user: "pulsys"
+    file_path: "/var/lib/migrate"
+    now: "{{ ansible_date_time.date }}"
   vars_files:
     - ../group_vars/{{ project_name }}/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/{{ project_name }}/common.yml

--- a/playbooks/orangelight_toggle_readonly.yml
+++ b/playbooks/orangelight_toggle_readonly.yml
@@ -8,8 +8,8 @@
   remote_user: pulsys
   become: true
   vars:
-    - deploy_user: "deploy"
-    - rails_app_name: "orangelight"
+    deploy_user: "deploy"
+    rails_app_name: "orangelight"
   vars_files:
     - ../site_vars.yml
     - ../group_vars/orangelight/vault.yml

--- a/playbooks/orcid.yml
+++ b/playbooks/orcid.yml
@@ -12,9 +12,9 @@
     - ../group_vars/orcid/vault.yml
 
   vars:
-    - post_install: |
-        Possible Things left to do:
-        - run a cap deploy for orcid: https://github.com/pulibrary/orcid_princeton
+    post_install: |
+      Possible Things left to do:
+      - run a cap deploy for orcid: https://github.com/pulibrary/orcid_princeton
 
   roles:
     - role: roles/rails_app

--- a/playbooks/pas.yml
+++ b/playbooks/pas.yml
@@ -14,7 +14,7 @@
     - ../group_vars/pas/vault.yml
     - ../group_vars/nfsserver/common.yml
   vars:
-    - pas_upload_path: 'pas/pas-production'
+    pas_upload_path: 'pas/pas-production'
   roles:
     - role: nfsserver
     - role: roles/pas

--- a/playbooks/pdc_describe.yml
+++ b/playbooks/pdc_describe.yml
@@ -12,9 +12,9 @@
     - ../group_vars/pdc_describe/vault.yml
 
   vars:
-    - post_install: |
-        Possible Things left to do:
-        - run a cap deploy for pdc_describe: https://github.com/pulibrary/pdc_describe
+    post_install: |
+      Possible Things left to do:
+      - run a cap deploy for pdc_describe: https://github.com/pulibrary/pdc_describe
 
   roles:
     - role: roles/mailcatcher

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -12,9 +12,9 @@
     - ../group_vars/pdc_discovery/vault.yml
 
   vars:
-    - post_install: |
-        Possible Things left to do:
-        - run a cap deploy for pdc_discovery: https://github.com/pulibrary/pdc_discovery
+    post_install: |
+      Possible Things left to do:
+      - run a cap deploy for pdc_discovery: https://github.com/pulibrary/pdc_discovery
 
   roles:
     - role: roles/mailcatcher

--- a/playbooks/postgresql_db_migration.yml
+++ b/playbooks/postgresql_db_migration.yml
@@ -35,9 +35,9 @@
 # where leader_db_host is defined for all pgsql machines
 # to the vars_files: section
   vars:
-    - deploy_user: "pulsys"
-    - file_path: "/var/lib/migrate"
-    - now: "{{ ansible_date_time.date }}"
+    deploy_user: "pulsys"
+    file_path: "/var/lib/migrate"
+    now: "{{ ansible_date_time.date }}"
   vars_files:
     - ../group_vars/{{ project_name }}/{{ app_runtime_env | default(runtime_env) | default('staging') }}.yml
     # - ../group_vars/{{ project_name }}/main.yml  # some roles have this

--- a/playbooks/recap.yml
+++ b/playbooks/recap.yml
@@ -11,8 +11,8 @@
     - ../group_vars/nfsserver/common.yml
     - ../group_vars/recap/vault.yml
   vars:
-    - force_settings: true
-    - drupal_git_repo: ''
+    force_settings: true
+    drupal_git_repo: ''
   roles:
     - role: nfsserver
     - role: datadog

--- a/playbooks/special_collections.yml
+++ b/playbooks/special_collections.yml
@@ -6,12 +6,12 @@
   remote_user: pulsys
   become: true
   vars:
-    - force_settings: true
-    - drupal_git_repo: ''
-    - post_install: |
-        Possible Things left to do:
-        - run a cap for special_collections
-        - where needed make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)
+    force_settings: true
+    drupal_git_repo: ''
+    post_install: |
+      Possible Things left to do:
+      - run a cap for special_collections
+      - where needed make sure server is greenlisted on [lib-ponyexpress](https://github.com/pulibrary/pul-the-hard-way/blob/master/services/smtp-mail-server.md)
   vars_files:
     - ../group_vars/special_collections/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/special_collections/common.yml

--- a/playbooks/video_reserves.yml
+++ b/playbooks/video_reserves.yml
@@ -7,9 +7,9 @@
   remote_user: pulsys
   become: true
   vars: 
-    - post_install: |
-        Possible Things left to do:
-        - run a cap for video_reserves
+    post_install: |
+      Possible Things left to do:
+      - run a cap for video_reserves
   vars_files:
     - ../group_vars/video_reserves/{{ runtime_env | default('staging') }}.yml
   pre_tasks:

--- a/playbooks/whichiso.yml
+++ b/playbooks/whichiso.yml
@@ -12,9 +12,9 @@
     - ../group_vars/whichiso/vault.yml
 
   vars:
-    - post_install: |
-        Possible Things left to do:
-        - run a cap deploy for whichiso: https://github.com/pulibrary/whichiso
+    post_install: |
+      Possible Things left to do:
+      - run a cap deploy for whichiso: https://github.com/pulibrary/whichiso
 
   roles:
     - role: roles/rails_app


### PR DESCRIPTION
Receiving deprecation warnings on playbooks that lists for vars will not be used in Ansible v2.18.
Changing Vars sections to dictionaries by removing the `-` from the items.

Testing each playbook  with lists in the vars section using --check before and after making the change:
example `ansible-playbook playbooks/utils/expand_disk.yml --check`

Closes #5293 

