### PR TITLE
[orangelight] Add sidekiq

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -125,3 +125,4 @@ rails_app_vars:
     value: "{{ vault_ol_libanswers_client_secret }}"
 sneakers_worker_name: orangelight-sneakers
 sneakers_workers: EventHandler
+sidekiq_worker_name: sidekiq

--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -12,6 +12,8 @@
     - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/orangelight/vault.yml
   roles:
+    - role: sidekiq_worker
+      when: "'indexer' in inventory_hostname"
     - role: mailcatcher
     - role: roles/postgresql
     - role: roles/orangelight

--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -12,12 +12,21 @@
     - ../group_vars/orangelight/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/orangelight/vault.yml
   roles:
+    - role: deploy_user
+    - role: bind9
+    - role: ruby_s
+    - role: passenger
+    - role: postgresql
+    - role: nodejs
     - role: sidekiq_worker
       when: "'indexer' in inventory_hostname"
+    - role: rails_app
+    - role: sneakers_worker
+    - role: redis
+    - role: extra_path
     - role: mailcatcher
-    - role: roles/postgresql
-    - role: roles/orangelight
-    - role: roles/datadog
+    - role: orangelight
+    - role: datadog
       when: runtime_env | default('staging') == "production"
 
   post_tasks:

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -22,13 +22,6 @@
   run_once: true
   tags: update_keys
 
-- name: DEBUG DON'T COMMIT ME - inventory
-  ansible.builtin.debug:
-    var: hostvars[inventory_hostname]
-
-- name: DEBUG DON'T COMMIT ME - keys
-  ansible.builtin.debug:
-    var: deploy_user_keys_from_github
 
 - name: deploy_user | create the .ssh directory
   ansible.builtin.file:

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -22,6 +22,14 @@
   run_once: true
   tags: update_keys
 
+- name: DEBUG DON'T COMMIT ME - inventory
+  ansible.builtin.debug:
+    var: hostvars[inventory_hostname]
+
+- name: DEBUG DON'T COMMIT ME - keys
+  ansible.builtin.debug:
+    var: deploy_user_keys_from_github
+
 - name: deploy_user | create the .ssh directory
   ansible.builtin.file:
     path: "/home/{{ deploy_user }}/.ssh/"

--- a/roles/orangelight/meta/main.yml
+++ b/roles/orangelight/meta/main.yml
@@ -7,14 +7,9 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.2
+  min_ansible_version: '2.2'
 
   platforms:
     - name: Ubuntu
       versions:
-        - 18.04
-dependencies:
-  - role: 'redis'
-  - role: 'sneakers_worker'
-  - role: 'extra_path'
-  - role: 'rails_app'
+        - jammy

--- a/roles/orangelight/molecule/default/converge.yml
+++ b/roles/orangelight/molecule/default/converge.yml
@@ -9,6 +9,17 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    - role: deploy_user
+    - role: bind9
+    - role: ruby_s
+    - role: passenger
+    - role: postgresql
+    - role: nodejs
+    - role: rails_app
+    - role: sneakers_worker
+    - role: redis
+    - role: extra_path
   tasks:
     - name: "Include orangelight"
       include_role:


### PR DESCRIPTION
Connected to https://github.com/pulibrary/orangelight/issues/4609

This adds the sidekiq role to the orangelight playbook.  A few things to note:

- Some role dependencies are moved from the orangelight role to the orangelight playbook.  This is because, when they were in the role, time-consuming tasks like the `ruby_s` tasks would run twice: first for the sidekiq boxes, then again for non-sidekiq boxes.  Now that they are in the playbook, placed before the `sidekiq` role, `ruby_s` (and other tasks like `bind9`) only run once.
- The `sidekiq_worker_name` does not contain the name of the application, as it does for bibdata.  This is so we can simply run `systemctl restart sidekiq`, rather than having to figure out the application-specific sidekiq name.