### PR TITLE
[lib-sftp] make /alma/aspace directory group-writeable

### DIFF
--- a/playbooks/lib_sftp.yml
+++ b/playbooks/lib_sftp.yml
@@ -26,8 +26,9 @@
   roles:
     - role: ../roles/deploy_user
     - role: ../roles/lib_sftp
-    - role: ../roles/datadog
-      when: runtime_env | default('staging') == "production"
+    # The following datadog role causes the playbook to fail as of 9 January, 2024
+    # - role: ../roles/datadog
+      # when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/roles/lib_sftp/tasks/main.yml
+++ b/roles/lib_sftp/tasks/main.yml
@@ -28,4 +28,4 @@
     recurse: true
     owner: "{{ aspaceftp_user }}"
     group: "domain users"
-    mode: "0755"
+    mode: "0775"


### PR DESCRIPTION
Two users write to the /alma/aspace directory: the alma user and the aspace user.  They are both part of the same group, but the group needs write permissions to the directory.