### PR TITLE
[orangelight] Update mailcatcher paths

### DIFF
--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -4,7 +4,7 @@ install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
 mailcatcher_version: 0.10.0
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.1.0/gems/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
+mailcatcher_install_location: "{{ global_gems_directory }}/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
 ol_smtp_host: 'localhost'
 ol_smtp_port: 1025
 ol_bibdata_base: 'https://bibdata-qa.princeton.edu'

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -4,7 +4,7 @@ install_mailcatcher: true
 mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
 mailcatcher_version: 0.10.0
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.1.0/gems/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
+mailcatcher_install_location: "{{ global_gems_directory }}/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
 ol_smtp_host: 'localhost'
 ol_smtp_port: 1025
 ol_bibdata_base: 'https://bibdata-staging.lib.princeton.edu'

--- a/roles/ruby_s/defaults/main.yml
+++ b/roles/ruby_s/defaults/main.yml
@@ -2,7 +2,9 @@
 # defaults file for roles/ruby_s
 ruby_version: "{{ ruby_version_override | default(ruby_version_default) }}"
 ruby_version_default: "ruby-3.1.3"
+ruby_minor_version: "{{ ruby_version | regex_search('ruby-([0-9]\\.[0-9])\\.[0-9]', '\\1') | first }}"
 ubuntu_ruby_version: "{{ ubuntu_ruby_version_override | default(ubuntu_ruby_version_default) }}"
 ubuntu_ruby_version_default: "ruby2.7"
 install_path: /opt/install
+global_gems_directory: "/usr/local/lib/ruby/gems/{{ ruby_minor_version }}.0/gems"
 ruby_yjit: false


### PR DESCRIPTION
Also, add two default variables to the ruby_s role to automatically update the mailcatcher path when the ruby_version_override variable changes. These default variables could be overriden in the group_vars if needed.

I ran this on staging and qa, and confirmed that the systemd service is now looking at the new path.