### PR TITLE
[mailcatcher] Add pkg-config dependency

### DIFF
--- a/roles/mailcatcher/tasks/main.yml
+++ b/roles/mailcatcher/tasks/main.yml
@@ -2,7 +2,9 @@
 # tasks file for roles/mailcatcher
 - name: mailcatcher | Install dependencies
   ansible.builtin.apt:
-    name: 'libsqlite3-dev'
+    pkg:
+    - libsqlite3-dev
+    - pkg-config
     state: present
   tags: mailcatcher
 


### PR DESCRIPTION
pkg-config can sometimes be necessary for compiling the sqlite3 gem's C extensions, see [this failure of the lib-jobs playbook](https://ansible-tower.princeton.edu/#/jobs/playbook/10600/output).