### PR TITLE
Update group ownership in lib_sftp/tasks to `pusvc-g`

### DIFF
--- a/roles/lib_sftp/tasks/main.yml
+++ b/roles/lib_sftp/tasks/main.yml
@@ -7,7 +7,7 @@
     state: directory
     recurse: true
     owner: "{{ almasftp_user }}"
-    group: "domain users"
+    group: "pusvc-g"
     mode: "0755"
   loop:
     - "/alma/bursar"
@@ -27,5 +27,5 @@
     state: directory
     recurse: true
     owner: "{{ aspaceftp_user }}"
-    group: "domain users"
+    group: "pusvc-g"
     mode: "0775"


### PR DESCRIPTION
Updated group to `pusvc-g` from `domain users` in `roles/lib_sftp/tasks/main.yml` 
Closes #5723 