### PR TITLE
Move rails_app dependency out of sidekiq_worker role

### DIFF
--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -27,14 +27,13 @@
     # re-add nodejs when removed from rails_app
     # can be run on only web machines
     # - role: nodejs
-    # sidekiq_worker role must be before the rails_app & passenger roles so that nginx restarts on all boxes
+    - role: rails_app
     - role: sidekiq_worker
       when: "'worker' in inventory_hostname"
     - role: bibdata_sqs_poller
       when: 
         - "'worker' in inventory_hostname"
         - "'1' in inventory_hostname"
-    - role: rails_app
     - role: timezone
     - role: bibdata
     # samba must be before hr_share

--- a/playbooks/dpul.yml
+++ b/playbooks/dpul.yml
@@ -11,6 +11,14 @@
     - ../group_vars/dpul/{{ runtime_env | default('staging') }}_solr.yml
     - ../group_vars/dpul/vault.yml
   roles:
+    - role: roles/redis
+    - role: roles/nodejs
+    - role: roles/openjdk
+    - role: roles/imagemagick
+    - role: roles/rails_app
+    - role: roles/shared_data
+    - role: roles/sidekiq_worker
+    - role: roles/sneakers_worker
     - role: roles/dpul
     - role: roles/datadog
       when: runtime_env | default('staging') == "production"

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -43,6 +43,7 @@
     - ../group_vars/figgy/production_workers.yml
   roles:
     - role: roles/common
+    - role: roles/rails_app
     - role: roles/sidekiq_worker
     - role: roles/sidekiq_worker
       sidekiq_worker_name: "figgy-realtime-workers"

--- a/playbooks/figgy_staging.yml
+++ b/playbooks/figgy_staging.yml
@@ -10,6 +10,7 @@
   roles:
     - {role: roles/memcached, when: inventory_hostname == 'figgy-web-staging1.princeton.edu'}
     - role: roles/rabbitmq
+    - role: roles/rails_app
     - role: roles/sidekiq_worker
     - role: roles/sidekiq_worker
       sidekiq_worker_name: "figgy-realtime-workers"

--- a/playbooks/pulfalight.yml
+++ b/playbooks/pulfalight.yml
@@ -14,6 +14,7 @@
   roles:
     - { role: 'roles/postgresql', tags: 'postgresql' }
     - role: roles/openjdk
+    - role: roles/rails_app
     - role: roles/sidekiq_worker  # the staging box is both web and worker
       when: runtime_env | default('staging') == "staging"
     - role: roles/pulfalight
@@ -49,6 +50,7 @@
     - { role: 'roles/postgresql', tags: 'postgresql' }
     - role: roles/openjdk
     - role: roles/sidekiq_worker
+    - role: roles/rails_app
     - role: roles/pulfalight
     - role: roles/datadog
       when: runtime_env | default('staging') == "production"

--- a/playbooks/pulmap.yml
+++ b/playbooks/pulmap.yml
@@ -20,6 +20,11 @@
       tags: rubygems
 
   roles:
+    - role: roles/samba
+    - role: roles/redis
+    - role: roles/rails_app
+    - role: roles/sidekiq_worker
+    - role: roles/sneakers_worker
     - role: roles/pulmap
     - role: datadog
       when: runtime_env | default('staging') == "production"

--- a/playbooks/tigerdata.yml
+++ b/playbooks/tigerdata.yml
@@ -14,6 +14,7 @@
     - role: roles/mailcatcher
     - role: rails_app
     - role: roles/redis
+    - role: roles/rails_app
     - role: roles/sidekiq_worker
     - role: datadog
       when: runtime_env | default('staging') == "production"

--- a/roles/dpul/meta/main.yml
+++ b/roles/dpul/meta/main.yml
@@ -12,13 +12,5 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
-dependencies:
-  - role: redis
-  - role: nodejs
-  - role: openjdk
-  - role: imagemagick
-  - role: rails_app
-  - role: shared_data
-  - role: sidekiq_worker
-  - role: sneakers_worker
+        - jammy
+dependencies: []

--- a/roles/dpul/molecule/default/converge.yml
+++ b/roles/dpul/molecule/default/converge.yml
@@ -9,6 +9,15 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    - role: redis
+    - role: nodejs
+    - role: openjdk
+    - role: imagemagick
+    - role: rails_app
+    - role: shared_data
+    - role: sidekiq_worker
+    - role: sneakers_worker
   tasks:
     - name: "Include dpul"
       ansible.builtin.include_role:

--- a/roles/figgy/molecule/default/converge.yml
+++ b/roles/figgy/molecule/default/converge.yml
@@ -9,6 +9,8 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    - role: rails_app
   tasks:
     - name: "Include figgy"
       include_role:

--- a/roles/lib_jobs/meta/main.yml
+++ b/roles/lib_jobs/meta/main.yml
@@ -16,7 +16,5 @@ galaxy_info:
 dependencies:
   - role: 'ruby_s'
   - role: 'deploy_user'
-  - role: 'redis'
-  - role: 'sidekiq_worker'
   - role: 'rails_app'
   - role: 'mailcatcher'

--- a/roles/pulfalight/molecule/default/converge.yml
+++ b/roles/pulfalight/molecule/default/converge.yml
@@ -13,6 +13,8 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    - role: rails_app
   tasks:
     - name: "Include pulfalight"
       include_role:

--- a/roles/pulmap/meta/main.yml
+++ b/roles/pulmap/meta/main.yml
@@ -13,9 +13,4 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - 18.04
-dependencies:
-  - role: "samba"
-  - role: "redis"
-  - role: "rails_app"
-  - role: "sidekiq_worker"
-  - role: "sneakers_worker"
+dependencies: []

--- a/roles/pulmap/molecule/default/converge.yml
+++ b/roles/pulmap/molecule/default/converge.yml
@@ -10,11 +10,11 @@
         update_cache: true
         cache_valid_time: 600
   roles:
-    - role: roles/samba
-    - role: roles/redis
-    - role: roles/rails_app
-    - role: roles/sidekiq_worker
-    - role: roles/sneakers_worker
+    - role: samba
+    - role: redis
+    - role: rails_app
+    - role: sidekiq_worker
+    - role: sneakers_worker
   tasks:
     - name: "Include pulmap"
       include_role:

--- a/roles/pulmap/molecule/default/converge.yml
+++ b/roles/pulmap/molecule/default/converge.yml
@@ -9,6 +9,12 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    - role: roles/samba
+    - role: roles/redis
+    - role: roles/rails_app
+    - role: roles/sidekiq_worker
+    - role: roles/sneakers_worker
   tasks:
     - name: "Include pulmap"
       include_role:

--- a/roles/sidekiq_worker/meta/main.yml
+++ b/roles/sidekiq_worker/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  role_name: sidekiq_workers
+  role_name: sidekiq_worker
   author: pulibrary
-  description: Sidekiq Workers
+  description: Sidekiq Worker
   company: Princeton University Library
 
   license: MIT
@@ -12,8 +12,4 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - 16.04
-        - 18.04
-
-dependencies:
-  - role: rails_app
+        - jammy

--- a/roles/sidekiq_worker/molecule/default/converge.yml
+++ b/roles/sidekiq_worker/molecule/default/converge.yml
@@ -9,6 +9,8 @@
       apt:
         update_cache: true
         cache_valid_time: 600
+  roles:
+    - role: rails_app
   tasks:
     - name: "Include rails_app"
       include_role:


### PR DESCRIPTION
- This reduces duplicate runs of sub-tasks of rails_app
- This also removes a order-dependent bug where sometimes the nginx restart task would not run when the sidekiq_workers was run on only some boxes
- This moves toward the possibility of future further specialization of web and worker boxes - e.g., web boxes need passenger and node, worker boxes may or may not need passenger and node.