### PR TITLE
[postfix] Add catalog-indexer boxes to allowlist

### DIFF
--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -12,6 +12,9 @@ postfix_relay_hosts_addresses:
   - catalog3.princeton.edu
   - catalog4.princeton.edu
   - catalog5.princeton.edu
+  - catalog-indexer1.princeton.edu
+  - catalog-indexer2.princeton.edu
+  - catalog-indexer3.princeton.edu
   - cdh-derrida1.princeton.edu
   - cdh-derrida2.princeton.edu
   - cdh-derrida-crawl1.princeton.edu


### PR DESCRIPTION
After https://github.com/pulibrary/orangelight/pull/4700, we will send emails from a queue on the indexers, rather than directly on the web servers.  To do this, we need to include those indexers in the allowlist

I ran this on production just now, and confirmed that the indexers can send mail.