### PR TITLE
[fail2ban] Use <ADDR> rather than <HOST> when we only need an IP address

### DIFF
--- a/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-badbots-filter.conf
@@ -2,6 +2,6 @@
 
 badbots = 360Spider|AI2Bot|Amazonbot|Applebot|Applebot-Extended|Bytespider|CCBot|ChatGPT-User|Claudebot|DuckAssistBot|Diffbot|FacebookBot|Google-Extended|GPTBot|Meta-ExternalAgent|OAI-SearchBot|YouBot
 
-failregex = (?i)\{\"remote_ip\"\: \"<HOST>\".*?\"user_agent\"\:.*?(?:%(badbots)s).*$
+failregex = (?i)\{\"remote_ip\"\: \"<ADDR>\".*?\"user_agent\"\:.*?(?:%(badbots)s).*$
 
 ignoreregex =


### PR DESCRIPTION
The [fail2ban documentation](https://github.com/fail2ban/fail2ban/wiki/Best-practice) says that if we don't need DNS resolution, we should use `<ADDR>` instead of `<HOST>`.

I confirmed using `fail2ban-regex` that it produces the same results on a sample of 10,000 log entries, and that it is consistently a little faster.