### PR TITLE
Remove ojs-prod1.princeton.edu from the load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/ojs-prod.conf
+++ b/roles/nginxplus/files/conf/http/ojs-prod.conf
@@ -3,7 +3,7 @@ proxy_cache_path /var/cache/nginx/ojs-prod/ keys_zone=ojs-prodcache:10m;
 
 upstream ojs-prod1 {
     zone ojs-prod 64k;
-    server ojs-prod1.princeton.edu:443;
+    #server ojs-prod1.princeton.edu:443;
     #server ojs-prod2.princeton.edu:443;
     sticky learn
         create=$upstream_cookie_ojsprodcookie


### PR DESCRIPTION
The VM doesn't exist anymore and this caused 'nginx -t' to fail