### PR TITLE
update lockers-and-study-spaces-staging.conf 

### DIFF
--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
@@ -38,8 +38,8 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-#        # app_protect_enable on;
-        # app_protect_security_log_enable on;
+        app_protect_enable off;
+        app_protect_security_log_enable on;
         proxy_pass http://lockers-and-study-spaces-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto https;
@@ -48,6 +48,10 @@ server {
         # handle errors using errors.conf
         proxy_intercept_errors on;
         health_check uri=/health.json interval=10 fails=3 passes=2;
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;        
     }
 
     include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
Added 4 lines to lockers-and-study-spaces-staging.conf to restrict access to princeton IPs

Successfully ran the playbook on production

closes #5742 

Co-authored-by: Francis Kayiwa <kayiwa@users.noreply.github.com>

