### PR TITLE
[fail2ban] Reject requests with 15 facets, rather than 20

### DIFF
--- a/roles/nginxplus/files/fail2ban/nginx-bad-httpbots.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-bad-httpbots.conf
@@ -3,6 +3,6 @@ enabled = true
 port    = http,https
 filter  = nginx-f_inclusive
 logpath = /var/log/nginx/access.log
-maxretry = 3
+maxretry = 10
 findtime = 3600
 bantime  = 3600

--- a/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
+++ b/roles/nginxplus/files/fail2ban/nginx-f_inclusive.conf
@@ -1,3 +1,3 @@
 [Definition]
-failregex = ^\{\"remote_ip\"\: \"<ADDR>\".{45,80}\"uri\"\:.{4,}?(?:\&?f(?:_inclusive)?%%5B.{5,}?){20,}
+failregex = ^\{\"remote_ip\"\: \"<ADDR>\".{45,80}\"uri\"\:.{4,}?(?:\&?f(?:_inclusive)?%%5B.{5,}?){15,}
 ignoreregex =


### PR DESCRIPTION
@christinach and I found that the current fail2ban configuration is stressing our load balancers -- maxing out 2 CPUs and it is having trouble keeping up with the volume.

While testing locally with fail2ban-regex, looking for 15 facets applied is more than 20 times faster than looking for 20 facets. This reduces the number of facets accordingly, while relaxing the number of such requests that an IP needs to make before being banned.