### PR TITLE
Removed deprecated http2 to reduce noise of nginxplus test

### DIFF
--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -24,7 +24,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name figgy.princeton.edu;
 
     client_max_body_size 0;

--- a/roles/nginxplus/files/conf/http/figgy-staging.conf
+++ b/roles/nginxplus/files/conf/http/figgy-staging.conf
@@ -22,7 +22,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name figgy-staging.princeton.edu;
 
     client_max_body_size 0;

--- a/roles/nginxplus/files/conf/http/imagecat_staging.conf
+++ b/roles/nginxplus/files/conf/http/imagecat_staging.conf
@@ -22,7 +22,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name imagecat-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/imagecat-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/lae-staging.conf
+++ b/roles/nginxplus/files/conf/http/lae-staging.conf
@@ -30,7 +30,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name lae-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/lae-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
+++ b/roles/nginxplus/files/conf/http/lib-jobs-staging.conf
@@ -29,7 +29,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name lib-jobs-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/lib-jobs-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/lib-sc-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-sc-prod.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name lib-sc-prod.princeton.edu;
 
     client_max_body_size 8m;

--- a/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
+++ b/roles/nginxplus/files/conf/http/lockers-and-study-spaces-staging.conf
@@ -29,7 +29,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name lockers-and-study-spaces-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/lockers-and-study-spaces-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/maps-prod.conf
+++ b/roles/nginxplus/files/conf/http/maps-prod.conf
@@ -22,7 +22,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name maps.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/maps/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/maps-staging.conf
+++ b/roles/nginxplus/files/conf/http/maps-staging.conf
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name maps-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/maps-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/oawaiver-prod.conf
+++ b/roles/nginxplus/files/conf/http/oawaiver-prod.conf
@@ -30,7 +30,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name oawaiver.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/oawaiver/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/oawaiver-staging.conf
+++ b/roles/nginxplus/files/conf/http/oawaiver-staging.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name oawaiver-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/oawaiver-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/ojs-prod.conf
+++ b/roles/nginxplus/files/conf/http/ojs-prod.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name ojs-prod.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/ojs-prod/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/ojs-staging.conf
+++ b/roles/nginxplus/files/conf/http/ojs-staging.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name ojs-staging.princeton.edu;
     client_max_body_size 75M;
 

--- a/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_prod.conf
@@ -27,7 +27,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pdc-describe-prod.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/pdc-describe-prod/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/pdc-describe_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-describe_staging.conf
@@ -28,7 +28,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pdc-describe-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/pdc-describe-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_prod.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pdc-discovery-prod.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/datacommons/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
+++ b/roles/nginxplus/files/conf/http/pdc-discovery_staging.conf
@@ -22,7 +22,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pdc-discovery-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/pdc-discovery-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/pudl_prod.conf
+++ b/roles/nginxplus/files/conf/http/pudl_prod.conf
@@ -19,7 +19,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pudltest.princeton.edu;
     rewrite ^/(.*)$ https://pudl.princeton.edu/$1 permanent;
 
@@ -31,7 +31,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pudl.princeton.edu;
 
     client_max_body_size 8m;

--- a/roles/nginxplus/files/conf/http/pulcheck_staging.conf
+++ b/roles/nginxplus/files/conf/http/pulcheck_staging.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pulcheck-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/pulcheck-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/pulfa_old.conf
+++ b/roles/nginxplus/files/conf/http/pulfa_old.conf
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pulfa.princeton.edu;
 
 

--- a/roles/nginxplus/files/conf/http/pulfalight-qa.conf
+++ b/roles/nginxplus/files/conf/http/pulfalight-qa.conf
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-   listen 443 ssl http2;
+   listen 443 ssl;
    server_name findingaids-qa.princeton.edu;
 
    ssl_certificate            /etc/letsencrypt/live/findingaids-qa/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
+++ b/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pulmonitor-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/pulmonitor-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/rbsc-prod.conf
+++ b/roles/nginxplus/files/conf/http/rbsc-prod.conf
@@ -8,7 +8,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name rbsc.princeton.edu;
     rewrite ^/(.*)$ https://library.princeton.edu/special-collections/$1 permanent;
 

--- a/roles/nginxplus/files/conf/http/recap-prod.conf
+++ b/roles/nginxplus/files/conf/http/recap-prod.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name recap.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/recap/fullchain.pem;
@@ -43,7 +43,7 @@ server {
 
 }
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name recap-prod.princeton.edu;
     rewrite ^/(.*)$ https://recap.princeton.edu/$1 permanent;
 }

--- a/roles/nginxplus/files/conf/http/recap-staging.conf
+++ b/roles/nginxplus/files/conf/http/recap-staging.conf
@@ -22,7 +22,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name recap-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/recap-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/repec-prod.conf
+++ b/roles/nginxplus/files/conf/http/repec-prod.conf
@@ -29,7 +29,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name repec-prod.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/repec-prod/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/repec-staging.conf
+++ b/roles/nginxplus/files/conf/http/repec-staging.conf
@@ -28,7 +28,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name repec-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/repec-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/slavery-dev.conf
+++ b/roles/nginxplus/files/conf/http/slavery-dev.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name slavery-dev.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/slavery-dev/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/slavery-prod.conf
+++ b/roles/nginxplus/files/conf/http/slavery-prod.conf
@@ -28,7 +28,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name slavery.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/slavery/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/slavery-staging.conf
+++ b/roles/nginxplus/files/conf/http/slavery-staging.conf
@@ -28,7 +28,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name slavery-staging.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/slavery-staging/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/svn-prod.conf
+++ b/roles/nginxplus/files/conf/http/svn-prod.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pulibrary-svn.princeton.edu;
 
     client_max_body_size 8m;

--- a/roles/nginxplus/files/conf/http/svn-staging.conf
+++ b/roles/nginxplus/files/conf/http/svn-staging.conf
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name pulibrary-svn-staging.princeton.edu;
 
     client_max_body_size 8m;

--- a/roles/nginxplus/files/conf/http/towerdeploy_prod.conf
+++ b/roles/nginxplus/files/conf/http/towerdeploy_prod.conf
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name towerdeploy.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/towerdeploy/fullchain.pem;

--- a/roles/nginxplus/files/conf/http/veridian-sites.conf
+++ b/roles/nginxplus/files/conf/http/veridian-sites.conf
@@ -59,7 +59,7 @@ server {
 
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name bluemountain.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/bluemountain/fullchain.pem;
@@ -81,7 +81,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name historicperiodicals.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/historicperiodicals/fullchain.pem;
@@ -126,7 +126,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name papersofprinceton.princeton.edu;
 
     ssl_certificate            /etc/letsencrypt/live/papersofprinceton/fullchain.pem;


### PR DESCRIPTION
ran `perl -pi -e 's/listen 443 ssl http2/listen 443 ssl/g' git/princeton_ansible/roles/nginxplus/files/conf/http/*.conf` to remove http2 from .conf files.

Related to #5764 