### PR TITLE
[cdh] ssl error

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_test_derrida.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_derrida.conf
@@ -5,9 +5,9 @@ upstream test_derrida {
     zone prod_derrida 64k;
     server cdh-test-derrida1.princeton.edu;
     sticky learn
-          create=$upstream_cookie_test_derridacookie
-          lookup=$cookie_test_derridacookie
-          zone=test_derridaclient_sessions:1m;
+        create=$upstream_cookie_test_derridacookie
+        lookup=$cookie_test_derridacookie
+        zone=test_derridaclient_sessions:1m;
 }
 
 server {
@@ -33,25 +33,10 @@ server {
     http2 on;
     server_name cdh-test-derrida.princeton.edu;
 
-    ssl_certificate            /etc/letsencrypt/live/cdh-test-derrida/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/cdh-test-derrida/privkey.pem;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
-
-    location / {
-        return 301 https://test-derrida.cdh.princeton.edu$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name cdh-test-derrida.princeton.edu;
-
-    ssl_certificate            /etc/letsencrypt/live/cdh-test-derrida/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/cdh-test-derrida/privkey.pem;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
+    ssl_certificate             /etc/letsencrypt/live/cdh-test-derrida/fullchain.pem;
+    ssl_certificate_key         /etc/letsencrypt/live/cdh-test-derrida/privkey.pem;
+    ssl_session_cache           shared:SSL:1m;
+    ssl_prefer_server_ciphers   on;
 
     location / {
         return 301 https://test-derrida.cdh.princeton.edu$request_uri;
@@ -65,14 +50,14 @@ server {
 
     client_max_body_size 50M;
 
-    ssl_certificate            /etc/letsencrypt/live/cdh-test-derrida/fullchain.pem;
-    ssl_certificate_key        /etc/letsencrypt/live/cdh-test-derrida/privkey.pem;
-    ssl_session_cache          shared:SSL:1m;
-    ssl_prefer_server_ciphers  on;
+    ssl_certificate             /etc/letsencrypt/live/cdh-test-derrida/fullchain.pem;
+    ssl_certificate_key         /etc/letsencrypt/live/cdh-test-derrida/privkey.pem;
+    ssl_session_cache           shared:SSL:1m;
+    ssl_prefer_server_ciphers   on;
 
     location / {
-#        # app_protect_enable on;
-#        # app_protect_security_log_enable on;
+        app_protect_enable off;
+        app_protect_security_log_enable on;
         proxy_pass http://test_derrida;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
the cdh-test-derrida was giving us a TLS error. This change removes it

related to #5764
