### PR TITLE
[nginxplus] remove focal load balancers

### DIFF
--- a/inventory/all_projects/nginxplus
+++ b/inventory/all_projects/nginxplus
@@ -1,8 +1,6 @@
 [nginxplus_production]
 adc-prod1.princeton.edu
 adc-prod2.princeton.edu
-lib-adc1.princeton.edu
-lib-adc2.princeton.edu
 [nginxplus_staging]
 adc-dev1.lib.princeton.edu
 adc-dev2.lib.princeton.edu


### PR DESCRIPTION
remove the focal loadbalancers from nginxplus inventory they will remain on the orphaned inventory until we sunset them

related to #5670 