### PR TITLE
removed references to datadog role

### DIFF
--- a/playbooks/lib_sftp.yml
+++ b/playbooks/lib_sftp.yml
@@ -26,9 +26,6 @@
   roles:
     - role: ../roles/deploy_user
     - role: ../roles/lib_sftp
-    # The following datadog role causes the playbook to fail as of 9 January, 2024
-    # - role: ../roles/datadog
-      # when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook


### PR DESCRIPTION
lib-sftp will not be sending logs to datadog, so we don't need the role reference

closes #5709 