### PR TITLE
Updating Node.js to release 18.20.6 for oawaiver server hosts

### DIFF
--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -31,7 +31,7 @@ install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
 
 # System Node.js
-desired_nodejs_version: "v18.17.0"
+desired_nodejs_version: "v18.20.6"
 
 # NGINX
 nginx_remove_default_vhost: true

--- a/group_vars/oawaiver/staging.yml
+++ b/group_vars/oawaiver/staging.yml
@@ -37,7 +37,7 @@ install_ruby_from_source: true
 ruby_version_override: "ruby-3.1.3"
 
 # System Node.js
-desired_nodejs_version: "v18.17.0"
+desired_nodejs_version: "v18.20.6"
 
 # NGINX
 nginx_remove_default_vhost: true

--- a/roles/rails_app/meta/main.yml
+++ b/roles/rails_app/meta/main.yml
@@ -18,5 +18,7 @@ dependencies:
   - role: 'bind9'
   - role: 'deploy_user'
   - role: 'passenger'
-  - { role: 'postgresql', tags: 'postgresql' }
-  - { role: 'nodejs', when: install_nodejs|default(true) }
+  - role: postgresql
+    tags: 'postgresql'
+  - role: nodejs
+    when: install_nodejs|default(true)


### PR DESCRIPTION
Advances https://github.com/pulibrary/oawaiver/issues/232 by addressing the following:
- Updating Node.js to release 18.20.6 for oawaiver server hosts
- Ensuring that PostgreSQL server is not installed when postgres_is_local is true for the oawaiver Role