### PR TITLE
[postgresql] remove enable postgresql

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -55,15 +55,15 @@
     - postgresql_is_local
     - ansible_os_family == "RedHat"
 
-- name: PostgreSQL | Ensure PostgreSQL is enabled and started
-  ansible.builtin.service:
-    name: postgresql
-    state: started
-    enabled: true
-  when:
-    - running_on_server
-
-# this looks redundant given the task that follow. Test this when postgresql needs to be 15
+#- name: PostgreSQL | Ensure PostgreSQL is enabled and started
+#  ansible.builtin.service:
+#    name: postgresql
+#    state: started
+#    enabled: true
+#  when:
+#    - running_on_server
+#
+## this looks redundant given the task that follow. Test this when postgresql needs to be 15
 - name: PostgreSQL | Check if PostgreSQL data initialization logs exist (RedHat)
   ansible.builtin.stat:
     path: "/var/lib/pgsql/initdb_postgresql.log"


### PR DESCRIPTION
    the enable postgresql task reports a failure even though the service is
    still running. We comment it out and the role runs successfully

Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
