### PR TITLE
[nginxplus] add logrotate monitor

### DIFF
--- a/group_vars/checkmk/rule_adc.yml
+++ b/group_vars/checkmk/rule_adc.yml
@@ -1,0 +1,4 @@
+checkmk_rules:
+checkmk_local_scripts:
+  - template: "logrotatecheck.j2"
+    dest: "logrotatecheck.sh"


### PR DESCRIPTION
we need to make sure logrotate runs on our loadbalancer. this makes it
so we will get an alert when it doesn't

closes #5794

Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
