### PR TITLE
removed references to deleted undefined hosts

### DIFF
--- a/inventory/by_service/apache
+++ b/inventory/by_service/apache
@@ -5,7 +5,6 @@ eal_production
 eal_staging
 ealapps_production
 ealapps_staging
-libwww_production
 pas_production
 pas_staging
 recap_production

--- a/inventory/by_team/dacs
+++ b/inventory/by_team/dacs
@@ -15,7 +15,6 @@ dss_production
 dss_staging
 lib_jobs_production
 lib_jobs_staging
-libwww_production
 lockers_and_study_spaces_production
 lockers_and_study_spaces_staging
 orangelight_production


### PR DESCRIPTION
references to libwww_production in inventory/by_team/dacs and inventory/by_service/apache were causing errors when running playbooks

related to #5651 