### PR TITLE
[checkmk] add OOBM machines

### DIFF
--- a/inventory/all_projects/checkmk
+++ b/inventory/all_projects/checkmk
@@ -4,3 +4,5 @@ pulcheck-prod1.princeton.edu
 pulmonitor-staging1.princeton.edu
 [pulcheck_remote]
 pulmonitor-staging2.princeton.edu
+lib-vm-monit2.princeton.edu
+lib-vm-monit3.princeton.edu

--- a/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
+++ b/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
@@ -15,6 +15,16 @@ upstream pulmonitor-staging-remote {
     server pulmonitor-staging2.princeton.edu resolve;
 }
 
+upstream pulmonitor-forrestal-remote {
+    zone pulmonitor-staging 64k;
+    server lib-vm-monit2.princeton.edu resolve;
+}
+
+upstream pulmonitor-newsouth-remote {
+    zone pulmonitor-staging 64k;
+    server lib-vm-monit3.princeton.edu resolve;
+}
+
 server {
     listen 80;
     server_name pulmonitor-staging.princeton.edu;
@@ -33,11 +43,37 @@ server {
 
     # Redirect top level traffic to /pulmonitor/
     location / {
-        return 302 https://$server_name/pulmonitor/;
+        return 302 https://$server_name/production/;
     }
 
-    location /pulmonitor/ {
-        proxy_pass http://pulmonitor-staging/pulmonitor/;
+    location /forrestal {
+        proxy_pass http://pulmonitor-forrestal-remote;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
+    }
+
+    location /new_south {
+        proxy_pass http://pulmonitor-newsouth-remote;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
+    }
+
+    location /production/ {
+        proxy_pass http://pulmonitor-staging/production/;
         proxy_set_header X-Forwarded-Host $host;
         proxy_cache pulmonitor-stagingcache;
         health_check interval=10 fails=3 passes=2;


### PR DESCRIPTION
we add the two out of band monitors to the ansible inventory
we configure the loadbalancer to route traffic to them

related to #5818

uncommitted work to rename the sites was done inside checkmk

Co-authored-by: Angel Ruiz <aruiz1789@users.noreply.github.com>
Co-authored-by: Denzil Phillips <dphillips-39@users.noreply.github.com>
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
