### PR TITLE
[DPUL] add a datadog http check for the mount health monitor

### DIFF
--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -200,6 +200,13 @@ datadog_checks:
           - 'http_service:dpul'
           - 'http_service_type:health'
           - 'http_service_check:smtp'
+      - name: Mount Health
+        url: 'http://localhost/health.json?providers[]=mountstatus'
+        include_content: true
+        tags:
+          - 'http_service:dpul'
+          - 'http_service_type:health'
+          - 'http_service_check:mount'
 redis_bind_interface: '0.0.0.0'
 redis__server_default_configuration:
   syslog-enabled: "{{ redis__server_syslog | bool }}"


### PR DESCRIPTION
This has been run; ready to merge

closes pulibrary/dpul#1600