### PR TITLE
[Nomad] Use the consul agent token we created for Nomad.

### DIFF
--- a/group_vars/nomad_clients.yml
+++ b/group_vars/nomad_clients.yml
@@ -3,5 +3,6 @@ nomad_node_role: "client"
 nomad_docker_enable: true
 nomad_podman_enable: true
 nomad_consul_token: "{{ nomad_client_consul_token }}"
+consul_acl_agent_token: "{{ nomad_client_consul_token }}"
 nomad_meta:
   node_type: 'default'

--- a/group_vars/nomad_servers.yml
+++ b/group_vars/nomad_servers.yml
@@ -2,3 +2,4 @@ consul_node_role: "server"
 consul_bootstrap_expect: true
 nomad_node_role: "server"
 nomad_consul_token: "{{ nomad_server_consul_token }}"
+consul_acl_agent_token: "{{ nomad_server_consul_token }}"


### PR DESCRIPTION
Consul's deregistration retry logic was losing the context of the nomad token (see https://github.com/hashicorp/consul/issues/8078), so as a workaround we can just set the default agent token. We were already setting a token, so this just sets a reasonable default.

This prevents consul being unable to deregister services Nomad asks to deregister, which was resulting in bad gateway errors from the load balancer. The log we were seeing was: `2025-02-18T16:43:33.601-0500 [WARN]  agent: Check deregistration blocked by ACLs: check=_nomad-check-2c43c15e2c438d2a32729f6ec07d7b520821677c accessorID="anonymous token"`