### PR TITLE
Match mflux name to what's in inventory/by_environment/production

### DIFF
--- a/inventory/all_projects/mflux
+++ b/inventory/all_projects/mflux
@@ -2,7 +2,7 @@
 mflux-ci1.lib.princeton.edu
 [mflux_qa]
 mflux-qa1.lib.princeton.edu
-[mflux_prod]
+[mflux_production]
 mflux-prod1.lib.princeton.edu
 [mflux_staging]
 mflux-staging1.lib.princeton.edu


### PR DESCRIPTION
This fixes a yml parse warning