### PR TITLE
Add mysql collection to Execution Environment

### DIFF
--- a/tower_ees/execution-environment.yml
+++ b/tower_ees/execution-environment.yml
@@ -35,6 +35,8 @@ dependencies:
         version: 2.6.4
       - name: community.general
         version: 7.5.2
+      - name: community.mysql
+        version: 3.8.0
       - name: community.postgresql
         version: 2.4.3
       - name: community.rabbitmq


### PR DESCRIPTION
This should help with this failing tower job: https://ansible-tower.princeton.edu/#/templates/job_template/73

We have not yet built a new execution environment with the new collection.