### PR TITLE
adds skeleton playbook so we can set up a Tower template

### DIFF
--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -1,0 +1,10 @@
+---
+- name: get issues from GitLab
+  hosts: localhost
+  tasks:
+      - name: call issue API
+        ansible.builtin.uri:
+          url: "https://gitlab.lib.princeton.edu/api/v4/issues?scope=all&project_id=5&access_token={{ vault_gitlab_issue_access_token }}"
+          method: GET
+          # 'scope=all' pulls issues created by all users
+        register: api_output


### PR DESCRIPTION
We cannot set up a template in Tower until the playbook exists in the main branch.

This branch adds a minimalist playbook to make it possible to test this functionality in Tower.

Related to #5886 