### PR TITLE
add tower boxes to postfix allow list

### DIFF
--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -7,6 +7,8 @@ postfix_relay_hosts_addresses:
   - abid-prod2.princeton.edu
   - ansible-exec-node1.princeton.edu
   - ansible-exec-node2.princeton.edu
+  - ansible-tower1.princeton.edu
+  - ansible-tower2.princeton.edu
   - byzantine-tsp-prod1.princeton.edu
   - byzantine-tsp-prod2.princeton.edu
   - catalog1.princeton.edu


### PR DESCRIPTION
Partially addresses #5820.

This change adds the Tower VMs to support email notifications. Email notifications come from the Tower UI rather than from playbook/template execution. I've already run the playbook from the branch and tested the alert in the Tower UI. Last step for #5820 is to specify the conditions for alerting.