### PR TITLE
Remove static tables referrence from libstaic role.

### DIFF
--- a/roles/libstatic/defaults/main.yml
+++ b/roles/libstatic/defaults/main.yml
@@ -96,12 +96,6 @@ sites:
       options: 'Indexes FollowSymLinks MultiViews'
       version: 'main'
       alias: 'pathebaby'
-    - doc_root: '/var/local/static_tables/site'
-      repo_root: '/var/local/static_tables'
-      git_repo: 'https://github.com/pulibrary/static-tables.git'
-      options: 'Indexes FollowSymLinks MultiViews'
-      version: 'main'
-      alias: 'static_tables'
     - doc_root: "/var/local/cotsen-exhibits"
       repo_root: "/var/local/cotsen-exhibits"
       git_repo: 'https://github.com/pulibrary/cotsen-exhibits.git'


### PR DESCRIPTION
At least partially addresses #5859.