### PR TITLE
[prancible] add a playbook that configures ntp server

### DIFF
--- a/playbooks/utils/chronyd.yml
+++ b/playbooks/utils/chronyd.yml
@@ -1,0 +1,61 @@
+---
+- name: Uninstall NTP and Install Chronyd for Consistent Time Sync
+  hosts: all
+  become: true
+  remote_user: pulsys
+  tasks:
+    - name: Stop and disable NTP service (if running)
+      ansible.builtin.service:
+        name: ntpd
+        state: stopped
+        enabled: false
+      ignore_errors: true
+
+    - name: Uninstall NTP package
+      ansible.builtin.package:
+        name: ntp
+        state: absent
+      ignore_errors: true
+
+    - name: Install Chronyd package
+      ansible.builtin.package:
+        name: chrony
+        state: present
+
+    - name: Create /etc/chrony.conf if it does not exist
+      ansible.builtin.file:
+        path: /etc/chrony.conf
+        state: touch
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Configure Chronyd to use pool.ntp.org
+      ansible.builtin.blockinfile:
+        path: /etc/chrony.conf
+        block: |
+          pool pool.ntp.org iburst
+        marker: "# {mark} ANSIBLE MANAGED CHRONY CONFIG"
+      notify: restart_chronyd
+
+    - name: Ensure Chronyd service is enabled and started
+      ansible.builtin.service:
+        name: chronyd
+        state: started
+        enabled: true
+
+    - name: Verify Chronyd sources
+      ansible.builtin.command: chronyc sources -v
+      register: chrony_sources
+      changed_when: false
+      failed_when: "'System clock wrong' in chrony_sources.stderr"
+
+    - name: Display Chronyd sources
+      ansible.builtin.debug:
+        var: chrony_sources.stdout_lines
+
+  handlers:
+    - name: restart_chronyd
+      ansible.builtin.service:
+        name: chronyd
+        state: restarted

--- a/playbooks/utils/chronyd.yml
+++ b/playbooks/utils/chronyd.yml
@@ -22,21 +22,41 @@
         name: chrony
         state: present
 
-    - name: Create /etc/chrony.conf if it does not exist
+    - name: Create /etc/chrony.conf if it does not exist (Rocky Linux)
       ansible.builtin.file:
         path: /etc/chrony.conf
         state: touch
         owner: root
         group: root
         mode: '0644'
+      when: ansible_os_family == "RedHat"
 
-    - name: Configure Chronyd to use pool.ntp.org
-      ansible.builtin.blockinfile:
+    - name: Create /etc/chrony/sources.d directory (Ubuntu)
+      ansible.builtin.file:
+        path: /etc/chrony/sources.d/ntp-server.sources
+        state: touch
+        owner: root
+        group: root
+        mode: '0755'
+      when: ansible_os_family == "Debian"
+
+    - name: Configure Chronyd to use pool.ntp.org (Rocky Linux)
+      blockinfile:
         path: /etc/chrony.conf
         block: |
           pool pool.ntp.org iburst
         marker: "# {mark} ANSIBLE MANAGED CHRONY CONFIG"
       notify: restart_chronyd
+      when: ansible_os_family == "RedHat"
+
+    - name: Configure Chronyd to use pool.ntp.org (Ubuntu)
+      blockinfile:
+        path: /etc/chrony/sources.d/ntp-server.sources
+        block: |
+          pool pool.ntp.org iburst
+        marker: "# {mark} ANSIBLE MANAGED CHRONY CONFIG"
+      notify: restart_chronyd
+      when: ansible_os_family == "Debian"
 
     - name: Ensure Chronyd service is enabled and started
       ansible.builtin.service:


### PR DESCRIPTION
make all our VMS use the same ntp servers that our ESXi hosts use. We are otherwise getting false alerts about what time things happen

related to #5893 