### PR TITLE
[Nomad] Systemd should wait for Consul to join to be marked as up.

### DIFF
--- a/roles/ansible-consul/templates/consul_systemd.service.j2
+++ b/roles/ansible-consul/templates/consul_systemd.service.j2
@@ -14,6 +14,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+Type=notify
 User={{ consul_user }}
 Group={{ consul_group }}
 PIDFile={{ consul_run_path }}/consul.pid
@@ -28,7 +29,6 @@ ExecStart={{ consul_bin_path }}/consul agent \
     -config-dir={{ consul_configd_path}} \
     -pid-file={{ consul_run_path }}/consul.pid
 ExecReload=/bin/kill -HUP $MAINPID
-KillMode=process
 KillSignal=SIGTERM
 Restart={{ consul_systemd_restart }}
 RestartSec={{ consul_systemd_restart_sec }}s


### PR DESCRIPTION
This was allowing Nomad to start up before Consul.

See https://github.com/hashicorp/nomad/pull/24964

Refs #5864 