### PR TITLE
Pulsys keys playbook fails if no hosts match at all

### DIFF
--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -133,6 +133,6 @@
          msg: The playbook did not add keys to any hosts, please try again.
       failed_when:
         - first_play_had_hosts is undefined
-        - second_play_had_hosts is undefinend
+        - second_play_had_hosts is undefined
       run_once: true
       delegate_to: localhost

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -112,17 +112,19 @@
       when: ansible_play_hosts_all is search("princeton.edu")
 
 - name: Fail if neither play ran
-  hosts: localhost
+  hosts: all
 
   tasks:
 
     - name: view first play var
       ansible.builtin.debug:
         var: first_play_had_hosts
+      run_once: true
 
     - name: view second play var
       ansible.builtin.debug:
         var: second_play_had_hosts
+      run_once: true
 
     - name: Fail playbook when neither play matched a host
       ansible.builtin.fail:
@@ -130,3 +132,4 @@
       failed_when:
         - "first_play_no_hosts != true"
         - "second_play_no_hosts != true"
+      run_once: true

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -111,6 +111,19 @@
         second_play_had_hosts: true
       when: ansible_play_hosts_all is search("princeton.edu")
 
+- name: Fail if neither play ran
+  hosts: localhost
+
+  tasks:
+
+    - name: view first play var
+      ansible.builtin.debug:
+        var: first_play_had_hosts
+
+    - name: view second play var
+      ansible.builtin.debug:
+        var: second_play_had_hosts
+
     - name: Fail playbook when neither play matched a host
       ansible.builtin.fail:
          msg: The playbook did not add keys to any hosts, please try again.

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -120,16 +120,19 @@
       ansible.builtin.debug:
         var: first_play_had_hosts
       run_once: true
+      delegate_to: localhost
 
     - name: view second play var
       ansible.builtin.debug:
         var: second_play_had_hosts
       run_once: true
+      delegate_to: localhost
 
     - name: Fail playbook when neither play matched a host
       ansible.builtin.fail:
          msg: The playbook did not add keys to any hosts, please try again.
       failed_when:
-        - "first_play_no_hosts != true"
-        - "second_play_no_hosts != true"
+        - first_play_had_hosts is undefined
+        - second_play_had_hosts is undefinend
       run_once: true
+      delegate_to: localhost

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -48,10 +48,9 @@
         mode: '0600'
         backup: true
 
-    - name: set fact for hosts matched in the first play
+    - name: set fact if the first play ran
       ansible.builtin.set_fact:
-        first_play_had_hosts: true
-      when: ansible_play_hosts_all is search("princeton.edu")
+        first_play_ran: true
 
 - name: Update pulsys user keys on shared boxes
   hosts: cdh_shared_{{ runtime_env | default('staging') }}
@@ -98,10 +97,9 @@
         mode: '0600'
         backup: true
 
-    - name: set fact for hosts matched in the second play
+    - name: set fact if the second play ran
       ansible.builtin.set_fact:
-        second_play_had_hosts: true
-      when: ansible_play_hosts_all is search("princeton.edu")
+        second_play_ran: true
 
 - name: Fail if neither play ran
   hosts: all
@@ -112,7 +110,7 @@
       ansible.builtin.fail:
          msg: The playbook did not add keys to any hosts, please try again.
       failed_when:
-        - first_play_had_hosts is undefined
-        - second_play_had_hosts is undefined
+        - first_play_ran is undefined
+        - second_play_ran is undefined
       run_once: true
       delegate_to: localhost

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -54,8 +54,8 @@
 
     - name: set fact for hosts matched in the first play
       ansible.builtin.set_fact:
-        first_play_no_hosts: true
-      when: ansible_play_hosts_all is null
+        first_play_had_hosts: true
+      when: ansible_play_hosts_all is search("princeton.edu")
 
 - name: Update pulsys user keys on shared boxes
   hosts: cdh_shared_{{ runtime_env | default('staging') }}
@@ -108,12 +108,12 @@
 
     - name: set fact for hosts matched in the second play
       ansible.builtin.set_fact:
-        second_play_no_hosts: true
-      when: ansible_play_hosts_all is null
+        second_play_had_hosts: true
+      when: ansible_play_hosts_all is search("princeton.edu")
 
     - name: Fail playbook when neither play matched a host
       ansible.builtin.fail:
          msg: The playbook did not add keys to any hosts, please try again.
       failed_when:
-        - "first_play_no_hosts is true"
-        - "second_play_no_hosts is true"
+        - "first_play_no_hosts != true"
+        - "second_play_no_hosts != true"

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -48,6 +48,15 @@
         mode: '0600'
         backup: true
 
+    - name: view special var
+      ansible.builtin.debug:
+        var: ansible_play_hosts_all
+
+    - name: set fact for hosts matched in the first play
+      ansible.builtin.set_fact:
+        first_play_no_hosts: true
+      when: ansible_play_hosts_all is null
+
 - name: Update pulsys user keys on shared boxes
   hosts: cdh_shared_{{ runtime_env | default('staging') }}
   remote_user: pulsys
@@ -92,3 +101,19 @@
         owner: pulsys
         mode: '0600'
         backup: true
+
+    - name: view special var
+      ansible.builtin.debug:
+        var: ansible_play_hosts_all
+
+    - name: set fact for hosts matched in the second play
+      ansible.builtin.set_fact:
+        second_play_no_hosts: true
+      when: ansible_play_hosts_all is null
+
+    - name: Fail playbook when neither play matched a host
+      ansible.builtin.fail:
+         msg: The playbook did not add keys to any hosts, please try again.
+      failed_when:
+        - "first_play_no_hosts is true"
+        - "second_play_no_hosts is true"

--- a/playbooks/pulsys_user.yml
+++ b/playbooks/pulsys_user.yml
@@ -48,10 +48,6 @@
         mode: '0600'
         backup: true
 
-    - name: view special var
-      ansible.builtin.debug:
-        var: ansible_play_hosts_all
-
     - name: set fact for hosts matched in the first play
       ansible.builtin.set_fact:
         first_play_had_hosts: true
@@ -102,10 +98,6 @@
         mode: '0600'
         backup: true
 
-    - name: view special var
-      ansible.builtin.debug:
-        var: ansible_play_hosts_all
-
     - name: set fact for hosts matched in the second play
       ansible.builtin.set_fact:
         second_play_had_hosts: true
@@ -115,18 +107,6 @@
   hosts: all
 
   tasks:
-
-    - name: view first play var
-      ansible.builtin.debug:
-        var: first_play_had_hosts
-      run_once: true
-      delegate_to: localhost
-
-    - name: view second play var
-      ansible.builtin.debug:
-        var: second_play_had_hosts
-      run_once: true
-      delegate_to: localhost
 
     - name: Fail playbook when neither play matched a host
       ansible.builtin.fail:


### PR DESCRIPTION
Closes #5243.

The pulsys user playbook sometimes runs in Tower without adding keys to any VMs because no hosts match either play. This PR ~~adds variables for matching hosts~~ sets a fact when each play runs, and adds a third play that forces failure if neither of the first two plays ~~has any matching hosts~~ runs.

~~Could use a test run @maxkadel.~~

Update: I figured out the most common use case - if I use `limit` to run on a specific VM or group and then select an `environment` setting that does not include the VM or group, the playbook will behave as described in #5243. Here's the [Tower run](https://ansible-tower.princeton.edu/#/jobs/playbook/13669/output) that tested the functionality of this branch.