### PR TITLE
Don't use become/sudo in check_os_versions.yml

### DIFF
--- a/playbooks/utils/check_os_versions.yml
+++ b/playbooks/utils/check_os_versions.yml
@@ -3,7 +3,7 @@
   hosts: all
   # hosts: staging:qa:production
   remote_user: pulsys
-  become: true
+  # become: true
 
   tasks:
     - name: report operating system & version


### PR DESCRIPTION
With `become` set to true in the check_os_versions playbook, we see this error on some machines:

`fatal: [prds-dataspace-dtn1]: FAILED! => {"msg": "Missing sudo password"}`

The playbook gathers facts and reports them. We shouldn't need sudo/become for that.