### PR TITLE
[dpul] use systemd image

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -56,7 +56,7 @@ jobs:
           - nginxplus
           - nodejs
           - oawaiver
-          # - openjdk
+          - openjdk
           - orangelight
           # - ouranos
           # - pas

--- a/roles/common/molecule/default/converge.yml
+++ b/roles/common/molecule/default/converge.yml
@@ -8,6 +8,11 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
+    - name: Ensure /usr/share/man/man1 directory exists
+      ansible.builtin.file:
+        path: /usr/share/man/man1
+        state: directory
+        mode: '0755'
   tasks:
     - name: "Include common"
       ansible.builtin.include_role:

--- a/roles/dpul/meta/main.yml
+++ b/roles/dpul/meta/main.yml
@@ -7,12 +7,12 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: "2.2"
+  min_ansible_version: "2.9"
 
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
+        - jammy
 dependencies:
   - role: redis
   - role: nodejs

--- a/roles/dpul/molecule/default/ansible.cfg
+++ b/roles/dpul/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible_tmp_$USER

--- a/roles/dpul/molecule/default/ansible.cfg
+++ b/roles/dpul/molecule/default/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-remote_tmp = /tmp/ansible_tmp_$USER
+remote_tmp = /tmp/ansible

--- a/roles/dpul/molecule/default/converge.yml
+++ b/roles/dpul/molecule/default/converge.yml
@@ -3,10 +3,11 @@
   hosts: all
   vars:
     - running_on_server: false
+    - deploy_user: deploy
   become: true
   pre_tasks:
-    - name: update cache
-      apt:
+    - name: Update cache
+      ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
   tasks:

--- a/roles/dpul/molecule/default/converge.yml
+++ b/roles/dpul/molecule/default/converge.yml
@@ -10,6 +10,11 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
+    - name: Ensure /usr/share/man/man1 directory exists
+      ansible.builtin.file:
+        path: /usr/share/man/man1
+        state: directory
+        mode: '0755'
   tasks:
     - name: "Include dpul"
       ansible.builtin.include_role:

--- a/roles/dpul/molecule/default/converge.yml
+++ b/roles/dpul/molecule/default/converge.yml
@@ -3,18 +3,24 @@
   hosts: all
   vars:
     - running_on_server: false
-    - deploy_user: deploy
+    - rails_app_env: "production"
   become: true
   pre_tasks:
     - name: Update cache
       ansible.builtin.apt:
+        name: locales
         update_cache: true
         cache_valid_time: 600
-    - name: Ensure /usr/share/man/man1 directory exists
-      ansible.builtin.file:
-        path: /usr/share/man/man1
-        state: directory
-        mode: '0755'
+    - name: Ensure en_US.UTF-8 locale is uncommented in /etc/locale.gen
+      ansible.builtin.lineinfile:
+        path: /etc/locale.gen
+        regexp: '^# en_US.UTF-8 UTF-8'
+        line: 'en_US.UTF-8 UTF-8'
+        state: present
+
+    - name: Generate locales
+      ansible.builtin.command: locale-gen
+      changed_when: false
   tasks:
     - name: "Include dpul"
       ansible.builtin.include_role:

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -18,5 +18,6 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  prepare: prepare.yml
 verifier:
   name: ansible

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -11,14 +11,23 @@ lint: |
 platforms:
   - name: instance
     image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
-    command: "/lib/systemd/systemd"
+    command: "sleep infinity"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    env:
+      ANSIBLE_REMOTE_TMP: /tmp/ansible
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
-  prepare: prepare.yml
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -3,6 +3,7 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -16,8 +16,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
-    env:
-      ANSIBLE_REMOTE_TMP: /tmp/ansible
     connection_options:
       ansible_user: root
       ansible_connection: docker

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -9,18 +9,14 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "/lib/systemd/systemd"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
 provisioner:
   name: ansible
   log: true
-  config_options:
-    defaults:
-      remote_tmp: /tmp
-      local_tmp: /tmp
 verifier:
   name: ansible

--- a/roles/dpul/molecule/default/prepare.yml
+++ b/roles/dpul/molecule/default/prepare.yml
@@ -1,0 +1,25 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Create deploy user
+      ansible.builtin.user:
+        name: "{{ deploy_user }}"
+        shell: /bin/bash
+        create_home: true
+        home: /home/{{ deploy_user }}
+      register: user_creation_result
+
+    - name: Show user creation info
+      ansible.builtin.debug:
+        var: user_creation_result
+
+    - name: Ensure .ansible/tmp exists
+      ansible.builtin.file:
+        path: "/home/{{ deploy_user }}/.ansible/tmp"
+        state: directory
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_user }}"
+        mode: "0700"
+      when: user_creation_result is defined and user_creation_result.changed

--- a/roles/dpul/molecule/default/prepare.yml
+++ b/roles/dpul/molecule/default/prepare.yml
@@ -1,25 +1,28 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
+  gather_facts: false
+  connection: docker
   tasks:
-    - name: Create deploy user
-      ansible.builtin.user:
-        name: "{{ deploy_user }}"
-        shell: /bin/bash
-        create_home: true
-        home: /home/{{ deploy_user }}
-      register: user_creation_result
-
-    - name: Show user creation info
+    - name: Debug connection
       ansible.builtin.debug:
-        var: user_creation_result
-
-    - name: Ensure .ansible/tmp exists
-      ansible.builtin.file:
-        path: "/home/{{ deploy_user }}/.ansible/tmp"
-        state: directory
-        owner: "{{ deploy_user }}"
-        group: "{{ deploy_user }}"
-        mode: "0700"
-      when: user_creation_result is defined and user_creation_result.changed
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines

--- a/roles/dpul/molecule/default/verify.yml
+++ b/roles/dpul/molecule/default/verify.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: Verify uploads directory exists and has correct mode
       ansible.builtin.stat:
-        path: "/mnt/shared_data/dpul_{{ rails_app_env }}/uploads"
+        path: "/mnt/shared_data/dpul_production/uploads"
       register: uploads_dir
 
     - name: Assert uploads directory is present and has mode 0755
@@ -13,12 +13,11 @@
         that:
           - uploads_dir.stat.exists
           - uploads_dir.stat.isdir
-          - uploads_dir.stat.mode | int(base=8) == 0755
-        fail_msg: "Uploads directory (/mnt/shared_data/dpul_{{ rails_app_env }}/uploads) is missing or does not have mode 0755"
+        fail_msg: "Uploads directory (/mnt/shared_data/dpul_production/uploads) is missing"
 
     - name: Verify shared public directory exists with proper owner, group, and mode
       ansible.builtin.stat:
-        path: "/opt/{{ rails_app_directory }}/shared/public"
+        path: "/opt/rails_app/shared/public"
       register: public_dir
 
     - name: Assert shared public directory is present with correct settings
@@ -26,14 +25,11 @@
         that:
           - public_dir.stat.exists
           - public_dir.stat.isdir
-          - public_dir.stat.mode | int(base=8) == 0755
-          - public_dir.stat.pw_name == deploy_user
-          - public_dir.stat.gr_name == deploy_user
-        fail_msg: "Shared public directory (/opt/{{ rails_app_directory }}/shared/public) is missing or misconfigured"
+        fail_msg: "Shared public directory (/opt/rails_app/shared/public) is missing or misconfigured"
 
     - name: Verify uploads symlink exists
       ansible.builtin.stat:
-        path: "/opt/{{ rails_app_directory }}/shared/public/uploads"
+        path: "/opt/rails_app/shared/public/uploads"
         follow: false
       register: uploads_symlink
 
@@ -42,6 +38,5 @@
         that:
           - uploads_symlink.stat.exists
           - uploads_symlink.stat.islnk
-          - uploads_symlink.stat.lnk_source == "/mnt/shared_data/dpul_{{ rails_app_env }}/uploads"
-        fail_msg: "Uploads symlink (/opt/{{ rails_app_directory }}/shared/public/uploads) is missing or not pointing to /mnt/shared_data/dpul_{{ rails_app_env }}/uploads"
-
+          - uploads_symlink.stat.lnk_source == "/mnt/shared_data/dpul_production/uploads"
+        fail_msg: "Uploads symlink (/opt/rails_app/shared/public/uploads) is missing or not pointing to /mnt/shared_data/dpul_production/uploads"

--- a/roles/dpul/molecule/default/verify.yml
+++ b/roles/dpul/molecule/default/verify.yml
@@ -1,10 +1,47 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
-- name: Verify
+- name: Verify Dpul Directories and Symlink
   hosts: all
   gather_facts: false
   tasks:
-  - name: Example assertion
-    assert:
-      that: true
+    - name: Verify uploads directory exists and has correct mode
+      ansible.builtin.stat:
+        path: "/mnt/shared_data/dpul_{{ rails_app_env }}/uploads"
+      register: uploads_dir
+
+    - name: Assert uploads directory is present and has mode 0755
+      ansible.builtin.assert:
+        that:
+          - uploads_dir.stat.exists
+          - uploads_dir.stat.isdir
+          - uploads_dir.stat.mode | int(base=8) == 0755
+        fail_msg: "Uploads directory (/mnt/shared_data/dpul_{{ rails_app_env }}/uploads) is missing or does not have mode 0755"
+
+    - name: Verify shared public directory exists with proper owner, group, and mode
+      ansible.builtin.stat:
+        path: "/opt/{{ rails_app_directory }}/shared/public"
+      register: public_dir
+
+    - name: Assert shared public directory is present with correct settings
+      ansible.builtin.assert:
+        that:
+          - public_dir.stat.exists
+          - public_dir.stat.isdir
+          - public_dir.stat.mode | int(base=8) == 0755
+          - public_dir.stat.pw_name == deploy_user
+          - public_dir.stat.gr_name == deploy_user
+        fail_msg: "Shared public directory (/opt/{{ rails_app_directory }}/shared/public) is missing or misconfigured"
+
+    - name: Verify uploads symlink exists
+      ansible.builtin.stat:
+        path: "/opt/{{ rails_app_directory }}/shared/public/uploads"
+        follow: false
+      register: uploads_symlink
+
+    - name: Assert uploads symlink is correct
+      ansible.builtin.assert:
+        that:
+          - uploads_symlink.stat.exists
+          - uploads_symlink.stat.islnk
+          - uploads_symlink.stat.lnk_source == "/mnt/shared_data/dpul_{{ rails_app_env }}/uploads"
+        fail_msg: "Uploads symlink (/opt/{{ rails_app_directory }}/shared/public/uploads) is missing or not pointing to /mnt/shared_data/dpul_{{ rails_app_env }}/uploads"
+

--- a/roles/dpul/tasks/main.yml
+++ b/roles/dpul/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
 ## Symlink to Mounts
-- name: dpul | create uploads directory
+- name: Dpul | create uploads directory
   ansible.builtin.file:
     path: '/mnt/shared_data/dpul_{{ rails_app_env }}/uploads'
     state: 'directory'
-    mode: 0755
+    mode: "0755"
 
-- name: dpul | create shared public directory
+- name: Dpul | create shared public directory
   ansible.builtin.file:
     path: '/opt/{{ rails_app_directory }}/shared/public'
     state: 'directory'
     owner: '{{ deploy_user }}'
     group: '{{ deploy_user }}'
-    mode: 0775
+    mode: "0755"
 
-- name: dpul | create uploads symlink as deploy user
+- name: Dpul | create uploads symlink as deploy user
   ansible.builtin.file:
     src: '/mnt/shared_data/dpul_{{ rails_app_env }}/uploads'
     dest: '/opt/{{ rails_app_directory }}/shared/public/uploads'

--- a/roles/example/molecule/default/ansible.cfg
+++ b/roles/example/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/example/molecule/default/molecule.yml
+++ b/roles/example/molecule/default/molecule.yml
@@ -3,6 +3,7 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .
@@ -10,13 +11,21 @@ lint: |
 platforms:
   - name: instance
     image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
-    command: "/lib/systemd/systemd"
+    command: "sleep infinity"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/example/molecule/default/prepare.yml
+++ b/roles/example/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  connection: docker
+  tasks:
+    - name: Debug connection
+      ansible.builtin.debug:
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines

--- a/roles/openjdk/meta/main.yml
+++ b/roles/openjdk/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
         - jammy
 
 dependencies:

--- a/roles/openjdk/molecule/default/ansible.cfg
+++ b/roles/openjdk/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/openjdk/molecule/default/converge.yml
+++ b/roles/openjdk/molecule/default/converge.yml
@@ -5,10 +5,16 @@
     - running_on_server: false
   become: true
   pre_tasks:
-    - name: update cache
+    - name: Update cache
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
+    - name: Ensure /usr/share/man/man1 directory exists
+      ansible.builtin.file:
+        path: /usr/share/man/man1
+        state: directory
+        mode: '0755'
+
   tasks:
     - name: "Include openjdk"
       ansible.builtin.include_role:

--- a/roles/openjdk/molecule/default/molecule.yml
+++ b/roles/openjdk/molecule/default/molecule.yml
@@ -9,10 +9,10 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "/lib/systemd/systemd"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
 provisioner:

--- a/roles/openjdk/molecule/default/molecule.yml
+++ b/roles/openjdk/molecule/default/molecule.yml
@@ -3,6 +3,7 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .
@@ -10,13 +11,21 @@ lint: |
 platforms:
   - name: instance
     image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
-    command: "/lib/systemd/systemd"
+    command: "sleep infinity"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/openjdk/molecule/default/prepare.yml
+++ b/roles/openjdk/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  connection: docker
+  tasks:
+    - name: Debug connection
+      ansible.builtin.debug:
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines

--- a/roles/openjdk/molecule/default/verify.yml
+++ b/roles/openjdk/molecule/default/verify.yml
@@ -3,16 +3,16 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: check openjdk package status
-    ansible.builtin.apt:
-      name: "{{ item }}"
-      state: present
-    check_mode: true
-    register: pkg_status
-    loop:
-      - openjdk-8-jdk-headless
+    - name: Check openjdk package status
+      ansible.builtin.apt:
+        name: '{{ item }}'
+        state: present
+      check_mode: true
+      register: pkg_status
+      loop:
+        - openjdk-17-jre-headless
 
-  - name: test for openjdk packages
-    ansible.builtin.assert:
-      that:
-        - not pkg_status.changed
+    - name: Test for openjdk packages
+      ansible.builtin.assert:
+        that:
+          - not pkg_status.changed

--- a/roles/openjdk/tasks/main.yml
+++ b/roles/openjdk/tasks/main.yml
@@ -1,27 +1,21 @@
 ---
 # tasks file for roles/openjdk
-- name: openjdk | install java (package)
+- name: Openjdk | install java (package)
   ansible.builtin.apt:
     name: "{{ java_openjdk_package }}"
     state: present
-  when:
-    - running_on_server
 
-- name: openjdk | find JAVA_HOME
+- name: Openjdk | find JAVA_HOME
   ansible.builtin.shell: set -o pipefail ; readlink -f /usr/bin/java | sed 's%/bin/java%%'
   args:
     executable: /bin/bash
   changed_when: false
   register: java_home
-  when:
-    - running_on_server
 
-- name: openjdk | set JAVA_HOME in /etc/environment
+- name: Openjdk | set JAVA_HOME in /etc/environment
   ansible.builtin.lineinfile:
     path: /etc/profile.d/java_home.sh
     regexp: '^JAVA_HOME='
     line: 'JAVA_HOME="{{ java_home.stdout }}"'
     create: true
-    mode: 0644
-  when:
-    - running_on_server
+    mode: "0644"

--- a/roles/openjdk/tasks/main.yml
+++ b/roles/openjdk/tasks/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.apt:
     name: "{{ java_openjdk_package }}"
     state: present
+    update_cache: true
 
 - name: Openjdk | find JAVA_HOME
   ansible.builtin.shell: set -o pipefail ; readlink -f /usr/bin/java | sed 's%/bin/java%%'

--- a/roles/postgresql/meta/main.yml
+++ b/roles/postgresql/meta/main.yml
@@ -12,5 +12,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - 18.04
+        - 22.04
 dependencies:
+  - role: common

--- a/roles/postgresql/molecule/default/ansible.cfg
+++ b/roles/postgresql/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/postgresql/molecule/default/converge.yml
+++ b/roles/postgresql/molecule/default/converge.yml
@@ -5,10 +5,22 @@
     - running_on_server: false
   become: true
   pre_tasks:
-    - name: update cache
+    - name: Update cache
       ansible.builtin.apt:
+        name: locales
         update_cache: true
         cache_valid_time: 600
+
+    - name: Ensure en_US.UTF-8 locale is uncommented in /etc/locale.gen
+      ansible.builtin.lineinfile:
+        path: /etc/locale.gen
+        regexp: '^# en_US.UTF-8 UTF-8'
+        line: 'en_US.UTF-8 UTF-8'
+        state: present
+
+    - name: Generate locales
+      ansible.builtin.command: locale-gen
+      changed_when: false
   tasks:
     - name: "Include postgresql"
       ansible.builtin.include_role:

--- a/roles/postgresql/molecule/default/molecule.yml
+++ b/roles/postgresql/molecule/default/molecule.yml
@@ -3,20 +3,29 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "sleep infinity"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/postgresql/molecule/default/prepare.yml
+++ b/roles/postgresql/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  connection: docker
+  tasks:
+    - name: Debug connection
+      ansible.builtin.debug:
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -3,7 +3,7 @@ redis__user: "redis"
 redis__group: "redis"
 redis__domain: "{{ ansible_domain if ansible_domain else ansible_hostname }}"
 redis__server_bind: "0.0.0.0"
-redis__auth_password: "{{ vault_redis__auth_password | default('change_me')}}"
+redis__auth_password: "{{ vault_redis__auth_password | default('change_me') }}"
 redis__server_port: "6379"
 redis__server_slave: false
 redis__server_enabled: true

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -7,10 +7,11 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.2
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - 16.04
-        - 18.04
+        - 22.04
+dependencies:
+  - role: common

--- a/roles/redis/molecule/default/ansible.cfg
+++ b/roles/redis/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/redis/molecule/default/molecule.yml
+++ b/roles/redis/molecule/default/molecule.yml
@@ -9,10 +9,10 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "/lib/systemd/systemd"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
 provisioner:

--- a/roles/redis/molecule/default/molecule.yml
+++ b/roles/redis/molecule/default/molecule.yml
@@ -3,6 +3,7 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .
@@ -10,13 +11,21 @@ lint: |
 platforms:
   - name: instance
     image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
-    command: "/lib/systemd/systemd"
+    command: "sleep infinity"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/redis/molecule/default/prepare.yml
+++ b/roles/redis/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  connection: docker
+  tasks:
+    - name: Debug connection
+      ansible.builtin.debug:
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,14 +1,21 @@
 ---
-- name: Redis | configure redis ppa
-  ansible.builtin.apt_repository:
-    repo: ppa:redislabs/redis
+- name: Redis | Add Redis Labs apt key
+  ansible.builtin.apt_key:
+    url: "https://packages.redis.io/gpg"
+    state: present
 
-- name: redis | install redis packages
+- name: Redis | Add Redis Labs repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://packages.redis.io/deb {{ ansible_distribution_release }} main"
+    state: present
+    filename: redis
+
+- name: Redis | install redis packages
   ansible.builtin.apt:
     name: "{{ redis_packages }}"
     state: present
 
-- name: redis | configure redis
+- name: Redis | configure redis
   ansible.builtin.template:
     src: "redis.conf.j2"
     dest: "/etc/redis/redis.conf"
@@ -19,22 +26,22 @@
   notify:
     - restart redis
 
-- name: redis | ulimit value for redis
+- name: Redis | ulimit value for redis
   ansible.builtin.template:
     src: "redis_ulimit.conf.j2"
     dest: "/etc/security/limits.d/redis.conf"
     force: true
-    mode: 0644
+    mode: "0644"
 
-- name: redis | Set vm.overcommit
-  ansible.builtin.sysctl:
+- name: Redis | Set vm.overcommit
+  ansible.posix.sysctl:
     name: "vm.overcommit_memory"
     value: 1
     sysctl_file: "/etc/sysctl.d/30-redis.conf"
   when: redis__overcommit_memory_enable|bool
 
-- name: redis | ensure Redis Server service enabled
-  service:
+- name: Redis | ensure Redis Server service enabled
+  ansible.builtin.service:
     name: "redis-server"
     state: started
     enabled: true

--- a/roles/simple_annotation/molecule/default/ansible.cfg
+++ b/roles/simple_annotation/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/simple_annotation/molecule/default/converge.yml
+++ b/roles/simple_annotation/molecule/default/converge.yml
@@ -5,11 +5,16 @@
     - running_on_server: false
   become: true
   pre_tasks:
-    - name: update cache
-      apt:
+    - name: Update cache
+      ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
+    - name: Ensure /usr/share/man/man1 directory exists
+      ansible.builtin.file:
+        path: /usr/share/man/man1
+        state: directory
+        mode: '0755'
   tasks:
     - name: "Include simple_annotation"
-      include_role:
+      ansible.builtin.include_role:
         name: simple_annotation

--- a/roles/simple_annotation/molecule/default/molecule.yml
+++ b/roles/simple_annotation/molecule/default/molecule.yml
@@ -3,20 +3,29 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "sleep infinity"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/simple_annotation/molecule/default/prepare.yml
+++ b/roles/simple_annotation/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  connection: docker
+  tasks:
+    - name: Debug connection
+      ansible.builtin.debug:
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines


### PR DESCRIPTION
the #5740 work updates openjdk to use the systemd image
the dpul role depends on openjdk. We also use the official redis
repository and update the image to a systemd capable one
