### PR TITLE
[Traefik Wall] Fix wireless IPs being hit with captcha.

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -29,6 +29,7 @@ http:
           challengeTmpl: /challenge.tmpl.html
           # Exclude facet routes - they're an ajax request.
           excludeRoutes: "/catalog/facet,/catalog/range_limit"
+          logLevel: "DEBUG"
     append-catalog-regex:
       redirectRegex:
         regex: /\?f(.*)

--- a/nomad/traefik-wall/deploy/traefik.tpl.yml
+++ b/nomad/traefik-wall/deploy/traefik.tpl.yml
@@ -22,4 +22,4 @@ experimental:
   plugins:
     captcha-protect:
       modulename: github.com/libops/captcha-protect
-      version: v1.5.0
+      version: v1.6.1


### PR DESCRIPTION
Anyone on our wireless shouldn't be hit with captcha - this upgrades the plugin and fixes the config so it's fine.