### PR TITLE
[openjdk] add openjdk tests

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -56,7 +56,7 @@ jobs:
           - nginxplus
           - nodejs
           - oawaiver
-          # - openjdk
+          - openjdk
           - orangelight
           # - ouranos
           # - pas

--- a/roles/openjdk/molecule/default/ansible.cfg
+++ b/roles/openjdk/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/openjdk/molecule/default/converge.yml
+++ b/roles/openjdk/molecule/default/converge.yml
@@ -5,10 +5,16 @@
     - running_on_server: false
   become: true
   pre_tasks:
-    - name: update cache
+    - name: Update cache
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
+    - name: Ensure /usr/share/man/man1 directory exists
+      ansible.builtin.file:
+        path: /usr/share/man/man1
+        state: directory
+        mode: '0755'
+
   tasks:
     - name: "Include openjdk"
       ansible.builtin.include_role:

--- a/roles/openjdk/molecule/default/molecule.yml
+++ b/roles/openjdk/molecule/default/molecule.yml
@@ -3,20 +3,29 @@ scenario:
   name: default
 driver:
   name: docker
+  command_timeout: 60
 lint: |
   set -e
   yamllint .
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
-    command: ""
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "sleep infinity"
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: true
+    connection_options:
+      ansible_user: root
+      ansible_connection: docker
 provisioner:
   name: ansible
   log: true
+  playbooks:
+    prepare: prepare.yml
+  config_options:
+    defaults:
+      remote_tmp: /tmp/ansible
 verifier:
   name: ansible

--- a/roles/openjdk/molecule/default/prepare.yml
+++ b/roles/openjdk/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  connection: docker
+  tasks:
+    - name: Debug connection
+      ansible.builtin.debug:
+        msg: "Connected successfully"
+        
+    - name: Check permissions
+      ansible.builtin.command: ls -la /tmp
+      register: tmp_permissions
+      
+    - name: Display tmp permissions
+      ansible.builtin.debug:
+        var: tmp_permissions.stdout_lines
+        
+    - name: Try to create directory manually
+      ansible.builtin.shell: |
+        mkdir -p /tmp/ansible
+        chmod 777 /tmp/ansible
+        ls -la /tmp/ansible
+      register: dir_creation
+      
+    - name: Display directory creation result
+      ansible.builtin.debug:
+        var: dir_creation.stdout_lines

--- a/roles/openjdk/molecule/default/verify.yml
+++ b/roles/openjdk/molecule/default/verify.yml
@@ -3,16 +3,16 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: check openjdk package status
-    ansible.builtin.apt:
-      name: "{{ item }}"
-      state: present
-    check_mode: true
-    register: pkg_status
-    loop:
-      - openjdk-8-jdk-headless
+    - name: Check openjdk package status
+      ansible.builtin.apt:
+        name: '{{ item }}'
+        state: present
+      check_mode: true
+      register: pkg_status
+      loop:
+        - openjdk-17-jre-headless
 
-  - name: test for openjdk packages
-    ansible.builtin.assert:
-      that:
-        - not pkg_status.changed
+    - name: Test for openjdk packages
+      ansible.builtin.assert:
+        that:
+          - not pkg_status.changed

--- a/roles/openjdk/tasks/main.yml
+++ b/roles/openjdk/tasks/main.yml
@@ -1,27 +1,21 @@
 ---
 # tasks file for roles/openjdk
-- name: openjdk | install java (package)
+- name: Openjdk | install java (package)
   ansible.builtin.apt:
     name: "{{ java_openjdk_package }}"
     state: present
-  when:
-    - running_on_server
 
-- name: openjdk | find JAVA_HOME
+- name: Openjdk | find JAVA_HOME
   ansible.builtin.shell: set -o pipefail ; readlink -f /usr/bin/java | sed 's%/bin/java%%'
   args:
     executable: /bin/bash
   changed_when: false
   register: java_home
-  when:
-    - running_on_server
 
-- name: openjdk | set JAVA_HOME in /etc/environment
+- name: Openjdk | set JAVA_HOME in /etc/environment
   ansible.builtin.lineinfile:
     path: /etc/profile.d/java_home.sh
     regexp: '^JAVA_HOME='
     line: 'JAVA_HOME="{{ java_home.stdout }}"'
     create: true
-    mode: 0644
-  when:
-    - running_on_server
+    mode: "0644"


### PR DESCRIPTION
we want to ensure the openjdk role is tested
remove the running on server
we manually create the directory for manuals as a pre-task

related to #5740
