### PR TITLE
[Traefik Wall] Fix redirect for production Catalog.

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -31,6 +31,8 @@ http:
           excludeRoutes: "/catalog/facet,/catalog/range_limit"
     append-catalog-regex:
       redirectRegex:
-        regex: /\?f(.*)
-        replacement: /catalog?f${1}
+        # Matches http://x.x.x.x:yyyy/?f[]=
+        regex: //([^/]*)/\?f(.*)
+        # Converts to http://x.x.x.x:yyyy/catalog?f[]=
+        replacement: //${1}/catalog?f${2}
 {{- end -}}

--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -34,6 +34,8 @@ http:
           logLevel: "DEBUG"
     append-catalog-regex:
       redirectRegex:
+        # Matches http://x.x.x.x:yyyy/?f[]=
         regex: //([^/]*)/\?f(.*)
+        # Converts to http://x.x.x.x:yyyy/catalog?f[]=
         replacement: //${1}/catalog?f${2}
 {{- end -}}

--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -34,6 +34,6 @@ http:
           logLevel: "DEBUG"
     append-catalog-regex:
       redirectRegex:
-        regex: edu/\?f(.*)
-        replacement: edu/catalog?f${1}
+        regex: //([^/]*)/\?f(.*)
+        replacement: //${1}/catalog?f${2}
 {{- end -}}

--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -34,6 +34,6 @@ http:
           logLevel: "DEBUG"
     append-catalog-regex:
       redirectRegex:
-        regex: /\?f(.*)
-        replacement: /catalog?f${1}
+        regex: edu/\?f(.*)
+        replacement: edu/catalog?f${1}
 {{- end -}}

--- a/nomad/traefik-wall/deploy/sites/sites-production.yml
+++ b/nomad/traefik-wall/deploy/sites/sites-production.yml
@@ -7,7 +7,7 @@ http:
         - http
       middlewares:
         - captcha-protect
-        #    - append-catalog-regex
+        - append-catalog-regex
     figgy-production:
       service: figgy-production
       rule: Header(`X-Forwarded-Host`, `figgy.princeton.edu`)


### PR DESCRIPTION
This makes sure we only rewrite `?f[]=` if it's right after the first slash in a path, so it no longer matches on `https://catalog.princeton.edu/catalog/?f[subject_facet][]=Catrysse%2C+Wim+1973-%E2%80%94Exhibitions`