### PR TITLE
[pas] add missing environment variable

### DIFF
--- a/roles/pas/templates/env-craft4.j2
+++ b/roles/pas/templates/env-craft4.j2
@@ -2,6 +2,7 @@ CRAFT_APP_ID="{{ vault_pas_app_id }}"
 
 # The environment Craft is currently running in ('dev', 'staging', 'production', etc.)
 CRAFT_ENVIRONMENT="{{ pas_env | default('staging') }}"
+ENVIRONMENT="{{ pas_env | default('staging') }}"
 
 # The secure key Craft will use for hashing and encrypting data
 CRAFT_SECURITY_KEY="{{ pas_security_key }}"


### PR DESCRIPTION
This addresses the following warning, which fills up the logs at /var/log/apache2/error.log:

```
PHP Warning:  Undefined array key ENVIRONMENT in /opt/pas_cap/releases/20250310191309/bootstrap.php on line 22
```