### PR TITLE
For GCP hosts, use installed python at /usr/bin/python3

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -67,6 +67,7 @@ obsd_httpd_staging
 
 [gcp_staging:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-staging.pulcloud.io"'
+ansible_python_interpreter=/usr/bin/python3
 
 [obsd:children]
 bastion_dev


### PR DESCRIPTION
Explicitly setting the path for python3 should fix the error we've been seeing in Tower:

```
Platform unknown on host gcp_oar_staging1 is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.15/reference_appendices/interpreter_discovery.html for more information.
```