### PR TITLE
[postfix] Remove duplicate .princeton.edu domain when obtaining TLS certificate

### DIFF
--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -66,7 +66,7 @@
   notify: restart postfix
 
 - name: Postfix | update acme certificates for {{ domain_name }}
-  ansible.builtin.command: /usr/bin/certbot certonly --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ domain_name }}.princeton.edu --cert-name {{ domain_name }}
+  ansible.builtin.command: /usr/bin/certbot certonly --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ domain_name }} --cert-name {{ domain_name }}
   changed_when: false
   when: running_on_server
 


### PR DESCRIPTION
In this case, `domain_name` is set to the `inventory_hostname` (lib-ponyexpr-prod.princeton.edu), so appending .princeton.edu leaves us with lib-ponyexpr-prod.princeton.edu.princeton.edu.

Helps with https://github.com/PrincetonUniversityLibrary/pas-craft3/issues/147