### PR TITLE
[DPUL] Add X-Real-IP to DPUL

### DIFF
--- a/roles/nginxplus/files/conf/http/dpul-prod.conf
+++ b/roles/nginxplus/files/conf/http/dpul-prod.conf
@@ -38,6 +38,8 @@ server {
         proxy_pass http://dpul-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_cache dpul-prodcache;
         proxy_intercept_errors on;
         health_check uri=/health.json interval=10 fails=3 passes=2;

--- a/roles/nginxplus/files/conf/http/dpul-staging.conf
+++ b/roles/nginxplus/files/conf/http/dpul-staging.conf
@@ -37,6 +37,8 @@ server {
         proxy_pass http://dpul-staging;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_cache dpul-stagingcache;
         health_check uri=/health.json interval=10 fails=3 passes=2;
     }


### PR DESCRIPTION
This will prevent passenger from filtering out all logs for DPUL.

Necessary work to implement #5948 