### PR TITLE
[Traefik Wall] Add traffic tracking for /advanced route.

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -5,7 +5,7 @@ http:
       plugin:
         captcha-protect:
           # We're only protecting Blacklight apps for now.
-          protectRoutes: /catalog
+          protectRoutes: "/catalog,/advanced"
           captchaProvider: turnstile
           siteKey: "{{ .TURNSTILE_SITE_KEY }}"
           secretKey: "{{ .TURNSTILE_SECRET_KEY }}"

--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -5,7 +5,7 @@ http:
       plugin:
         captcha-protect:
           # We're only protecting Blacklight apps for now.
-          protectRoutes: /catalog
+          protectRoutes: "/catalog,/advanced"
           captchaProvider: turnstile
           siteKey: "{{ .TURNSTILE_SITE_KEY }}"
           secretKey: "{{ .TURNSTILE_SECRET_KEY }}"


### PR DESCRIPTION
The catalog's advanced search is very similar to /cat
alog, and is getting hit in the same way.