### PR TITLE
Restore libweb5-redirects.conf, delete libweb2-redirects.conf

### DIFF
--- a/roles/nginxplus/files/conf/http/templates/libweb2-redirects.conf
+++ b/roles/nginxplus/files/conf/http/templates/libweb2-redirects.conf
@@ -1,1 +1,0 @@
-rewrite http://libweb2.princeton.edu/rbsc2/(.*)$ https://static-prod.lib/princeton.edu/scsites/$request_uri permanent;

--- a/roles/nginxplus/files/conf/http/templates/libweb5-redirects.conf
+++ b/roles/nginxplus/files/conf/http/templates/libweb5-redirects.conf
@@ -1,0 +1,1 @@
+rewrite ^/visual_materials/(.*)$ https://library.princeton.edu$request_uri permanent;


### PR DESCRIPTION
Closes #5967.

In #5368 we deleted the wrong redirect file. We should have deleted the redirects for libweb2; instead we deleted the redirects for libweb5. This PR fixes our mistake.