### PR TITLE
[prancible] add a condition for Rapid7 in security_theater playbook

### DIFF
--- a/playbooks/utils/security_theater.yml
+++ b/playbooks/utils/security_theater.yml
@@ -102,55 +102,58 @@
         ansible.builtin.command: /etc/init.d/besclient start
       #For future maintenance, BigFix block ends here
 
-  - name: Download the Rapid7 deb file (Ubuntu)
-    ansible.builtin.get_url:
-      url: "https://isoshare.cpaneldev.princeton.edu/isoShares/Agents/Rapid7/Latest/Linux/rapid7-insight-agent_{{ rapid7_version }}-1_amd64.deb"
-      dest: "/tmp/rapid7-insight-agent_{{ rapid7_version }}-1_amd64.deb"
-      mode: "0644"
-    when:
-      - ansible_os_family == "Debian"
+  - name: Install, configure, and start Rapid7
+    when: "ansible_facts.services['ir_agent.service'] is not defined"
+    block:
+      - name: Download the Rapid7 deb file (Ubuntu)
+        ansible.builtin.get_url:
+          url: "https://isoshare.cpaneldev.princeton.edu/isoShares/Agents/Rapid7/Latest/Linux/rapid7-insight-agent_{{ rapid7_version }}-1_amd64.deb"
+          dest: "/tmp/rapid7-insight-agent_{{ rapid7_version }}-1_amd64.deb"
+          mode: "0644"
+        when:
+          - ansible_os_family == "Debian"
 
-  - name: Download the Rapid7 rpm file (RedHat)
-    ansible.builtin.get_url:
-      url: "https://isoshare.cpaneldev.princeton.edu/isoShares/Agents/Rapid7/Latest/Linux/rapid7-insight-agent-{{ rapid7_version }}-1.x86_64.rpm"
-      dest: "/tmp/rapid7-insight-agent-{{ rapid7_version }}-1.x86_64.rpm"
-      mode: "0644"
-    when:
-      - ansible_os_family == "RedHat"
+      - name: Download the Rapid7 rpm file (RedHat)
+        ansible.builtin.get_url:
+          url: "https://isoshare.cpaneldev.princeton.edu/isoShares/Agents/Rapid7/Latest/Linux/rapid7-insight-agent-{{ rapid7_version }}-1.x86_64.rpm"
+          dest: "/tmp/rapid7-insight-agent-{{ rapid7_version }}-1.x86_64.rpm"
+          mode: "0644"
+        when:
+          - ansible_os_family == "RedHat"
 
-  - name: install Rapid7 agent (Ubuntu)
-    ansible.builtin.apt:
-      deb: "/tmp/rapid7-insight-agent_{{ rapid7_version }}-1_amd64.deb"
-    become: true
-    when:
-      - ansible_os_family == "Debian"
+      - name: install Rapid7 agent (Ubuntu)
+        ansible.builtin.apt:
+          deb: "/tmp/rapid7-insight-agent_{{ rapid7_version }}-1_amd64.deb"
+        become: true
+        when:
+          - ansible_os_family == "Debian"
 
-  - name: Verify GPG signature (RedHat)
-    ansible.builtin.rpm_key:
-      state: present
-      key: https://us.storage.endpoint.ingress.rapid7.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/Rapid7_public_key.pub
-    become: true
-    when:
-      - ansible_os_family == "RedHat"
+      - name: Verify GPG signature (RedHat)
+        ansible.builtin.rpm_key:
+          state: present
+          key: https://us.storage.endpoint.ingress.rapid7.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/Rapid7_public_key.pub
+        become: true
+        when:
+          - ansible_os_family == "RedHat"
 
-  - name: install Rapid7 agent (RedHat)
-    ansible.builtin.yum:
-      name: "/tmp/rapid7-insight-agent-{{ rapid7_version }}-1.x86_64.rpm"
-      state: present
-    become: true
-    when:
-      - ansible_os_family == "RedHat"
+      - name: install Rapid7 agent (RedHat)
+        ansible.builtin.yum:
+          name: "/tmp/rapid7-insight-agent-{{ rapid7_version }}-1.x86_64.rpm"
+          state: present
+        become: true
+        when:
+          - ansible_os_family == "RedHat"
 
-  - name: Configure the agent with token
-    ansible.builtin.shell:
-      /opt/rapid7/ir_agent/components/insight_agent/{{ rapid7_version }}/configure_agent.sh --token {{ vault_Rapid7_token }} --attributes="Library Systems"
-    become: true
+      - name: Configure the agent with token
+        ansible.builtin.shell:
+          /opt/rapid7/ir_agent/components/insight_agent/{{ rapid7_version }}/configure_agent.sh --token {{ vault_Rapid7_token }} --attributes="Library Systems"
+        become: true
 
-  - name: Restart or start rapid7
-    ansible.builtin.service:
-      name: ir_agent
-      state: restarted
-    become: true
+      - name: Restart or start rapid7
+        ansible.builtin.service:
+          name: ir_agent
+          state: restarted
+        become: true
 
   # post_tasks:
   #   - name: send information to slack


### PR DESCRIPTION
Unlike the other tools in the `security_theater` playbook, Rapid7 did not have an initial task to `Install, configure, and start [the service]` before proceeding to download the .deb file. This was causing the playbook to fail on the Rapid7 task to install the agent when Rapid7 was already on a machine, since it detected the deb file on the machine and failed to configure the agent. The task we added allows for a check of the Rapid7 service first before installing the file, and if it is already installed, it will skip the task to download the .deb file and will proceed to update to the latest version of the agent if it's already there. 