### PR TITLE
Add a reminder about revoking old certs

### DIFF
--- a/playbooks/postfix.yml
+++ b/playbooks/postfix.yml
@@ -16,6 +16,12 @@
     - role: roles/postfix
 
   post_tasks:
+    - name: Remind ops to revoke the old acme certificates
+      community.general.slack:
+        token: "{{ vault_tower_slack_token }}"
+        msg: "@ops Ansible just rebuilt a Postfix server and updated the ACME certificate for `{{ domain_name }}` - go revoke the old one }}"
+        channel: "ansible-alerts"
+
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -70,12 +70,6 @@
   changed_when: false
   when: running_on_server
 
-- name: Postfix | Remind ops to revoke the old acme certificates
-  community.general.slack:
-    token: "{{ vault_tower_slack_token }}"
-    msg: "@ops Ansible just updated the ACME certificate for `{{ domain_name }}` - go revoke the old one }}"
-    channel: "ansible-alerts"
-
 - name: Postfix | Configure TLS in main.cf
   ansible.builtin.blockinfile:
     path: "{{ postfix_main_cf }}"

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -70,6 +70,12 @@
   changed_when: false
   when: running_on_server
 
+- name: Postfix | Remind ops to revoke the old acme certificates
+  community.general.slack:
+    token: "{{ vault_tower_slack_token }}"
+    msg: "@ops Ansible just updated the ACME certificate for `{{ domain_name }}` - go revoke the old one }}"
+    channel: "ansible-alerts"
+
 - name: Postfix | Configure TLS in main.cf
   ansible.builtin.blockinfile:
     path: "{{ postfix_main_cf }}"


### PR DESCRIPTION
The mail servers host their own SSL certificates. They auto-renew, so we don't normally interact with them much. However, when we rebuild a mail server using the postfix role, we create fresh certificates. When we do that, we need to revoke the previous certificates, or they will propagate endlessly. This PR adds a reminder to slack to the tasks file for the postfix role. 