### PR TITLE
move bibdata to the private network

### DIFF
--- a/group_vars/nfsserver/qa.yml
+++ b/group_vars/nfsserver/qa.yml
@@ -1,6 +1,6 @@
 ---
 # servers
-bibdata_qa1: "128.112.204.65"
+bibdata_qa1: "172.20.80.89"
 bibdata_qa2: "128.112.204.57"
 bibdata_worker_qa1: "128.112.204.68"
 bibdata_worker_qa2: "128.112.204.95"


### PR DESCRIPTION
move the bibdata-qa1 to the private network. This allows us to see if the reduce the noise from failing cifs mounts from checkmk

related to #5988