### PR TITLE
Expand GitLab API call to pull up to 100 open tickets to Airtable

### DIFF
--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: call issue API
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/issues?scope=all&project_id=5&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/issues?scope=all&project_id=5&per_page=100&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
       register: api_output

--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: call issue API
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/issues?scope=all&project_id=5&per_page=100&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/issues?scope=all&project_id=5&per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
       register: api_output


### PR DESCRIPTION
Our GitLab API call was not pulling all our tickets into Airtable. The limitation turned out to be [pagination](https://docs.gitlab.com/api/issues/#issues-pagination) - by default API calls are limited to 20 per page.

This PR sets `per_page` to `100` and also limits by `state=opened`. This enables the GitLab-Airtable connection to work as long as the number of open tickets stays under 100 per repo in GitLab.

If we need more, we can first pull the number of pages using the `x-total-pages` parameter. See [this forum post](https://forum.gitlab.com/t/rest-api-seems-to-only-return-the-first-20-resource-label-events-for-the-issue/63268).