### PR TITLE
[bibdata] move to private network

### DIFF
--- a/group_vars/nfsserver/qa.yml
+++ b/group_vars/nfsserver/qa.yml
@@ -1,7 +1,7 @@
 ---
 # servers
 bibdata_qa1: "172.20.80.89"
-bibdata_qa2: "128.112.204.57"
+bibdata_qa2: "172.20.80.97"
 bibdata_worker_qa1: "128.112.204.68"
 bibdata_worker_qa2: "128.112.204.95"
 tigerdata_qa1: "128.112.204.128"


### PR DESCRIPTION
to reduce the noise from cifs mounts we move bibdata-qa2 to the private
network

related to #5988
