### PR TITLE
Supports agent installs in the paid version of CheckMK

### DIFF
--- a/group_vars/checkmk/agent_common.yml
+++ b/group_vars/checkmk/agent_common.yml
@@ -1,6 +1,7 @@
 ---
 checkmk_agent_version: "2.3.0p15"
 checkmk_agent_edition: cee
+checkmk_agent_add_host: 'true'
 checkmk_agent_server_protocol: http
 checkmk_agent_server: pulmonitor-staging1.princeton.edu
 checkmk_agent_server_port: "{% if checkmk_agent_server_protocol == 'https' %}443{% else %}80{% endif %}"

--- a/group_vars/checkmk/agent_remote.yml
+++ b/group_vars/checkmk/agent_remote.yml
@@ -4,7 +4,7 @@ checkmk_agent_edition: cee
 checkmk_agent_server_protocol: http
 checkmk_agent_server: pulmonitor-staging2.princeton.edu
 checkmk_agent_server_port: "{% if checkmk_agent_server_protocol == 'https' %}443{% else %}80{% endif %}"
-checkmk_agent_site: "staging"
+checkmk_agent_site: "{{ runtime_env | default('staging') }}"
 checkmk_agent_registration_server: "{{ checkmk_agent_server }}"
 checkmk_agent_user: "automation"
 checkmk_agent_secret: "{{ vault_automation_secret }}"

--- a/playbooks/utils/checkmk_agent.yml
+++ b/playbooks/utils/checkmk_agent.yml
@@ -24,4 +24,3 @@
 
   roles:
     - role: roles/checkmk_agent
-


### PR DESCRIPTION
Partially addresses #5959.

When we looked at the errors with running the agent playbook, we discovered that the playbook ran successfully if we first manually added the `host` record on the CheckMK site where we wanted the host to be monitored. The first commit on this branch recreates that fix by adding a variable value allowing hosts to be created. I confirmed this by adding my sandbox to the `production` CheckMK site using the `checkmk_agent.yml` playbook: 
`ansible-playbook -e runtime_env=sandbox -e checkmk_agent_site=production -e checkmk_folder=linux/ops playbooks/utils/checkmk_agent.yml --limit sandbox-acozine.lib.princeton.edu`

**Remaining work:**

- Originally we were using `runtime_env` to manage the host group(s) and the checkmk vars - for example, run the playbook against `bibdata_staging` and register the agent on those VMs with the `staging` CheckMK site. I'm not sure that works well in our new distributed environment. There's probably a better way to do this.
- The group_vars also need to be updated for the new distributed environment - the `checkmk_agent_site` (the last bit of the URL, as in pulmonitor-staging.princeton.edu/production) and the `checkmk_agent_server` (the VM where that 'site' is managed) need to match now that we have separate VMs for each site.
- Also, I think the playbook for adding rules is still broken. At least, I haven't tested it, and I can't see how this would fix it. 