### PR TITLE
[pas] move to private network

### DIFF
--- a/group_vars/nfsserver/production.yml
+++ b/group_vars/nfsserver/production.yml
@@ -22,7 +22,7 @@ lib_jobs_prod1: "172.20.80.96"
 lib_jobs_prod2: "172.20.80.102"
 pdc_describe_prod1: "128.112.204.79"
 pdc_describe_prod2: "128.112.204.80"
-slavery_prod1: "128.112.203.125"
+slavery_prod1: "172.20.80.104"
 tigerdata_prod1: "128.112.202.20"
 tigerdata_prod2: "128.112.202.24"
 # mounts

--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -112,9 +112,6 @@ postfix_relay_hosts_addresses:
   - lib-vmsan-spb.princeton.edu
   - lib-vmtest01.princeton.edu
   - lib-vr-prod1.princeton.edu
-  - library-prod1.princeton.edu
-  - library-prod3.princeton.edu
-  - library-prod4.princeton.edu
   - lockers-and-study-spaces-prod2.princeton.edu
   - lockers-and-study-spaces-prod1.princeton.edu
   - maps-prod1.princeton.edu


### PR DESCRIPTION
add the new IP to our NFS exports

this is to reduce the CIFS alerts
remove library servers from postfix allow list

related to #5988
