### PR TITLE
[adc] fix logrotate

### DIFF
--- a/roles/nginxplus/tasks/localhost.yml
+++ b/roles/nginxplus/tasks/localhost.yml
@@ -26,10 +26,10 @@
 
 - name: Nginxplus | add app_protect logrotate
   ansible.builtin.template:
-    src: logrotate.d.app_protect.j2 
-    dest: /etc/logrotate.d/app_protect
+    src: logrotate.d.app_protect.j2
+    dest: /etc/logrotate.d/app_protect.conf
     mode: "0644"
-    owner: root  
+    owner: root
     group: root
   when: running_on_server
 


### PR DESCRIPTION
we didn't catch that upstream had a logrotate (it wasn't working)
we add our config to prevent future updates from upstream breaking
logrotate

closes #6006
