### PR TITLE
[bibdata] move to private network

### DIFF
--- a/group_vars/nfsserver/qa.yml
+++ b/group_vars/nfsserver/qa.yml
@@ -2,7 +2,7 @@
 # servers
 bibdata_qa1: "172.20.80.89"
 bibdata_qa2: "172.20.80.97"
-bibdata_worker_qa1: "128.112.204.68"
+bibdata_worker_qa1: "172.20.80.105"
 bibdata_worker_qa2: "128.112.204.95"
 tigerdata_qa1: "128.112.204.128"
 tigerdata_qa2: "128.112.204.130"


### PR DESCRIPTION
we are moving all hosts to the private network to reduce the CIFS mounts
noise from our monitoring

related to #5988
