### PR TITLE
[figgy] move worker-prod4 to private network

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -68,9 +68,10 @@ figgy_derivatives_mount: '/mnt/libimages2/data/jp2s/figgy_prod'
 figgy_ezid_shoulder: '{{vault_figgy_ezid_shoulder}}'
 figgy_ezid_username: '{{vault_figgy_ezid_username}}'
 figgy_ezid_password: '{{vault_figgy_ezid_password}}'
-figgy_rabbit_user: '{{vault_rabbit_production_user}}'
 figgy_rabbit_password: '{{vault_rabbit_production_password}}'
-figgy_rabbit_server: 'amqp://{{figgy_rabbit_user}}:{{figgy_rabbit_password}}@{{figgy_rabbit_host}}:5672'figgy_solr_name: figgy-production
+figgy_rabbit_server: 'amqp://{{figgy_rabbit_user}}:{{figgy_rabbit_password}}@{{figgy_rabbit_host}}:5672'
+figgy_solr_name: figgy-production
+figgy_rabbit_user: '{{vault_rabbit_production_user}}'
 figgy_host_name: 'figgy.princeton.edu'
 figgy_solr_url: 'http://lib-solr8-prod.princeton.edu:{{solr_port}}/solr/{{figgy_solr_name}}'
 imagemagick_max_memory: '8GiB'


### PR DESCRIPTION
we are moving the worker boxes to the private network to reduce the
CIFS noise on CheckMK.
Running the playbook to add the VM to the db server failed until this
change

related to #5988
