### PR TITLE
[bibdata] move to private network

### DIFF
--- a/group_vars/nfsserver/qa.yml
+++ b/group_vars/nfsserver/qa.yml
@@ -3,7 +3,7 @@
 bibdata_qa1: "172.20.80.89"
 bibdata_qa2: "172.20.80.97"
 bibdata_worker_qa1: "172.20.80.105"
-bibdata_worker_qa2: "128.112.204.95"
+bibdata_worker_qa2: "172.20.80.108"
 tigerdata_qa1: "128.112.204.128"
 tigerdata_qa2: "128.112.204.130"
 # mounts


### PR DESCRIPTION
we reduce the noise from CIFS mounts dropping connections by moving them
to the private network

related to #5988
