### PR TITLE
[Bibdata] Add Prometheus to Bibdata QA / DPUL Staging

### DIFF
--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -134,3 +134,12 @@ postgres_admin_user: "{{ db_clusteradmin_user }}"
 postgres_admin_password: "{{ db_clusteradmin_password }}"
 postgresql_is_local: false
 timezone: "America/New_York"
+metrics_basic_password: '{{vault_metrics_basic_password}}'
+node_exporter_basic_auth_users:
+  metrics_user: '{{metrics_basic_password}}'
+node_exporter_enabled_collectors:
+  - "systemd"
+  - textfile:
+      directory: "{{ node_exporter_textfile_dir }}"
+  - "processes"
+  - "mountstats"

--- a/group_vars/dpul/staging.yml
+++ b/group_vars/dpul/staging.yml
@@ -101,3 +101,12 @@ redis__server_default_configuration:
   maxmemory: "{{ redis__server_maxmemory }}"
   maxmemory-policy: "{{ redis__server_maxmemory_policy }}"
   maxmemory-samples: "{{ redis__server_maxmemory_samples }}"
+metrics_basic_password: '{{vault_metrics_basic_password}}'
+node_exporter_basic_auth_users:
+  metrics_user: '{{metrics_basic_password}}'
+node_exporter_enabled_collectors:
+  - "systemd"
+  - textfile:
+      directory: "{{ node_exporter_textfile_dir }}"
+  - "processes"
+  - "mountstats"

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -42,9 +42,11 @@
     - role: hr_share
     - role: datadog
       when: runtime_env | default('staging') == "production"
-  post_tasks:
-    - name: tell everyone on slack you ran an ansible playbook
-      community.general.slack:
-        token: "{{ vault_pul_slack_token }}"
-        msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: "{{ slack_alerts_channel }}"
+    - role: prometheus.prometheus.node_exporter
+      when: runtime_env | default('staging') == "qa"
+  # post_tasks:
+  #   - name: tell everyone on slack you ran an ansible playbook
+  #     community.general.slack:
+  #       token: "{{ vault_pul_slack_token }}"
+  #       msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
+  #       channel: "{{ slack_alerts_channel }}"

--- a/playbooks/dpul.yml
+++ b/playbooks/dpul.yml
@@ -14,6 +14,8 @@
     - role: roles/dpul
     - role: roles/datadog
       when: runtime_env | default('staging') == "production"
+    - role: prometheus.prometheus.node_exporter
+      when: runtime_env | default('staging') == "staging"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook


### PR DESCRIPTION
We need a service that connected to one of our NFS shares to compare
performance and rule out networking issues. This seemed lowest impact.
