### PR TITLE
[Traefik Wall] Add collector systems to exempt IPs.

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -28,6 +28,9 @@ http:
             - 66.180.176.0/24
             - 66.180.177.0/24
             - 66.180.180.0/22
+            # Collector Systems
+            - 57.151.79.172/32
+            - 57.151.79.127/32
           challengeTmpl: /challenge.tmpl.html
           # Exclude facet routes - they're an ajax request.
           excludeRoutes: "/catalog/facet,/catalog/range_limit"

--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -30,6 +30,9 @@ http:
             - 66.180.176.0/24
             - 66.180.177.0/24
             - 66.180.180.0/22
+            # Collector Systems
+            - 57.151.79.172/32
+            - 57.151.79.127/32
           challengeTmpl: /challenge.tmpl.html
           # Exclude facet routes - they're an ajax request.
           excludeRoutes: "/catalog/facet,/catalog/range_limit"


### PR DESCRIPTION
Collector systems needs to be able to query Figgy catalog URLs with parameters - these are their IPs, they should be let through the bot wall.