### PR TITLE
Restore nginx conf files for getit redirects

### DIFF
--- a/roles/nginxplus/files/conf/http/getit_dev.conf
+++ b/roles/nginxplus/files/conf/http/getit_dev.conf
@@ -1,0 +1,8 @@
+# Ansible managed
+server {
+    listen 80;
+    server_name getit-dev.princeton.edu;
+
+    rewrite ^/resolve(.*)$ https://princeton.alma.exlibrisgroup.com/discovery/openurl?institution=01PRI_INST&vid=01PRI_INST:Services&$1 permanent;
+    rewrite ^/(.*)$ https://catalog-qa.princeton.edu/?f%5Baccess_facet%5D%5B%5D=Online&f%5Bformat%5D%5B%5D=Journal permanent;
+}

--- a/roles/nginxplus/files/conf/http/getit_prod.conf
+++ b/roles/nginxplus/files/conf/http/getit_prod.conf
@@ -1,0 +1,8 @@
+# Ansible managed
+server {
+    listen 80;
+    server_name getit.princeton.edu;
+
+    rewrite ^/resolve(.*)$ https://princeton.alma.exlibrisgroup.com/discovery/openurl?institution=01PRI_INST&vid=01PRI_INST:Services&$1 permanent;
+    rewrite ^/(.*)$ https://catalog.princeton.edu/?f%5Baccess_facet%5D%5B%5D=Online&f%5Bformat%5D%5B%5D=Journal permanent;
+}


### PR DESCRIPTION
A vendor still has getit.princeton.edu for our URL and this redirect needs to stay in place until they update to the current Alma location