### PR TITLE
add canary host to inventory

### DIFF
--- a/inventory/all_projects/checkmk
+++ b/inventory/all_projects/checkmk
@@ -1,4 +1,5 @@
 [pulcheck_production]
+canary1.lib.princeton.edu
 pulcheck-prod1.princeton.edu
 [pulcheck_staging]
 pulmonitor-staging1.princeton.edu


### PR DESCRIPTION
our canary host was not getting patched. This adds the host to the pulcheck group so it will get patched on Tuesdays