### PR TITLE
[orangelight] remove deploy user file owner ship

### DIFF
--- a/roles/orangelight/tasks/main.yml
+++ b/roles/orangelight/tasks/main.yml
@@ -53,7 +53,7 @@
     group: deploy
     state: touch
   become: true
-  when: sneakers_log_file_stat.stat.exists and (sneakers_log_file_stat.stat.owner != "deploy" or sneakers_log_file_stat.stat.group != "deploy")
+  when: sneakers_log_file_stat.stat.exists
   register: sneakers_log_file_changed
 
 - name: Orangelight | enable and start sneakers service


### PR DESCRIPTION
theres a discrepancy with file ownership for brownfield hosts with will sometimes have root own the files

followup work on #6042 