### PR TITLE
[bibdata] add prometheus collection

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -58,6 +58,7 @@ ansible-creator = "*"
 netaddr = "*"
 passlib = "*"
 bcrypt = "*"
+ansible-builder = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c2c1892baa24341294114ac003c5ee787180c1b05e9eaba5fdd6635daddd4168"
+            "sha256": "047200cd7ddace0cc7bd62923e1f3128ac0a80bd3a4ef8a22a09dd79c8cd7129"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,6 +25,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==9.1.0"
+        },
+        "ansible-builder": {
+            "hashes": [
+                "sha256:d2dc573e26a7bd5095e98aeb37ee9b00bc9f5005abea7147d74229c0f3426fcb",
+                "sha256:ed4a6717dd466c2fc2cbdd7c9a9b5323260275a13fcf20cf6fe9a807f8c8ad3f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.0"
         },
         "ansible-compat": {
             "hashes": [
@@ -128,6 +137,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==4.3.0"
+        },
+        "bindep": {
+            "hashes": [
+                "sha256:c0e6cc626be2cc84f447fbaaa9d4b6cfbd92b11e8738d29d7a15df2d07fb45de",
+                "sha256:df7564753e583033bb113338150d772540145b4d189a4801ec56a25b5ede5050"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.13.0"
         },
         "black": {
             "hashes": [
@@ -404,6 +421,14 @@
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
             "version": "==44.0.1"
         },
+        "distro": {
+            "hashes": [
+                "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed",
+                "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.9.0"
+        },
         "dnspython": {
             "hashes": [
                 "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50",
@@ -635,6 +660,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==23.2"
         },
+        "parsley": {
+            "hashes": [
+                "sha256:9444278d47161d5f2be76a767809a3cbe6db4db822f46a4fd7481d4057208d41",
+                "sha256:c3bc417b8c7e3a96c87c0f2f751bfd784ed5156ffccebe2f84330df5685f8dc3"
+            ],
+            "version": "==1.3"
+        },
         "passlib": {
             "hashes": [
                 "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1",
@@ -651,6 +683,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==0.12.1"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:38d4daea5d9fa63b3f626131b9d34947fd0c8be9b05a29276870580050a25a76",
+                "sha256:93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b"
+            ],
+            "markers": "python_version >= '2.6'",
+            "version": "==6.1.1"
         },
         "platformdirs": {
             "hashes": [
@@ -954,6 +994,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.11.4"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54",
+                "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==78.1.0"
         },
         "six": {
             "hashes": [

--- a/tower_ees/execution-environment.yml
+++ b/tower_ees/execution-environment.yml
@@ -55,6 +55,8 @@ dependencies:
         version: 2.19.1
       - name: checkmk.general
         version: 4.3.1
+      - name: prometheus.prometheus
+        version: 0.26.1
 
   # python packages, stuff you install with 'pip install'
   python:


### PR DESCRIPTION
we have roles that pull directly from ansible galaxy to install
prometheus. this change allows playbooks to successfully run from
Ansible Tower when the new execution environment is rebuilt

closes #6047

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
