### PR TITLE
[videoreserves] Install needed php modules for PHP 8.4

### DIFF
--- a/group_vars/video_reserves/production.yml
+++ b/group_vars/video_reserves/production.yml
@@ -1,4 +1,4 @@
 ---
-php_version: "8.3"
+php_version: "8.4"
 video_reserves_cert_path: "/etc/apache2/ssl/certs/{{ inventory_hostname }}_chained.pem"
 video_reserves_domain_name: "videoreserves-prod.princeton.edu"

--- a/group_vars/video_reserves/staging.yml
+++ b/group_vars/video_reserves/staging.yml
@@ -1,5 +1,5 @@
 ---
-php_version: "8.3"
+php_version: "8.4"
 
 video_reserves_cert_path: "/etc/apache2/ssl/certs/{{ inventory_hostname }}_chained.pem"
 video_reserves_domain_name: "videoreserves-staging.princeton.edu"

--- a/roles/video_reserves/tasks/main.yml
+++ b/roles/video_reserves/tasks/main.yml
@@ -6,6 +6,8 @@
   notify: restart apache2
   loop:
     - libapache2-mod-php{{ php_version }}
+    - php{{ php_version }}-curl
+    - php{{ php_version }}-mbstring
 
 - name: video_reserves | create directories for shared files
   ansible.builtin.file:


### PR DESCRIPTION
Ansible thought we were using PHP 8.3, but the staging and prod servers were using 8.4 instead, and missing some needed php modules.

Closes https://github.com/PrincetonUniversityLibrary/video_reserves/issues/92