### PR TITLE
[lib-jobs] Don't install node

### DIFF
--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -12,7 +12,7 @@ application_db_name: '{{ app_db_name }}'
 application_dbuser_name: '{{ app_db_user }}'
 application_dbuser_password: '{{ app_db_password }}'
 application_host_protocol: 'https'
-desired_nodejs_version: v18.19.1
+install_nodejs: false
 postgresql_is_local: false
 open_marc_records_directory: 'open_marc_records'
 install_ruby_from_source: true


### PR DESCRIPTION
As of https://github.com/pulibrary/lib_jobs/pull/907, it is no longer needed.

Helps with https://github.com/pulibrary/lib_jobs/issues/896

I ran this on staging, and also manually removed the node and yarn binaries from the staging boxes.