### PR TITLE
[Figgy] Update ILL OCR mount name.

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -162,9 +162,9 @@ rails_app_vars:
   - name: OCR_OUT_PATH
     value: '/mnt/illiad/images'
   - name: OCR_ILLIAD_IN_PATH
-    value: '/mnt/hosted_illiad/ILL_OCR_Scans/ocr_scan'
+    value: '/mnt/hosted_illiad/RequestScans/ocr_scan'
   - name: OCR_ILLIAD_OUT_PATH
-    value: '/mnt/hosted_illiad/ILL_OCR_Scans/images'
+    value: '/mnt/hosted_illiad/RequestScans/images'
   - name: CDL_IN_PATH
     value: '/mnt/illiad/cdl_scans/figgy_ingest'
   - name: ASPACE_URL

--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -100,7 +100,7 @@ rails_app_vars:
   - name: OCR_ILLIAD_IN_PATH
     value: '/opt/figgy/current/tmp/ocr_in'
   - name: OCR_ILLIAD_OUT_PATH
-    value: '/mnt/hosted_illiad/ILL_OCR_Scans/images'
+    value: '/mnt/hosted_illiad/RequestScans/images'
   - name: CDL_IN_PATH
     value: '/opt/figgy/current/tmp/cdl_in'
   - name: ASPACE_URL

--- a/roles/figgy/tasks/main.yml
+++ b/roles/figgy/tasks/main.yml
@@ -28,7 +28,7 @@
     - 'illiad/ocr_scan'
     - 'illiad/cdl_scans'
     - 'hosted_illiad'
-    - 'hosted_illiad/ILL_OCR_Scans'
+    - 'hosted_illiad/RequestScans'
 
 - name: figgy | Copy smb credentials
   ansible.builtin.copy:
@@ -167,7 +167,7 @@
   tags: 'mounts'
   when: running_on_server
   loop:
-    - ILL_OCR_Scans
+    - RequestScans
 
 ## Symlink to Mounts
 - name: figgy | Create symlinks


### PR DESCRIPTION
They liked this name better.

This has been run, and the old mounts removed with
`ansible figgy_staging -u pulsys -become -m ansible.posix.mount -a "name=/mnt/hosted_illiad/ILL_OCR_Scans state=absent"`

(same with prod)

Work for pulibrary/figgy#6412