### PR TITLE
[DSS] Use latest node version 24.x

### DIFF
--- a/group_vars/dss/common.yml
+++ b/group_vars/dss/common.yml
@@ -1,5 +1,5 @@
 ---
-desired_nodejs_version: "v20.11.1"
+desired_nodejs_version: "v24.0.0"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.3.6"
 ruby_yjit: true


### PR DESCRIPTION
closes https://github.com/pulibrary/DSS/issues/530

use latest node version 24.x
Release comes out on [4/22/2025](https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule)

See also https://github.com/pulibrary/DSS/pull/553 