### PR TITLE
[nginxplus] monitor logs

### DIFF
--- a/playbooks/utils/checkmk_add_logsize_check.yml
+++ b/playbooks/utils/checkmk_add_logsize_check.yml
@@ -1,0 +1,64 @@
+---
+- name: Deploy Checkmk local check for app_protect log size with Slack webhook
+  hosts: nginxplus_{{ runtime_env | default('staging') }}
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../group_vars/all/vault.yml
+
+  vars:
+    checkmk_local_check_path: /usr/lib/check_mk_agent/local/90-app-protect-logsize
+    app_protect_log_file: /var/log/app_protect/security.log
+    app_protect_log_max_mb: 2048  # 2GB threshold during tests
+    slack_alerts_channel: "#sensu-alerts"
+    alert_script_log_path: /tmp/app_protect_log_alerted.flag  # Prevent repeat alerts
+    slack_webhook_url: "https://hooks.slack.com/services/{{ vault_pul_slack_token }}"
+
+  tasks:
+    - name: Ensure Checkmk local plugin directory exists
+      ansible.builtin.file:
+        path: "{{ checkmk_local_check_path | dirname }}"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Deploy App Protect log size check script with Slack webhook
+      ansible.builtin.copy:
+        dest: "{{ checkmk_local_check_path }}"
+        owner: root
+        group: root
+        mode: '0755'
+        content: |
+          #!/bin/bash
+          LOG_FILE="{{ app_protect_log_file }}"
+          MAX_MB={{ app_protect_log_max_mb }}
+          ALERT_FLAG="{{ alert_script_log_path }}"
+          HOST=$(hostname)
+          WEBHOOK="{{ slack_webhook_url }}"
+          CHANNEL="{{ slack_alerts_channel }}"
+
+          if [ -f "$LOG_FILE" ]; then
+            FILE_SIZE_MB=$(du -m "$LOG_FILE" | cut -f1)
+            if [ "$FILE_SIZE_MB" -ge "$MAX_MB" ]; then
+              echo "0 app_protect_securitylog - CRITICAL - Log size ${FILE_SIZE_MB}MB exceeds ${MAX_MB}MB"
+
+              if [ ! -f "$ALERT_FLAG" ]; then
+                echo "alerted" > "$ALERT_FLAG"
+                logger -t checkmk-local "AppProtect log size exceeded on $HOST"
+
+                curl -X POST -H 'Content-type: application/json' --data "{
+                  \"channel\": \"${CHANNEL}\",
+                  \"username\": \"checkmk-alert\",
+                  \"text\": \":rotating_light: *App Protect log too large on ${HOST}*: \`security.log\` is using *${FILE_SIZE_MB}MB*.\",
+                  \"icon_emoji\": \":warning:\"
+                }" "$WEBHOOK" > /dev/null 2>&1
+              fi
+            else
+              echo "0 app_protect_securitylog - OK - Log size ${FILE_SIZE_MB}MB"
+              rm -f "$ALERT_FLAG"
+            fi
+          else
+            echo "0 app_protect_securitylog - UNKNOWN - Log file not found"
+          fi
+


### PR DESCRIPTION
we get a warning from datadog when the disk is about to fill up.
This playbook installs a checkmk local check and warns us with a
parametrized size of the security log is too large
we can then force a logrotate.
This will eventually be obsolete by better logroation

related to #6075 
