### PR TITLE
Add second pas prod server back.

### DIFF
--- a/roles/nginxplus/files/conf/http/slavery-prod.conf
+++ b/roles/nginxplus/files/conf/http/slavery-prod.conf
@@ -12,7 +12,7 @@ limit_req_zone $external_traffic zone=slavery-prod-ratelimit:10m rate=10r/s;
 upstream slavery-prod {
     zone slavery-prod 64k;
     server slavery-prod1.princeton.edu resolve;
-    # server slavery-prod2.princeton.edu resolve;
+    server slavery-prod2.princeton.edu resolve;
     sticky learn
           create=$upstream_cookie_slavery-prodcookie
           lookup=$cookie_slavery-prodcookie


### PR DESCRIPTION
The server exists and the app has been successfully deployed to it via the cap task defined in the application config. 