### PR TITLE
Remove default DNS servers from dnsmasq

### DIFF
--- a/group_vars/nomad_cluster.yml
+++ b/group_vars/nomad_cluster.yml
@@ -10,6 +10,8 @@ consul_acl_replication_token: "{{ vault_consul_acl_replication_token }}"
 consul_acl_default_policy: deny
 consul_dns_token: "{{ vault_consul_dns_token }}"
 consul_raw_key: "{{ vault_consul_raw_key }}"
+# Unset dnsmasq servers so it pulls it from DNS.
+consul_dnsmasq_servers: []
 nomad_use_consul: true
 nomad_version: 1.9.6
 nomad_raft_protocol: 3

--- a/roles/ansible-consul/tasks/main.yml
+++ b/roles/ansible-consul/tasks/main.yml
@@ -52,6 +52,7 @@
   ansible.builtin.include_tasks:
     file: nix.yml
   when: ansible_os_family != 'Windows'
+  tags: always
 
 # -----------------------------------------------------------------------
 # Tasks for Windows

--- a/roles/ansible-consul/tasks/nix.yml
+++ b/roles/ansible-consul/tasks/nix.yml
@@ -347,3 +347,4 @@
   ansible.builtin.include_tasks:
     file: ../tasks/dnsmasq.yml
   when: consul_dnsmasq_enable | bool
+  tags: dnsmasq

--- a/roles/pul_nomad/tasks/main.yml
+++ b/roles/pul_nomad/tasks/main.yml
@@ -4,7 +4,9 @@
   ansible.builtin.include_role:
     name: 'ansible-consul'
     public: true
-  tags: consul_acl
+  tags:
+    - consul_acl
+    - dnsmasq
 
 # Set up a runner host
 - name: 'pul_nomad | register a host to run unique commands'


### PR DESCRIPTION
On Nomad, DNS was falling down to 8.8.8.8. We want it to pull from whatever DNS gave the machine, which is the PUL nameservers.

This was causing propagation of internal IPs to take ~8 hours.