### PR TITLE
[Nomad] Explicitly use Princeton DNS servers.

### DIFF
--- a/group_vars/nomad_cluster.yml
+++ b/group_vars/nomad_cluster.yml
@@ -10,8 +10,11 @@ consul_acl_replication_token: "{{ vault_consul_acl_replication_token }}"
 consul_acl_default_policy: deny
 consul_dns_token: "{{ vault_consul_dns_token }}"
 consul_raw_key: "{{ vault_consul_raw_key }}"
-# Unset dnsmasq servers so it pulls it from DNS.
-consul_dnsmasq_servers: []
+# Set to Princeton DNS servers.
+consul_dnsmasq_servers:
+  - 128.112.129.209
+  - 128.112.129.7
+  - 128.112.129.50
 nomad_use_consul: true
 nomad_version: 1.9.6
 nomad_raft_protocol: 3


### PR DESCRIPTION
Having none was working for the Rocky clients, but Ubuntu didn't have NetworkManager setup, so it doesn't update `/etc/resolv.conf`, so the Nomad hosts were failing to get nameservers from DHCP and thus couldn't contact outside the network.