### PR TITLE
[bibdata] Install clang

### DIFF
--- a/roles/bibdata/tasks/main.yml
+++ b/roles/bibdata/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: bibdata | Install dependencies
   ansible.builtin.apt:
-    name: ["nfs-common", "cifs-utils", "python3-psycopg2"]
+    name: ["nfs-common", "cifs-utils", "python3-psycopg2", "clang"]
     state: present
 
 - name: bibdata | include tasks to mount disks


### PR DESCRIPTION
Our library_standard_numbers gem depends on a rust crate named rb-sys, which depends on clang.

See https://ansible-tower.princeton.edu/#/jobs/playbook/18192/output

This is a prerequisite to https://github.com/pulibrary/bibdata/pull/2698