### PR TITLE
[Datadog] Remove staging and low impact hosts

### DIFF
--- a/playbooks/approvals.yml
+++ b/playbooks/approvals.yml
@@ -15,8 +15,6 @@
     # samba must be before hr_share
     - role: samba
     - role: hr_share
-    - role: datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: restart nginx

--- a/playbooks/byzantine.yml
+++ b/playbooks/byzantine.yml
@@ -20,8 +20,6 @@
   roles:
     - role: nfsserver
     - role: byzantine
-    - role: datadog
-      when: runtime_env | default('staging') == "production"
     - role: roles/mailcatcher
       when: runtime_env | default('staging') == "staging"
 

--- a/playbooks/lae.yml
+++ b/playbooks/lae.yml
@@ -12,8 +12,6 @@
 
   roles:
     - role: roles/lae
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/lockers_and_study_rooms.yml
+++ b/playbooks/lockers_and_study_rooms.yml
@@ -11,8 +11,6 @@
     - ../group_vars/lockers_and_study_spaces/vault.yml
   roles:
     - role: lockers_and_study_spaces
-    - role: datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: restart nginx

--- a/playbooks/orcid.yml
+++ b/playbooks/orcid.yml
@@ -18,7 +18,6 @@
 
   roles:
     - role: roles/rails_app
-    - role: roles/datadog
 
   post_tasks:
       # tasks file for roles/hr_share

--- a/playbooks/pas.yml
+++ b/playbooks/pas.yml
@@ -19,8 +19,6 @@
     - role: nfsserver
     - role: roles/pas
     - role: roles/mailcatcher
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:

--- a/playbooks/pdc_describe.yml
+++ b/playbooks/pdc_describe.yml
@@ -21,6 +21,7 @@
     - role: roles/rails_app
     - role: roles/sidekiq_worker
     - role: roles/datadog
+      when: runtime_env | default('staging') == "production"
 
   post_tasks:
       - name: send information to slack

--- a/playbooks/pdc_describe_redis.yml
+++ b/playbooks/pdc_describe_redis.yml
@@ -16,6 +16,7 @@
   roles:
     - role: roles/redis
     - role: roles/datadog
+      when: runtime_env | default('staging') == "production"
 
   post_tasks:
       - name: send information to slack

--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -20,6 +20,7 @@
     - role: roles/mailcatcher
     - role: roles/rails_app
     - role: roles/datadog
+      when: runtime_env | default('staging') == "production"
 
   post_tasks:
       - name: send information to slack

--- a/playbooks/static.yml
+++ b/playbooks/static.yml
@@ -9,8 +9,6 @@
     - ../group_vars/libstatic/{{ runtime_env | default('staging') }}.yml
   roles:
     - role: libstatic
-    - role: datadog
-      when: runtime_env | default('staging') == "production"
   pre_tasks:
     - set_fact:
         deploy_id_rsa_private_key: "{{  lookup('file', '../roles/libstatic/files/id_rsa')  }}\n"


### PR DESCRIPTION
Work towards #6126.

This was implemented by running the following:

```
ansible all -l 'approvals_staging,approvals_production,byzantine_staging,byzantine_production,lae_staging,lae_production,lockers_and_study_spaces_staging,lockers_and_study_spaces_production,orcid_staging,orcid_production,pas_staging,pas_production,pdc_describe_staging,pdc_describe_redis_staging,pdc_discovery_staging,static_staging,static_production' -m ansible.builtin.apt -u pulsys --become -a "name=datadog-agent state=absent"
```