### PR TITLE
[Datadog] Remove non-application, CheckMK monitored hosts.

### DIFF
--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -51,18 +51,18 @@ nginx_template_upload_dest: /etc/nginx/conf.d/templates/
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:
   tags: "{{ nginxplus_tags }}"
-  apm_enabled: "true"
+  apm_enabled: "false"
   log_enabled: true
+  enable_payloads:
+    series: false
+    events: false
+    service_checks: false
+    sketches: false
   process_config:
-    enabled: "true"
+    enabled: "false"
 nginxplus_tags: "application:nginxplus, environment:production, type:adc"
 datadog_checks:
   process:
-    nginx:
-      init_config:
-      instances:
-        - nginx_status_url: http://localhost/status.html
-          tags: "{{nginxplus_tags}}"
     logs:
       - type: file
         path: /var/log/nginx/access.log

--- a/playbooks/mysql.yml
+++ b/playbooks/mysql.yml
@@ -10,8 +10,6 @@
     - ../group_vars/mysql/vault.yml
   roles:
     - role: ../roles/mysql
-    - role: ../roles/datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/pdc_describe_redis.yml
+++ b/playbooks/pdc_describe_redis.yml
@@ -15,11 +15,8 @@
 
   roles:
     - role: roles/redis
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
       - name: send information to slack
         ansible.builtin.include_tasks:
           file: utils/slack_tasks_end_of_playbook.yml
-          

--- a/playbooks/postgresql.yml
+++ b/playbooks/postgresql.yml
@@ -14,12 +14,6 @@
   roles:
     - role: roles/common
     - role: ../roles/postgresql
-    - role: roles/datadog
-      when: 
-        - runtime_env | default('staging') == "production"
-        # Ansible Tower database runs on PostgreSQL 13 on a Rocky VM
-        # we do not send those logs to Datadog
-        - ansible_os_family != "RedHat"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/solr8cloud.yml
+++ b/playbooks/solr8cloud.yml
@@ -14,8 +14,6 @@
     - role: roles/ruby_s
     - role: roles/deploy_user
     - role: roles/solrcloud
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/solr9cloud.yml
+++ b/playbooks/solr9cloud.yml
@@ -14,8 +14,6 @@
     - role: roles/ruby_s
     - role: roles/deploy_user
     - role: roles/solrcloud
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/solrcloud.yml
+++ b/playbooks/solrcloud.yml
@@ -18,7 +18,6 @@
     - role: roles/ruby
     - role: roles/deploy_user
     - role: roles/solrcloud
-    - role: roles/datadog
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook

--- a/playbooks/zookeeper.yml
+++ b/playbooks/zookeeper.yml
@@ -12,8 +12,6 @@
   roles:
     - role: roles/openjdk
     - role: roles/zookeeper
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       when: runtime_env | default('staging') == "production"

--- a/playbooks/zookeeper_solr8.yml
+++ b/playbooks/zookeeper_solr8.yml
@@ -14,8 +14,6 @@
   roles:
     - role: roles/openjdk
     - role: roles/zookeeper
-    - role: roles/datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook


### PR DESCRIPTION
Work towards #6126.

Nginx+ is set up to still install Datadog, but only send logs. I'm hoping that pulls it off infrastructure billing.