### PR TITLE
Add bitcurator VMs to inventory

### DIFF
--- a/inventory/all_projects/bitcurator
+++ b/inventory/all_projects/bitcurator
@@ -1,0 +1,11 @@
+[bitcurator_production]
+lib-vm-bitcur2.princeton.edu
+lib-vm-bitcur3.princeton.edu
+lib-vm-bitcur4.princeton.edu
+lib-vm-bitcur5.princeton.edu
+lib-vm-bitcur6.princeton.edu
+lib-vm-bitcur7.princeton.edu
+lib-vm-bitcur8.princeton.edu
+lib-vm-bitcur10.princeton.edu
+lib-vm-bitcur11.princeton.edu
+lib-vm-bitcur12.princeton.edu

--- a/inventory/by_environment/production
+++ b/inventory/by_environment/production
@@ -5,6 +5,7 @@ ansible_tower
 approvals_production
 bastion_production
 bibdata_production
+bitcurator_production
 byzantine_production
 cantaloupe_production
 cdh_production


### PR DESCRIPTION
Added bitcurator machines to inventory/all_projects/bitcurator under [bitcurator_production]. Added bitcurator_production to inventory/by_environment/production

Related to #6142 