### PR TITLE
Remove abid-production{1,2}

### DIFF
--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -3,8 +3,6 @@
 postfix_main_cf: "/etc/postfix/main.cf"
 postfix_allowed_relay_hosts: "/etc/postfix/mynetworks"
 postfix_relay_hosts_addresses:
-  - abid-prod1.princeton.edu
-  - abid-prod2.princeton.edu
   - ansible-exec-node1.princeton.edu
   - ansible-exec-node2.princeton.edu
   - ansible-tower1.princeton.edu


### PR DESCRIPTION
Remove abid-production{1,2}.princeton.edu as these machines have been decomissioned. 

Closes #6166 