### PR TITLE
[Datacommons] Finish bot wall implementation

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -44,4 +44,11 @@ http:
         regex: //([^/]*)/\?f(.*)
         # Converts to http://x.x.x.x:yyyy/catalog?f[]=
         replacement: //${1}/catalog?f${2}
+    # discovery is hosted at a sub-path, need special handling.
+    append-discovery-regex:
+      redirectRegex:
+        # Matches http://x.x.x.x:yyyy/discovery/?f[]=
+        regex: //([^/]*)/discovery/\?f(.*)
+        # Converts to http://x.x.x.x:yyyy/discovery/catalog?f[]=
+        replacement: //${1}/discovery/catalog?f${2}
 {{- end -}}

--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -13,7 +13,7 @@ http:
           # We're only protecting Blacklight apps for now.
           # We have to add the DPUL exhibits one at a time right now, until
           # there's wildcards. These are all the most visited ones by bots.
-          protectRoutes: "/catalog,/advanced,/sae/catalog,/igor-savchenko/catalog,/msstreasures/catalog,/alchemy/catalog,/islamicmss/catalog,/eastasian/catalog,/badakhshan_collection/catalog,/sae_sri_lanka_dissidents/catalog,/marquand-library/catalog,/medieval_manuscripts/catalog,/gnib/catalog,/valva/catalog,/slavic/catalog,/performances/catalog,/pudl0135/catalog,/cotsen-collection/catalog,/pudl0038/catalog,/hellenica/catalog"
+          protectRoutes: "/catalog,/advanced,/discovery/catalog,/sae/catalog,/igor-savchenko/catalog,/msstreasures/catalog,/alchemy/catalog,/islamicmss/catalog,/eastasian/catalog,/badakhshan_collection/catalog,/sae_sri_lanka_dissidents/catalog,/marquand-library/catalog,/medieval_manuscripts/catalog,/gnib/catalog,/valva/catalog,/slavic/catalog,/performances/catalog,/pudl0135/catalog,/cotsen-collection/catalog,/pudl0038/catalog,/hellenica/catalog"
           captchaProvider: turnstile
           siteKey: "{{ .TURNSTILE_SITE_KEY }}"
           secretKey: "{{ .TURNSTILE_SECRET_KEY }}"

--- a/nomad/traefik-wall/deploy/sites/sites-production.yml
+++ b/nomad/traefik-wall/deploy/sites/sites-production.yml
@@ -37,7 +37,7 @@ http:
         - http
       middlewares:
         - captcha-protect
-        - append-catalog-regex
+        - append-discovery-regex
       priority: 10
 
     dpul-production-skip-all-mw:

--- a/roles/nginxplus/files/conf/http/datacommons.conf
+++ b/roles/nginxplus/files/conf/http/datacommons.conf
@@ -71,6 +71,18 @@ server {
         proxy_intercept_errors on;
 	}
 
+	location /challenge {
+        proxy_pass http://discovery/challenge;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_cache discovery-prodcache;
+        health_check uri=/discovery/health.json interval=10 fails=3 passes=2;
+        # handle errors using errors.conf
+        proxy_intercept_errors on;
+	}
+
     location /describe/ {
         app_protect_enable off;
 


### PR DESCRIPTION
Since PDC Discovery is hosted at a sub-path (`/discovery`), we have to:

* Allow the load balancer to redirect `/challenge` to the discovery boxes.
* Bot wall monitor `/discovery/catalog`
* Redirect `/discovery/?f[]=` to `/discovery/catalog?f[]=`
