### PR TITLE
Correct FQDN for reservoir-staging VM

### DIFF
--- a/inventory/all_projects/reservoir
+++ b/inventory/all_projects/reservoir
@@ -1,3 +1,3 @@
 [reservoir_staging]
-reservoir_staging1.lib.princeton.edu
-reservoir_staging2.lib.princeton.edu
+reservoir-staging1.lib.princeton.edu
+reservoir-staging2.lib.princeton.edu


### PR DESCRIPTION
Corrects the FQDN for reservoir-staging{1,2} vms added with #6178 