### PR TITLE
[checkmk] add prod config

### DIFF
--- a/group_vars/checkmk/production.yml
+++ b/group_vars/checkmk/production.yml
@@ -3,7 +3,7 @@
 # what is 'agent_prep_legacy' for?
 # we only set it in production
 # checkmk_agent_prep_legacy: 'false'
-checkmk_agent_server: "pulmonitor-staging1.princeton.edu"
+checkmk_agent_server: "pulmonitor-prod1.lib.princeton.edu"
 checkmk_agent_site: production
 checkmk_agent_secret: "{{ vault_automation_secret_production }}"
 checkmk_agent_automation_role: automation

--- a/group_vars/checkmk/staging.yml
+++ b/group_vars/checkmk/staging.yml
@@ -1,5 +1,5 @@
 ---
-checkmk_agent_server: pulmonitor-staging2.princeton.edu
+checkmk_agent_server: pulmonitor-prod2.lib.princeton.edu
 # the receiver_port var is not used in the collection role
 # we added it in our copy of the checkmk_agent role:
 checkmk_agent_site: staging

--- a/roles/nginxplus/files/conf/http/pulmonitor_production.conf
+++ b/roles/nginxplus/files/conf/http/pulmonitor_production.conf
@@ -1,0 +1,81 @@
+# Ansible managed
+proxy_cache_path /var/cache/nginx/pulmonitor-production/ keys_zone=pulmonitor-productioncache:10m;
+
+upstream pulmonitor-production {
+    zone pulmonitor-production 64k;
+    server pulmonitor-prod1.lib.princeton.edu resolve;
+    sticky learn
+          create=$upstream_cookie_pulmonitorproductioncookie
+          lookup=$cookie_pulmonitorproductioncookie
+          zone=pulmonitorproductionclient_sessions:1m;
+}
+
+upstream pulmonitor-production-remote {
+    zone pulmonitor-production 64k;
+    server pulmonitor-prod2.lib.princeton.edu resolve;
+}
+
+upstream pulmonitor-forrestal-remote {
+    zone pulmonitor-production 64k;
+    server pulmonitor-forrestal.princeton.edu resolve;
+}
+
+upstream pulmonitor-newsouth-remote {
+    zone pulmonitor-production 64k;
+    server pulmonitor-newsouth.princeton.edu resolve;
+}
+
+server {
+    listen 80;
+    server_name pulmonitor.princeton.edu;
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name pulmonitor.princeton.edu;
+    ssl_certificate            /etc/letsencrypt/live/pulmonitor/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/pulmonitor/privkey.pem;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    # Redirect top level traffic to /pulmonitor/
+    location / {
+        return 302 https://$server_name/production/;
+    }
+
+    location /forrestal {
+        proxy_pass http://pulmonitor-forrestal-remote;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /new_south {
+        proxy_pass http://pulmonitor-newsouth-remote;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /production/ {
+        proxy_pass http://pulmonitor-production/production/;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_cache pulmonitor-productioncache;
+        health_check interval=10 fails=3 passes=2;
+    }
+
+    location /staging {
+        proxy_pass http://pulmonitor-production-remote;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    include /etc/nginx/conf.d/templates/production-maintenance.conf;
+}

--- a/roles/nginxplus/files/conf/http/pulmonitor_production.conf
+++ b/roles/nginxplus/files/conf/http/pulmonitor_production.conf
@@ -77,5 +77,5 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    include /etc/nginx/conf.d/templates/production-maintenance.conf;
+    include /etc/nginx/conf.d/templates/prod-maintenance.conf;
 }

--- a/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
+++ b/roles/nginxplus/files/conf/http/pulmonitor_staging.conf
@@ -15,16 +15,6 @@ upstream pulmonitor-staging-remote {
     server pulmonitor-staging2.princeton.edu resolve;
 }
 
-upstream pulmonitor-forrestal-remote {
-    zone pulmonitor-staging 64k;
-    server pulmonitor-forrestal.princeton.edu resolve;
-}
-
-upstream pulmonitor-newsouth-remote {
-    zone pulmonitor-staging 64k;
-    server pulmonitor-newsouth.princeton.edu resolve;
-}
-
 server {
     listen 80;
     server_name pulmonitor-staging.princeton.edu;

--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -125,6 +125,8 @@ postfix_relay_hosts_addresses:
   - pulfalight-jammy-prod1.princeton.edu
   - pulfalight-jammy-prod2.princeton.edu
   - pulfalight-prod-worker1.princeton.edu
+  - pulmonitor-prod1.lib.princeton.edu
+  - pulmonitor-prod2.lib.princeton.edu
   - pulmonitor-staging1.princeton.edu
   - pulmonitor-staging2.princeton.edu
   - pulmonitor-forrestal.princeton.edu


### PR DESCRIPTION
we add a configuration for checkmk production.
we have allowed access outside VPN and are using RFC-1918 hosted VMS
we don't think this matters
