### PR TITLE
[Traefik] Improve regex to capture more facet queries.

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -41,14 +41,14 @@ http:
     append-catalog-regex:
       redirectRegex:
         # Matches http://x.x.x.x:yyyy/?f[]=
-        regex: //([^/]*)/\?f(.*)
+        regex: //([^/]*)/\?([^&]*&)*?f(.*)
         # Converts to http://x.x.x.x:yyyy/catalog?f[]=
-        replacement: //${1}/catalog?f${2}
+        replacement: //${1}/catalog?${2}f${3}
     # discovery is hosted at a sub-path, need special handling.
     append-discovery-regex:
       redirectRegex:
         # Matches http://x.x.x.x:yyyy/discovery/?f[]=
-        regex: //([^/]*)/discovery/\?f(.*)
+        regex: //([^/]*)/discovery/\?([^&]*&)*?f(.*)
         # Converts to http://x.x.x.x:yyyy/discovery/catalog?f[]=
-        replacement: //${1}/discovery/catalog?f${2}
+        replacement: //${1}/discovery/catalog?{2}f${2}
 {{- end -}}

--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -41,14 +41,18 @@ http:
     append-catalog-regex:
       redirectRegex:
         # Matches http://x.x.x.x:yyyy/?f[]=
+        # Matches http://x.x.x.x:yyyy/?something&f[]=
         regex: //([^/]*)/\?([^&]*&)*?f(.*)
         # Converts to http://x.x.x.x:yyyy/catalog?f[]=
+        # or http://x.x.x.x:yyyy/catalog?something&f[]=
         replacement: //${1}/catalog?${2}f${3}
     # discovery is hosted at a sub-path, need special handling.
     append-discovery-regex:
       redirectRegex:
-        # Matches http://x.x.x.x:yyyy/discovery/?f[]=
+        # Matches http://x.x.x.x:yyyy/discovery?f[]=
+        # Matches http://x.x.x.x:yyyy/discovery/catalog?something&f[]=
         regex: //([^/]*)/discovery/\?([^&]*&)*?f(.*)
         # Converts to http://x.x.x.x:yyyy/discovery/catalog?f[]=
+        # or http://x.x.x.x:yyyy/discovery/catalog?something&f[]=
         replacement: //${1}/discovery/catalog?{2}f${2}
 {{- end -}}


### PR DESCRIPTION
Sometimes it's not ?f[]=, it's &f[]=, this covers that case.

We were seeing this for findingaids:

`/?+Grau+&f%5Bhas_direct_online_content_ssim%5D%5B%5D=online&f%5Bnames_ssim%5D%5B%5D=Museo+nacional+de+historia+Mexico&range%5Bdate_range_sim%5D%5Bbegin%5D=1902&range%5Bdate_range_sim%5D%5Bend%5D=1904&sort=creator_sort+desc`