### PR TITLE
[bibdata] upgrade ruby to 3.4.4

### DIFF
--- a/group_vars/bibdata/common.yml
+++ b/group_vars/bibdata/common.yml
@@ -4,7 +4,7 @@ passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 install_ruby_from_source: true
-ruby_version_override: "ruby-3.4.1"
+ruby_version_override: "ruby-3.4.4"
 bundler_version: "2.6.3"
 rails_app_dependencies:
   - libpq-dev


### PR DESCRIPTION
Since the rust compiler is installed on bibdata boxes, ruby will be compiled with the YJIT option.

Helps with https://github.com/pulibrary/bibdata/issues/2720

I ran this on staging, and confirmed that YJIT is available with:

```
ruby --yjit -v
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +YJIT +PRISM [x86_64-linux]
```