### PR TITLE
[common] don't send vector's demo logs to the syslog

### DIFF
--- a/roles/common/files/vector.yaml
+++ b/roles/common/files/vector.yaml
@@ -1,0 +1,27 @@
+# Random Syslog-formatted logs
+sources:
+  dummy_logs:
+    type: "demo_logs"
+    format: "syslog"
+    interval: 1
+
+# Parse Syslog logs
+# See the Vector Remap Language reference for more info: https://vrl.dev
+transforms:
+  parse_logs:
+    type: "remap"
+    inputs: ["dummy_logs"]
+    source: |
+      . = parse_syslog!(string!(.message))
+
+sinks:
+  # A temporary sink so that we don't fill our syslog with the dummy_logs entries
+  # We will eventually want to send real logs to pulemetry
+  discard_logs_for_now:
+    type: "file"
+    path: "/dev/null"
+    inputs: ["parse_logs"]
+    encoding:
+      codec: "json"
+      json:
+        pretty: true

--- a/roles/common/tasks/vector.yml
+++ b/roles/common/tasks/vector.yml
@@ -48,8 +48,14 @@
   when:
     - ansible_os_family == "Debian"
 
+- name: Common | Configure vector to not write demo logs to syslog
+  ansible.builtin.copy:
+    src: files/vector.yaml
+    dest: /etc/vector/vector.yaml
+    mode: "0644"
+
 - name: Common | Ensure Vector is running and enabled
   ansible.builtin.service:
     name: vector
-    state: started
+    state: restarted
     enabled: true


### PR DESCRIPTION
They take up a non-trivial amount of disk space.  Eventually, we will want to send real logs to pulemetry, but it is not quite ready yet.  This configuration is taken from the basic config on the boxes, except that it uses a "file" sink to send the entries to /dev/null

I ran this on bibdata-worker-staging[12], where it did stop sending those demo logs to the syslog.