### PR TITLE
[Datadog] Skip logging load balancer 302s

### DIFF
--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -73,6 +73,9 @@ datadog_checks:
           - type: exclude_at_match
             name: drop_nginx_warn_messages
             pattern: "\\[warn\\]"
+          # Most 302s are from blocking bots and forwarding them to a turnstile.
+          # We'd like to be able to see these (and other redirects), but it's too expensive to store
+          # all of those, so ignore all 302s to cut down 15m logs/day
           - type: exclude_at_match
             name: drop_302_logs
             pattern: '"status": "302"'

--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -73,6 +73,9 @@ datadog_checks:
           - type: exclude_at_match
             name: drop_nginx_warn_messages
             pattern: "\\[warn\\]"
+          - type: exclude_at_match
+            name: drop_302_logs
+            pattern: '"status": "302"'
       - type: file
         path: /var/log/nginx/error.log
         service: adc


### PR DESCRIPTION
MOST of the 302s are for bots redirecting to Traefik.

This is a visibility loss for sure, but we're ingesting way too many logs right now. Hopefully we can switch to Loki soon. This should cut our log ingestion in half.