### PR TITLE
Correct typo for kennyloggin_staging

### DIFF
--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -16,7 +16,7 @@ ezproxy_testing
 figgy_staging
 geniza_staging
 gitlab_staging
-kennyloggin-staging
+kennyloggin_staging
 lae_staging
 lib_jobs_staging
 libsftp_staging
@@ -79,6 +79,7 @@ ezproxy_testing
 figgy_staging
 geniza_staging
 gitlab_staging
+kennyloggin_staging
 lae_staging
 lib_jobs_staging
 


### PR DESCRIPTION
In `inventory/by_environment/staging` the group `kennyloggin_staging` was mispelled as `kennylogging-staging`.

Closes #6208 