### PR TITLE
Remove undefined environments - were causing parsing problems

### DIFF
--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -21,7 +21,6 @@ lae_staging
 lib_jobs_staging
 libsftp_staging
 lib_fs_staging
-lib_fs_cdh_conf_prosody
 lib_svn_staging
 lockers_and_study_spaces_staging
 mflux_staging
@@ -44,7 +43,6 @@ postgresql_staging
 prds_staging
 prosody_staging
 pulcheck_staging
-pulemetry_staging
 pulfalight_staging
 pulmap_staging
 reservoir_staging
@@ -86,7 +84,6 @@ lib_jobs_staging
 [staging_2:children]
 libsftp_staging
 lib_fs_staging
-lib_fs_cdh_conf_prosody
 lib_svn_staging
 lockers_and_study_spaces_staging
 mflux_staging


### PR DESCRIPTION
I couldn't run some playbooks because of errors like this one:

```
(princeton_ansible) ➜  princeton_ansible git:(orangelight_ci_key) ansible-playbook playbooks/deploy_user.yml --tags update_keys -e runtime_env=staging --limit=orangelight_staging
> [WARNING]:  * Failed to parse /Users/max/projects/princeton_ansible/inventory/by_environment/staging with ini plugin:
/Users/max/projects/princeton_ansible/inventory/by_environment/staging:24: Section [staging_2:children] includes undefined group: lib_fs_cdh_conf_prosody
```