### PR TITLE
[circleci] Add gnupg2 for Chrome install

### DIFF
--- a/nomad/circleci_deployer/Dockerfile
+++ b/nomad/circleci_deployer/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
       file \
       g++ \
       gcc \
+      gnupg2 \
       imagemagick \
       libbz2-dev \
       libc6-dev \


### PR DESCRIPTION
Connected to https://github.com/pulibrary/orangelight/issues/4879

In order to use Capybara to drive a browser to test deployed environments, we need to be able to install Chrome and Chromedriver, which requires gnupg2

Failed CI run https://app.circleci.com/pipelines/github/pulibrary/orangelight/6788/workflows/65468fae-6eaa-459a-856d-3ce6a7861db7/jobs/35251