### PR TITLE
add a logmonitor check

### DIFF
--- a/playbooks/utils/checkmk_add_logmonitor.yml
+++ b/playbooks/utils/checkmk_add_logmonitor.yml
@@ -1,0 +1,34 @@
+---
+# To run the playbook:
+#  will run with the staging runtime environment and the rails rule group on pdc-describe-staging2
+
+- name: Install CheckMk local check scripts on host
+  hosts: "{{ runtime_env | default ('staging') }}"
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../../group_vars/all/vault.yml
+    - ../../group_vars/checkmk/{{ runtime_env | default('staging') }}.yml
+    - ../../group_vars/checkmk/agent_common.yml
+    - ../../group_vars/checkmk/vault.yml
+
+  roles:
+    - role: roles/checkmk
+
+  tasks:
+    - name: "Add new local services on hosts."
+      checkmk.general.discovery:
+        server_url: "{{ checkmk_agent_server_protocol }}://{{ checkmk_agent_server }}"
+        site: "{{ checkmk_agent_site }}"
+        automation_user: "{{ checkmk_agent_user }}"
+        automation_secret: "{{ vault_automation_secret }}"
+        hosts: "{{ checkmk_agent_host_name }}"
+        state: "new"
+
+    - name: "Start activation including foreign changes."
+      checkmk.general.activation:
+        server_url: "{{ checkmk_agent_server_protocol }}://{{ checkmk_agent_server }}"
+        site: "{{ checkmk_agent_site }}"
+        automation_user: "{{ checkmk_agent_user }}"
+        automation_secret: "{{ vault_automation_secret }}"
+        force_foreign_changes: 'true'

--- a/roles/checkmk/README.md
+++ b/roles/checkmk/README.md
@@ -1,0 +1,54 @@
+Checkmk Local
+=========
+
+This role will be used for defaults for checkmk local scripts
+
+Requirements
+------------
+
+Role Variables
+--------------
+
+variables for checkmk_log_monitor, add these to `group_vars/app_name/environment.yml` or `rolename/vars/main.yml`
+
+| Variable                    | Default                                      | Description                                        |
+|-----------------------------|----------------------------------------------|----------------------------------------------------|
+| `log_growth_logfile`        | `/var/log/myapp/app.log`                     | Path to the log file to monitor.                   |
+| `log_growth_statefile`      | `/var/lib/check_mk_agent/state/app.log.size` | Path to store previous file size state.            |
+| `log_growth_interval`       | `300`                                        | Agent execution interval in seconds.               |
+| `log_growth_warn_mb_per_hour` | `20`                                       | Warning threshold in MB/hour.                      |
+| `log_growth_crit_mb_per_hour` | `30`                                       | Critical threshold in MB/hour.                     |
+
+Dependencies
+------------
+
+Usage
+----------------
+
+```yaml
+- hosts: all
+  roles:
+    - role: checkmk
+      vars:
+        log_growth_logfile: "/var/log/other/app.log"
+        log_growth_interval: 600
+        log_growth_warn_mb_per_hour: 50
+        log_growth_crit_mb_per_hour: 100
+```
+
+After deployment:
+
+1. The script is placed at `/usr/lib/check_mk_agent/local/log_growth.sh`.
+2. The CheckMK agent will run it on its next execution, creating a `log_growth` service.
+
+## License
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/checkmk/defaults/main.yml
+++ b/roles/checkmk/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# defaults file for roles/checkmk
+# Path to the log to watch
+log_growth_logfile: "/var/log/myapp/app.log"
+# Where to store the previous size
+log_growth_statefile: "/var/lib/check_mk_agent/state/app.log.size"
+# Agent run interval in seconds
+log_growth_interval: 300
+
+# MB/hour thresholds
+log_growth_warn_mb_per_hour: 20
+log_growth_crit_mb_per_hour: 30

--- a/roles/checkmk/handlers/main.yml
+++ b/roles/checkmk/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for roles/checkmk

--- a/roles/checkmk/meta/main.yml
+++ b/roles/checkmk/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/checkmk/tasks/main.yml
+++ b/roles/checkmk/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for roles/checkmk
+- name: Checkmk | Deploy CheckMK log-growth local check
+  ansible.builtin.template:
+    src: log_growth.sh.j2
+    dest: /usr/lib/check_mk_agent/local/log_growth.sh
+    owner: root
+    group: root
+    mode: '0755'

--- a/roles/checkmk/templates/log_growth.sh.j2
+++ b/roles/checkmk/templates/log_growth.sh.j2
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# {{ ansible_managed | comment }}
+#
+# CheckMK local check for log-growth rate
+
+LOGFILE="{{ log_growth_logfile }}"
+STATEFILE="{{ log_growth_statefile }}"
+INTERVAL={{ log_growth_interval }}
+
+# get current & previous sizes (bytes)
+CUR=$(stat -c '%s' "$LOGFILE" 2>/dev/null || echo 0)
+PREV=$(cat "$STATEFILE" 2>/dev/null || echo $CUR)
+
+# persist current size
+mkdir -p "$(dirname "$STATEFILE")"
+echo "$CUR" > "$STATEFILE"
+
+# calculate growth per hour (bytes/sec * 3600)
+DELTA=$(( CUR - PREV ))
+# avoid negative
+if [ "$DELTA" -lt 0 ]; then
+  DELTA=0
+fi
+
+GROWTH_PER_HOUR=$(awk "BEGIN { printf \"%f\", ($DELTA / $INTERVAL) * 3600 }")
+GROWTH_MB=$(awk "BEGIN { printf \"%.2f\", $GROWTH_PER_HOUR / (1024*1024) }")
+
+# determine status
+if (( $(echo "$GROWTH_MB >= {{ log_growth_crit_mb_per_hour }}" | bc -l) )); then
+  STATUS=2
+  MSG="CRITICAL – ${GROWTH_MB} MB/h ≥ {{ log_growth_crit_mb_per_hour }}"
+elif (( $(echo "$GROWTH_MB >= {{ log_growth_warn_mb_per_hour }}" | bc -l) )); then
+  STATUS=1
+  MSG="WARN – ${GROWTH_MB} MB/h ≥ {{ log_growth_warn_mb_per_hour }}"
+else
+  STATUS=0
+  MSG="OK – ${GROWTH_MB} MB/h"
+fi
+
+# Nagios-style local check: <status> <service_id> <perfdata> <text>
+echo "$STATUS log_growth growth=${GROWTH_MB}MB/h ${MSG}"
+

--- a/roles/checkmk/tests/inventory
+++ b/roles/checkmk/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/checkmk/tests/test.yml
+++ b/roles/checkmk/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/checkmk

--- a/roles/checkmk/vars/main.yml
+++ b/roles/checkmk/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for roles/checkmk


### PR DESCRIPTION
we are creating a role because this check requires variables. As currently implemented there is no place to pass parameters to monitor on local scripts.

related to #6254