### PR TITLE
[solrcloud] ensure servers reboot

### DIFF
--- a/roles/solr9cloud/tasks/backup_mounts.yml
+++ b/roles/solr9cloud/tasks/backup_mounts.yml
@@ -28,51 +28,76 @@
     var: creds_file
   when: running_on_server
 
-# Try mounting with explicit options instead of credentials file
-- name: Solrcloud | Create mount to diglibdata shares
-  ansible.posix.mount:
-    path: "/mnt/{{ item.path }}"
-    src: "//diglibdata1.princeton.edu/{{ item.src }}"
-    fstype: cifs
-    opts: "credentials=/etc/solr.smb.credentials,uid=1001,gid=1001,file_mode=0644,dir_mode=0755,vers=3.0"
-    state: mounted
+# Ensure mount points exist
+- name: Solrcloud | Ensure CIFS mount point exists
+  ansible.builtin.file:
+    path: "/mnt/solr_backup"
+    state: directory
+    owner: deploy
+    group: deploy
+    mode: '0755'
   when: running_on_server
-  loop:
-    - {path: "solr_backup", src: "solrbackup"}
-  tags:
-    - fix_backups
-  register: mount_result
-  ignore_errors: true
 
-- name: Solrcloud | Ensure the bind mount is active
+- name: Solrcloud | Ensure bind mount point exists under Solr data
+  ansible.builtin.file:
+    path: "/solr/data/backup"
+    state: directory
+    owner: deploy
+    group: deploy
+    mode: '0755'
+  when: running_on_server
+
+# Mount the CIFS share at /mnt/solr_backup
+- name: Solrcloud | Mount CIFS share for backups
   ansible.posix.mount:
-    src: /mnt/solr_backup
-    path: "{{ solr_data_dir }}/backup"
+    path: "/mnt/solr_backup"
+    src: "//diglibdata1.princeton.edu/solrbackup"
+    fstype: cifs
+    opts: "credentials=/etc/solr.smb.credentials,uid=1001,gid=1001,file_mode=0644,dir_mode=0755,vers=3.0,_netdev,nofail,x-systemd.automount"
     state: mounted
-    opts: bind
-    fstype: none
-  when: is_solr9
-
-- name: Solrcloud | Ensure the bind mount is configured in /etc/fstab
-  ansible.posix.mount:
-    src: /mnt/solr_backup
-    path: "{{ solr_data_dir }}/backup"
-    state: present
-    fstype: none
-    opts: bind
-    dump: '0'
-    passno: '0'
-  when: is_solr9
-
-# Fallback method if the standard mount fails
-- name: Solrcloud | Mount fallback (mount command directly)
-  ansible.builtin.command: >
-    mount -t cifs //diglibdata1.princeton.edu/solrbackup
-    /mnt/solr_backup
-    -o credentials=/etc/solr.smb.credentials,uid=1001,gid=1001,file_mode=0644,dir_mode=0755,vers=3.0
-  when:
-    - running_on_server
-    - mount_result is failed
+    dump: 0
+    passno: 0
+  when: running_on_server
   tags:
     - fix_backups
 
+# Bind mount from CIFS share into Solr data home
+- name: Solrcloud | Bind mount backup directory into Solr data home
+  ansible.posix.mount:
+    path: "/solr/data/backup"
+    src: "/mnt/solr_backup"
+    fstype: none
+    opts: "bind"
+    state: mounted
+    dump: 0
+    passno: 0
+  when: running_on_server
+  tags:
+    - fix_backups
+
+# Ensure fstab entries for both mounts
+- name: Solrcloud | Ensure fstab entry for CIFS share
+  ansible.builtin.mount:
+    path: "/mnt/solr_backup"
+    src: "//diglibdata1.princeton.edu/solrbackup"
+    fstype: cifs
+    opts: "credentials=/etc/solr.smb.credentials,uid=1001,gid=1001,file_mode=0644,dir_mode=0755,vers=3.0,_netdev,nofail,x-systemd.automount"
+    state: present
+    dump: 0
+    passno: 0
+  when: running_on_server
+  tags:
+    - fix_backups
+
+- name: Solrcloud | Ensure fstab entry for bind mount
+  ansible.builtin.mount:
+    path: "/solr/data/backup"
+    src: "/mnt/solr_backup"
+    fstype: none
+    opts: "bind"
+    state: present
+    dump: 0
+    passno: 0
+  when: running_on_server
+  tags:
+    - fix_backups


### PR DESCRIPTION
we are having the solr servers fail to reboot if the diglibdata is unavailable, this ensures that the server will boot even when the backup mounts are not readily available

this is related to https://github.com/pulibrary/pdc_discovery/issues/807
