### PR TITLE
[offboarding max] - remove Max

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -23,7 +23,6 @@ deploy_user_github_keys:
   - https://github.com/kelynch.keys
   - https://github.com/kevinreiss.keys
   - https://github.com/leefaisonr.keys
-  - https://github.com/maxkadel.keys
   - https://github.com/mzelesky.keys
   - https://github.com/pdiskin.keys
   - https://github.com/precillap.keys
@@ -62,7 +61,6 @@ sidekiq_netids:
   - kc16 # Esmé Cowles
   - kr2 # Kevin Reiss
   - kl37 # Kate Lynch
-  - mk8066 # Max Kadel
   - rl3667 # Robert-Anthony Lee-Faison
   - rl8282 # Ryan Laddusaw
   - shaune # Shaun Ellis
@@ -93,7 +91,6 @@ library_github_keys:
   - https://github.com/kelynch.keys
   - https://github.com/kevinreiss.keys
   - https://github.com/leefaisonr.keys
-  - https://github.com/maxkadel.keys
   - https://github.com/mzelesky.keys
   - https://github.com/pdiskin.keys
   - https://github.com/precillap.keys

--- a/group_vars/bibdata/common.yml
+++ b/group_vars/bibdata/common.yml
@@ -17,7 +17,6 @@ bibdata_admin_netids:
   - heberlei
   - js7389
   - kr2
-  - mk8066
   - mzelesky
   - pdiskin
   - rl8282

--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -26,7 +26,6 @@ lib_jobs_admin_netids:
   - heberlei
   - js7389
   - kr2
-  - mk8066
   - mzelesky
   - pdiskin
   - rl8282

--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -10,7 +10,6 @@ ol_admin_netids:
   - heberlei
   - js7389
   - kr2
-  - mk8066
   - rl8282
   - kl37
   - ka1125


### PR DESCRIPTION
This hasn't been run on anything yet
The only one where it really matters is probably the deploy_user / pulsys playbook.

For the admin ones, I won't be able to log in without CAS, so shouldn't be a rush to run them.

Connected to https://github.com/pulibrary/dacs_handbook/issues/311