### PR TITLE
[nginxplus] update logrotate

### DIFF
--- a/group_vars/nginxplus/main.yml
+++ b/group_vars/nginxplus/main.yml
@@ -47,6 +47,37 @@ nginx_ssl_key_upload_dest: /etc/nginx/conf.d/ssl/private/
 nginx_template_upload_enable: true
 nginx_template_upload_src: conf/http/templates/*.conf
 nginx_template_upload_dest: /etc/nginx/conf.d/templates/
+# logrotation
+logrotate_rules:
+  - name: "app_protect.conf"
+    paths:
+      - "{{ app_protect_dir }}"
+    options:
+      rotate: "14"
+      maxsize: "{{ logrotate_global_defaults.maxsize }}"
+      create_mode: "{{ logrotate_global_defaults.create_mode }}"
+      create_owner: "nginx"
+      create_group: "nginx"
+      su_user: "{{ logrotate_global_defaults.su_user }}"
+      su_group: "{{ logrotate_global_defaults.su_group }}"
+      postrotate: |
+        /bin/systemctl restart nginx-app-protect.service > /dev/null 2>/dev/null || true
+  - name: "nginx"
+    paths:
+      - "/var/log/nginx/*.log"
+    options:
+      rotate: "14"
+      maxsize: "{{ logrotate_global_defaults.maxsize }}"
+      create_mode: "{{ logrotate_global_defaults.create_mode }}"
+      create_owner: "nginx"
+      create_group: "adm"
+      su_user: "{{ logrotate_global_defaults.su_user }}"
+      su_group: "{{ logrotate_global_defaults.su_group }}"
+      postrotate: |
+        if [ -f /var/run/nginx.pid ]; then
+                kill -USR1 `cat /var/run/nginx.pid`
+        fi
+
 # configure datadog log collection
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:

--- a/playbooks/utils/common_only.yml
+++ b/playbooks/utils/common_only.yml
@@ -6,6 +6,9 @@
   # hosts: staging:qa:production
   remote_user: pulsys
   become: true
+  vars_files:
+    - ../group_vars/nginxplus/main.yml
+    - ../group_vars/nginxplus/production.yml
   vars:
     running_on_server: true
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -48,20 +48,20 @@ logrotate_global_defaults:
   su_group:   "root"
 
 # Default logrotate rules - can be completely overridden
-logrotate_rules:
-  - name: "falcon-sensor"
-    paths:
-      - "/var/log/falcon-sensor.log"
-      - "/var/log/falcon-libbpf.log"
-    options:
-      rotate: "{{ logrotate_global_defaults.rotate }}"
-      maxsize: "{{ logrotate_global_defaults.maxsize }}"
-      create_mode: "{{ logrotate_global_defaults.create_mode }}"
-      create_owner: "{{ logrotate_global_defaults.create_owner }}"
-      create_group: "{{ logrotate_global_defaults.create_group }}"
-      su_user:      "{{ logrotate_global_defaults.su_user }}"
-      su_group:     "{{ logrotate_global_defaults.su_group }}"
-      # Optional: add postrotate script if service needs notification
+#logrotate_rules:
+#  - name: "falcon-sensor"
+#    paths:
+#      - "/var/log/falcon-sensor.log"
+#      - "/var/log/falcon-libbpf.log"
+#    options:
+#      rotate: "{{ logrotate_global_defaults.rotate }}"
+#      maxsize: "{{ logrotate_global_defaults.maxsize }}"
+#      create_mode: "{{ logrotate_global_defaults.create_mode }}"
+#      create_owner: "{{ logrotate_global_defaults.create_owner }}"
+#      create_group: "{{ logrotate_global_defaults.create_group }}"
+#      su_user:      "{{ logrotate_global_defaults.su_user }}"
+#      su_group:     "{{ logrotate_global_defaults.su_group }}"
+#      # Optional: add postrotate script if service needs notification
       # postrotate: |
       #   systemctl reload myservice || true
 # Example 1: Web server logs (group_vars/bibdata/staging.yml)

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -75,9 +75,6 @@
     owner: root
     group: root
   loop: "{{ logrotate_rules }}"
-  when: 
-    - logrotate_rules is defined
-    - logrotate_rules | length > 0
   notify:
     - test logrotate configuration
 


### PR DESCRIPTION
bypass the nginxplus license key to update logrotation PR <https://github.com/pulibrary/princeton_ansible/pull/6294>

```bash
-rw-r-----  1 nginx adm    165K Jul  1 12:11 hc.log.1
-rw-r-----  1 nginx adm    271K Jul  1 12:47 access.log.2.gz
-rw-r-----  1 nginx adm     12K Jul  1 13:04 access.log.1
-rw-r-----  1 nginx adm       0 Jul  2 00:00 hc.log
-rw-r-----  1 nginx adm       0 Jul  2 00:00 access.log
-rw-r-----  1 nginx adm    6.4M Jul  2 00:00 error.log.1
-rw-r-----  1 nginx adm     82K Jul  2 13:23 error.log-20250702-1751462631.gz
-rw-r--r--  1 nginx adm     12K Jul  2 13:25 error.log-20250702-1751462723
drwxr-xr-x  2 root  root   4.0K Jul  2 13:25 .
drwxrwxr-x 13 root  syslog 4.0K Jul  2 13:25 ..
-rw-r--r--  1 nginx adm    4.8K Jul  2 13:26 error.log
```

sample output of `/var/log/nginx/` shows that it works
