### PR TITLE
[nginxplus] disable waf for prosody

### DIFF
--- a/roles/nginxplus/files/conf/http/cdh_test_prosody.conf
+++ b/roles/nginxplus/files/conf/http/cdh_test_prosody.conf
@@ -78,8 +78,7 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-#        # app_protect_enable on;
-#        # app_protect_security_log_enable on;
+        app_protect_enable off;
         proxy_pass http://test_prosody;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
by default we have nginx WAF enabled. We disable it for this upstream

closes #6304
