### PR TITLE
[tigerdata/nfs] mount tigerdata

### DIFF
--- a/playbooks/utils/tigerdata_nfs_mount.yml
+++ b/playbooks/utils/tigerdata_nfs_mount.yml
@@ -1,6 +1,11 @@
 ---
 # you MUST run this playbook on a host or group with '--limit' for example `ansible-playbook -v ---limit cdh playbooks/utils/tigerdata_nfs_mount.yml`
-# you must provide the following values for this playbook to run successfully
+# you must provide values for three variables for this playbook to run successfully:
+# 'nfs_share'
+# 'mount_point' and 
+# 'nfs_opts'
+# values are available in Tower; or pass '-e' at the command line
+# For example:
 #  -e nfs_share=td-mf-cl2.princeton.edu:/figgy \
 #  -e mount_point=/mnt/tigerdata \
 #  -e nfs_opts="nfsvers=3,mountport=9015,port=9015,nolock,proto=tcp"

--- a/playbooks/utils/tigerdata_nfs_mount.yml
+++ b/playbooks/utils/tigerdata_nfs_mount.yml
@@ -1,16 +1,15 @@
 ---
 # you MUST run this playbook on a host or group with '--limit' for example `ansible-playbook -v ---limit cdh playbooks/utils/tigerdata_nfs_mount.yml`
+# you must provide the following values for this playbook to run successfully
+#  -e nfs_share=td-mf-cl2.princeton.edu:/figgy \
+#  -e mount_point=/mnt/tigerdata \
+#  -e nfs_opts="nfsvers=3,mountport=9015,port=9015,nolock,proto=tcp"
 #
 - name: Ensure Tigerdata NFS share is mounted
   hosts: all
   # hosts: staging:qa:production
   remote_user: pulsys
   become: true
-  vars:
-    running_on_server: true
-    nfs_share: "td-mf-cl2.princeton.edu:/cdh"
-    mount_point: "/mnt/tigerdata/cdh"
-    nfs_opts: "nfsvers=3,mountport=9007,port=9007,nolock,proto=tcp"
 
   pre_tasks:
     - name: stop playbook if you didn't pass --limit


### PR DESCRIPTION
the variables could get us into trouble on machines that do not have the tigerdata mount. We require a user to pass these for the playbook to work

related to <https://github.com/Princeton-CDH/cdh-ansible/issues/277>

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
