### PR TITLE
[passenger] update passenger logrotate

### DIFF
--- a/roles/passenger/molecule/default/group_vars/all.yml
+++ b/roles/passenger/molecule/default/group_vars/all.yml
@@ -1,12 +1,4 @@
 ---
-__nginx_user: "www-data"
-nginx_passenger_packages:
-  - nginx-extras
-  - libnginx-mod-http-passenger
-__nginx_passenger_packages_16_04:
-  - nginx-extras
-  - passenger
-# logrotate rules
 logrotate_rules:
   - name: "nginx"
     paths:


### PR DESCRIPTION
the passenger role modifies the nginx config. We ensure that this uses the opinionated common role for log rotation. Our current role results in the `/etc/logrotate.d/nginx` looking like so.

```bash
/var/log/nginx/*.log {
        daily
        missingok
        rotate 14
        compress
        delaycompress
        notifempty
        create 0640 www-data adm
        sharedscripts
        prerotate
                if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
                        run-parts /etc/logrotate.d/httpd-prerotate; \
                fi \
        endscript
        postrotate
                invoke-rc.d nginx rotate >/dev/null 2>&1
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
passenger-config reopen-logs >/dev/null 2>&1 || true
```

this change removes that.

closes #6269
