### PR TITLE
[lib_jobs] fix failure of cron jobs

### DIFF
--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -30,7 +30,7 @@ lib_jobs_admin_netids:
   - pdiskin
   - rl8282
 # logrotation
-logrotate_rules:
+lib_jobs_logrotate_rules:
   - name: "{{ rails_app_directory }}"
     paths:
       - "/opt/{{ rails_app_directory }}/shared/tmp/*.log"

--- a/roles/lib_jobs/defaults/main.yml
+++ b/roles/lib_jobs/defaults/main.yml
@@ -36,7 +36,7 @@ transaction_error_feed_recipients: 'test_user@princeton.edu'
 people_error_notification_recipients: 'test_user@princeton.edu'
 git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
 # logrotation
-logrotate_rules:
+lib_jobs_logrotate_rules:
   - name: "lib_jobs_cron"
     paths:
       - "/opt/{{ rails_app_directory }}/shared/tmp/*.log"

--- a/roles/lib_jobs/tasks/main.yml
+++ b/roles/lib_jobs/tasks/main.yml
@@ -22,13 +22,12 @@
     src: '../../common/templates/logrotate_rules.j2'
     dest: "/etc/logrotate.d/{{ item.name }}"
     mode: "0644"
-    owner: deploy
-    group: deploy
-  loop: "{{ logrotate_rules }}"
+    owner: root
+    group: root
+  loop: "{{ lib_jobs_logrotate_rules }}"
   when: 
-    - running_on_server
-    - logrotate_rules is defined
-    - logrotate_rules | length > 0
+    - lib_jobs_logrotate_rules is defined
+    - lib_jobs_logrotate_rules | length > 0
 
 # SVN
 - name: Install subversion client


### PR DESCRIPTION
the variables for logrotate are made consistent with the common role but we prefix the name of the role and call them within the role and the group vars. we may need to test at a later date if the variables in the `group_vars/lib_jobs/common.yml` are even needed.

closes #6324

End to end test performed with

Co-authored-by: Angel Ruiz <aruiz1789@users.noreply.github.com>
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
