### PR TITLE
Adding variables for Hanami environment

### DIFF
--- a/group_vars/orcid/main.yml
+++ b/group_vars/orcid/main.yml
@@ -33,6 +33,10 @@ passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 passenger_ruby: "/usr/local/bin/ruby"
 
+cas_host: 'fed.princeton.edu'
+cas_url: 'https://fed.princeton.edu/cas'
+database_url: 'postgres://{{ orcid_db_user }}:{{ orcid_db_password }}@{{ postgres_host }}/{{ orcid_db_name }}'
+
 rails_app_vars:
   - name: SECRET_KEY_BASE
     value: '{{orcid_secret_key}}'
@@ -60,6 +64,14 @@ rails_app_vars:
     value: '{{orcid_client_secret}}'
   - name: ORCID_SANDBOX
     value: '{{ orcid_sandbox }}'
+  - name: HANAMI_ENV
+    value: '{{ passenger_app_env }}'
+  - name: CAS_URL
+    value: '{{ cas_url }}'
+  - name: CAS_HOST
+    value: '{{ cas_host }}'
+  - name: DATABASE_URL
+    value: '{{ database_url }}'
 
 peoplesoft_share: '{{ vault_orcid_peoplesoft_share }}'
 peoplesoft_host: '{{ vault_orcid_peoplesoft_host }}'


### PR DESCRIPTION
Hanami deploys on the rails role.   We may want to consider renaming that role to something like ruby-webapp, but for the moment these are all the changes that are required to deploy a hanami application to the server