### PR TITLE
Make sure recap boxes do not automatically reboot

### DIFF
--- a/playbooks/utils/os_updates.yml
+++ b/playbooks/utils/os_updates.yml
@@ -89,7 +89,7 @@
         - ansible_os_family == "RedHat"
         - yum_update_status.changed
         - "'ansible' not in inventory_hostname"
-        - "'libserv44.princeton.edu' not in inventory_hostname"
+        - "'recap' not in inventory_hostname"
 
     - name: Ubuntu | Reboot if required
       ansible.builtin.reboot:
@@ -119,4 +119,4 @@
         - ansible_os_family == "RedHat"
         - yum_update_status.changed
         - "'ansible' in inventory_hostname"
-        - "'libserv44.princeton.edu' in inventory_hostname"
+        - "'recap' in inventory_hostname"


### PR DESCRIPTION
In #6314 we added logic to the os_updates playbook to ensure that ReCAP servers would not reboot without supervision.

In #6331 we corrected the hostname for the recapgfa server. However, we did not update the logic in the os_updates playbook.

This PR updates that logic to safeguard any host with 'recap' in the name.