### PR TITLE
Upgrading TigerData hosts to use Node.js 22.9.0 releases

### DIFF
--- a/group_vars/tigerdata/ci.yml
+++ b/group_vars/tigerdata/ci.yml
@@ -4,7 +4,7 @@ postgres_host: "lib-postgres-qa1.princeton.edu"
 passenger_server_name: "tigerdata-ci.princeton.edu"
 passenger_app_env: "ci"
 passenger_extra_config: "{{ lookup('template', 'roles/tigerdata/templates/nginx_extra_config.j2') }}"
-desired_nodejs_version: "v22.17.0"
+desired_nodejs_version: "v22.9.0"
 
 app_secret_key: '{{ vault_tigerdata_ci_secret_key }}'
 app_db_name: '{{ vault_tigerdata_ci_db_name }}'

--- a/group_vars/tigerdata/ci.yml
+++ b/group_vars/tigerdata/ci.yml
@@ -4,7 +4,7 @@ postgres_host: "lib-postgres-qa1.princeton.edu"
 passenger_server_name: "tigerdata-ci.princeton.edu"
 passenger_app_env: "ci"
 passenger_extra_config: "{{ lookup('template', 'roles/tigerdata/templates/nginx_extra_config.j2') }}"
-desired_nodejs_version: "v20.15.1"
+desired_nodejs_version: "v22.17.0"
 
 app_secret_key: '{{ vault_tigerdata_ci_secret_key }}'
 app_db_name: '{{ vault_tigerdata_ci_db_name }}'

--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -16,7 +16,7 @@ app_host_name: '{{ passenger_server_name }}'
 application_host_protocol: 'https'
 running_on_server: true
 tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
-desired_nodejs_version: 'v18.14.0'
+desired_nodejs_version: "v22.17.0"
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.3.0"

--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -16,7 +16,7 @@ app_host_name: '{{ passenger_server_name }}'
 application_host_protocol: 'https'
 running_on_server: true
 tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
-desired_nodejs_version: "v22.17.0"
+desired_nodejs_version: "v22.9.0"
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.3.0"

--- a/group_vars/tigerdata/production.yml
+++ b/group_vars/tigerdata/production.yml
@@ -3,7 +3,7 @@ postgres_host: "lib-postgres-prod1.princeton.edu"
 
 passenger_server_name: "tigerdata-prod.princeton.edu"
 passenger_app_env: "production"
-desired_nodejs_version: "v22.17.0"
+desired_nodejs_version: "v22.9.0"
 
 app_secret_key: '{{ vault_tigerdata_prod_secret_key }}'
 app_db_name: '{{ vault_tigerdata_prod_db_name }}'

--- a/group_vars/tigerdata/production.yml
+++ b/group_vars/tigerdata/production.yml
@@ -3,7 +3,7 @@ postgres_host: "lib-postgres-prod1.princeton.edu"
 
 passenger_server_name: "tigerdata-prod.princeton.edu"
 passenger_app_env: "production"
-desired_nodejs_version: "v20.15.1"
+desired_nodejs_version: "v22.17.0"
 
 app_secret_key: '{{ vault_tigerdata_prod_secret_key }}'
 app_db_name: '{{ vault_tigerdata_prod_db_name }}'

--- a/group_vars/tigerdata/qa.yml
+++ b/group_vars/tigerdata/qa.yml
@@ -3,7 +3,7 @@ postgres_host: "lib-postgres-qa1.princeton.edu"
 
 passenger_server_name: "tigerdata-qa.princeton.edu"
 passenger_app_env: "qa"
-desired_nodejs_version: "v20.15.1"
+desired_nodejs_version: "v22.17.0"
 
 app_secret_key: '{{ vault_tigerdata_qa_secret_key }}'
 app_db_name: '{{ vault_tigerdata_qa_db_name }}'

--- a/group_vars/tigerdata/qa.yml
+++ b/group_vars/tigerdata/qa.yml
@@ -3,7 +3,7 @@ postgres_host: "lib-postgres-qa1.princeton.edu"
 
 passenger_server_name: "tigerdata-qa.princeton.edu"
 passenger_app_env: "qa"
-desired_nodejs_version: "v22.17.0"
+desired_nodejs_version: "v22.9.0"
 
 app_secret_key: '{{ vault_tigerdata_qa_secret_key }}'
 app_db_name: '{{ vault_tigerdata_qa_db_name }}'

--- a/group_vars/tigerdata/staging.yml
+++ b/group_vars/tigerdata/staging.yml
@@ -4,7 +4,7 @@ postgres_host: "lib-postgres-staging1.princeton.edu"
 passenger_server_name: "tigerdata-staging.princeton.edu"
 passenger_app_env: "staging"
 passenger_extra_config: "{{ lookup('template', 'roles/tigerdata/templates/nginx_extra_config.j2') }}"
-desired_nodejs_version: "v20.15.1"
+desired_nodejs_version: "v22.17.0"
 
 app_secret_key: '{{ vault_tigerdata_staging_secret_key }}'
 app_db_name: '{{ vault_tigerdata_staging_db_name }}'

--- a/group_vars/tigerdata/staging.yml
+++ b/group_vars/tigerdata/staging.yml
@@ -4,7 +4,7 @@ postgres_host: "lib-postgres-staging1.princeton.edu"
 passenger_server_name: "tigerdata-staging.princeton.edu"
 passenger_app_env: "staging"
 passenger_extra_config: "{{ lookup('template', 'roles/tigerdata/templates/nginx_extra_config.j2') }}"
-desired_nodejs_version: "v22.17.0"
+desired_nodejs_version: "v22.9.0"
 
 app_secret_key: '{{ vault_tigerdata_staging_secret_key }}'
 app_db_name: '{{ vault_tigerdata_staging_db_name }}'


### PR DESCRIPTION
This advances https://github.com/pulibrary/tigerdata-app/issues/1598