### PR TITLE
[svn] remove lib-svn-staging1 from inventory

### DIFF
--- a/inventory/all_projects/lib-svn
+++ b/inventory/all_projects/lib-svn
@@ -1,4 +1,2 @@
-[lib_svn_staging]
-lib-svn-staging1.princeton.edu
 [lib_svn_production]
 lib-svn-prod1.princeton.edu

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -21,7 +21,6 @@ lae_staging
 lib_jobs_staging
 libsftp_staging
 lib_fs_staging
-lib_svn_staging
 lockers_and_study_spaces_staging
 mflux_staging
 mysql_staging


### PR DESCRIPTION
we have migrated the staging to use git

related to https://github.com/pulibrary/ops-catchall/issues/84
