### PR TITLE
Removes derrida crawl and twade sandbox machines,adds derrida prod2 VM

### DIFF
--- a/inventory/all_projects/derrida
+++ b/inventory/all_projects/derrida
@@ -1,6 +1,5 @@
 [derrida_staging]
 cdh-test-derrida1.princeton.edu
-cdh-test-derrida-crawl1.princeton.edu
 [derrida_production]
 cdh-derrida1.princeton.edu
-cdh-derrida-crawl1.princeton.edu
+cdh-derrida2.princeton.edu

--- a/inventory/all_projects/sandboxes
+++ b/inventory/all_projects/sandboxes
@@ -1,9 +1,8 @@
 [sandboxes]
 # these are all in the staging environment
 sandbox-acozine.lib.princeton.edu
-sandbox-rl3667.lib.princeton.edu
-sandbox-tw8766.lib.princeton.edu
-sandbox-vkarasic.lib.princeton.edu
 sandbox-aruiz.lib.princeton.edu
 sandbox-dp1285.lib.princeton.edu
 sandbox-fkayiwa1.lib.princeton.edu
+sandbox-rl3667.lib.princeton.edu
+sandbox-vkarasic.lib.princeton.edu


### PR DESCRIPTION
Closes #6358.

Related to #6357.

This PR does a little tidying on our inventory - removing decommissioned VMs and adding a production VM that was previously missed.