### PR TITLE
removes sandbox-rl36671 from inventory, consolidates sandbox entries

### DIFF
--- a/inventory/all_projects/_orphans
+++ b/inventory/all_projects/_orphans
@@ -26,13 +26,3 @@ libserv55.princeton.edu # hot, no clues
 libserv101.princeton.edu # aka 128.112.200.213
 libserv128.princeton.edu # hot, no clues
 theprince.princeton.edu
-[sandboxes]
-sandbox-acozine.lib.princeton.edu
-sandbox-bs3097.lib.princeton.edu
-sandbox-dp1285.lib.princeton.edu
-sandbox-fkayiwa1.lib.princeton.edu
-sandbox-heberlei.lib.princeton.edu
-sandbox-pp9425.lib.princeton.edu
-sandbox-rl36671.lib.princeton.edu
-sandbox-vkarasic.lib.princeton.edu
-sandbox-aruiz.lib.princeton.edu

--- a/inventory/all_projects/sandboxes
+++ b/inventory/all_projects/sandboxes
@@ -2,6 +2,9 @@
 # these are all in the staging environment
 sandbox-acozine.lib.princeton.edu
 sandbox-aruiz.lib.princeton.edu
+sandbox-bs3097.lib.princeton.edu
 sandbox-dp1285.lib.princeton.edu
 sandbox-fkayiwa1.lib.princeton.edu
+sandbox-heberlei.lib.princeton.edu
+sandbox-pp9425.lib.princeton.edu
 sandbox-vkarasic.lib.princeton.edu


### PR DESCRIPTION
We had a `sandboxes` group in the `_orphans` file in inventory. We also had a dedicated file in `all_projects` called `sandboxes` with another group and a different list of VMs.

This PR removes one obsolete sandbox VM (sandbox-rl36671), deduplicates, consolidates, and alphabetizes the others.