### PR TITLE
Use only one pair of double quotes for Bibdata allow list

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -57,7 +57,7 @@ rails_app_vars:
   - name: BIBDATA_DB_HOST
     value: '{{ postgres_host }}'
   - name: BIBDATA_IP_ALLOWLIST
-    value: '"{{ bibdata_ip_allowlist | join(" ") }}"'
+    value: '{{ bibdata_ip_allowlist | join(" ") }}'
   - name: BIBDATA_RAILS_KEY
     value: '{{ bibdata_rails_key }}'
   - name: BIBDATA_DATA_DIR

--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -53,7 +53,7 @@ rails_app_vars:
   - name: BIBDATA_DB_HOST
     value: '{{ postgres_host }}'
   - name: BIBDATA_IP_ALLOWLIST
-    value: '"{{ bibdata_qa_ip_allowlist | join(" ") }}"'
+    value: '{{ bibdata_qa_ip_allowlist | join(" ") }}'
   - name: BIBDATA_RAILS_KEY
     value: '{{ bibdata_rails_key }}'
   - name: BIBDATA_DATA_DIR

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -57,7 +57,7 @@ rails_app_vars:
   - name: BIBDATA_DB_HOST
     value: '{{ postgres_host }}'
   - name: BIBDATA_IP_ALLOWLIST
-    value: '"{{ bibdata_staging_ip_allowlist | join(" ") }}"'
+    value: '{{ bibdata_staging_ip_allowlist | join(" ") }}'
   - name: BIBDATA_RAILS_KEY
     value: '{{ bibdata_rails_key }}'
   - name: BIBDATA_DATA_DIR


### PR DESCRIPTION
Prior to this commit, running the bibdata playbook led to the following line in ~deploy/app_configs/bibdata:

```
export BIBDATA_IP_ALLOWLIST=""128.112.200.203 128.112.204.114""
```

And when you ran `env | grep -i allowlist`, you got:

```
BIBDATA_IP_ALLOWLIST=128.112.200.203
```

And when you log into a new SSH session, you got this distracting error:

```
-bash: export: `128.112.204.114': not a valid identifier
```

Since #6368 was merged, we no longer need to supply double quotes for this environment variable, so let's remove them so we only have one pair of quotes.

I have run this on staging and qa.