### PR TITLE
Enable Tower to connect to GCP hosts

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -47,7 +47,7 @@ dspace_dev
 obsd_httpd_dev
 
 [gcp_dev:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-dev.pulcloud.io"'
+ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new ProxyCommand="ssh -W %h:%p -q pulsys@bastion-dev.pulcloud.io"'
 checkmk_folder=linux/staging
 
 [gcp_production:children]
@@ -56,7 +56,7 @@ obsd_httpd_production
 sftp_production
 
 [gcp_production:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-prod.pulcloud.io"'
+ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new ProxyCommand="ssh -W %h:%p -q pulsys@bastion-prod.pulcloud.io"'
 checkmk_folder=linux/production
 
 [gcp_staging:children]
@@ -65,7 +65,7 @@ dspace_staging
 obsd_httpd_staging
 
 [gcp_staging:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q pulsys@bastion-staging.pulcloud.io"'
+ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new ProxyCommand="ssh -J pulsys@bastion-staging.pulcloud.io"'
 ansible_python_interpreter=/usr/bin/python3
 checkmk_folder=linux/staging
 


### PR DESCRIPTION
Related to #6357.

Connections through our jump hosts to GCP resources were failing in Tower with an error about accepting the host key. 

This PR sets an SSH argument that accepts the host key the first time it's encountered. When added as a variable to a Template in Tower, this SSH argument allowed Tower to gather facts on a GCP machine. Adding it to our inventory should continue to allow access from Tower without changing our approach to other infrastructure.