### PR TITLE
GCP third time's the charm?

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -8,7 +8,7 @@ bastion-dev.pulcloud.io
 bastion-prod.pulcloud.io
 
 [bastion_staging]
-bastion-staging.pulcloud.io ansible_python_interpreter=/usr/bin/python
+bastion-staging.pulcloud.io
 
 [cdhapps_staging]
 gcp-simrisk-staging ansible_host=10.140.0.17
@@ -30,6 +30,7 @@ gcp-oar-staging1 ansible_host=10.132.0.4
 dev.pulcloud.io
 
 [obsd_httpd_production]
+# inventory name is prod.pucloud.io but the VM name in google cloud is pul-gcdc-prod-adc
 prod.pulcloud.io ansible_host=10.246.0.2
 
 [obsd_httpd_staging]
@@ -80,6 +81,7 @@ sftp_production
 
 [obsd:vars]
 ansible_become_method=doas
+ansible_python_interpreter=/usr/bin/python
 
 [gcp_operations:children]
 bastion_dev


### PR DESCRIPTION
Related to #6378 and its friends.

We are trying to get connectivity from Tower to our GCP hosts via our jump hosts. By adding `-o StrictHostKeyChecking=accept-new` to our `ansible_ssh_common_args` we got past the Host Key checking error. The latest error is:

`Data could not be sent to remote host <IP or hostname here>.  Make sure this host can be reached over ssh: hostname contains invalid characters\r\n"`

We get the same error when we set the `ansible_host` to the private IP (`10.140.0.3`) and also when we set it to the GCP internal name (`gcp-dataspace-staging1.us-central1-a.c.pul-gcdc.internal`). 

On my laptop, SSH works to these hosts. My ssh config looks like this:

```
Host gcp_staging_jump
    user pulsys
    hostname bastion-staging.pulcloud.io

Host gcp_dataspace_staging1
    user pulsys
    hostname 10.132.0.5
    ForwardAgent yes
    ProxyCommand ssh gcp_staging_jump -W %h:%p
```

This PR attempts to recreate my SSH config file in our inventory, adding `ForwardAgent=yes` and trying a different syntax option in each environment:

- in prod, placing the jump host's `user@hostname` at the end of the ProxyCommand
- in staging, placing the jump host's `user@hostname` in the middle of the ProxyCommand, which approximates the entry in my config file above

I first tried to set all of these options in a variable in the Tower template, but that didn't work. One error I got was `Could not resolve hostname forwardagent=yes: Name or service not known` - my best guess is that only one of the `-o` options gets passed along, I'm not sure why. In the Tower template I tried setting them all together with `-o This=That OtherThing=Whatever`; I also tried setting them separately with `-o This=That -o OtherThing=Whatever`.

I'm hoping that setting these things in inventory will make them available in Tower. Consensus seems to be that each options needs its own `-o` so that's what I'm trying here.