### PR TITLE
[TOWER] Update tower to allow for newer version of capistrano

### DIFF
--- a/roles/towerdeploy/defaults/main.yml
+++ b/roles/towerdeploy/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for towerdeploy
-cap_version: "3.18.0"
+cap_version: "3.19.2"

--- a/roles/towerdeploy/molecule/default/verify.yml
+++ b/roles/towerdeploy/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: false
   vars:
-  - cap_version: "3.18.0"
+  - cap_version: "3.19.2"
   tasks:
   - name: check capistrano status
     ansible.builtin.command: cap --version


### PR DESCRIPTION
The new Hanami ORCID application utilizes a newer version of Capistrano.  This should allow that application and older ones to deploy.