### PR TITLE
Add quotes to GCP inventory vars

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -47,7 +47,7 @@ dspace_dev
 obsd_httpd_dev
 
 [gcp_dev:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh -o ForwardAgent yes -o StrictHostKeyChecking=accept-new -q pulsys@bastion-dev.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args='-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-dev.pulcloud.io -W %h:%p"'
 checkmk_folder=linux/staging
 
 [gcp_production:children]
@@ -56,7 +56,7 @@ obsd_httpd_production
 sftp_production
 
 [gcp_production:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh -o ForwardAgent yes -o StrictHostKeyChecking=accept-new -q pulsys@bastion-prod.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args='-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p"'
 checkmk_folder=linux/production
 
 [gcp_staging:children]
@@ -65,7 +65,7 @@ dspace_staging
 obsd_httpd_staging
 
 [gcp_staging:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh -o ForwardAgent yes -o StrictHostKeyChecking=accept-new -q pulsys@bastion-staging.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args='-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-staging.pulcloud.io -W %h:%p"'
 ansible_python_interpreter=/usr/bin/python3
 checkmk_folder=linux/staging
 


### PR DESCRIPTION
Follow-up on #6379.

The template failed this morning (after updating to the head of the main branch) with the errror `Make sure this host can be reached over ssh: kex_exchange_identification: Connection closed by remote host\`.
I'm confident that this means the `ForwardAgent yes` param is not getting passed. 

Comparing the current state of the inventory vars with the vars that worked in Tower, there was a difference in quoting. The vars need internal quotes for the settings to be passed correctly. 