### PR TITLE
Seeking the right combination of quotes and escaping for GCP inventory vars

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -47,7 +47,7 @@ dspace_dev
 obsd_httpd_dev
 
 [gcp_dev:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-dev.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args="-o ProxyCommand=\"ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-dev.pulcloud.io -W %h:%p\""
 checkmk_folder=linux/staging
 
 [gcp_production:children]
@@ -56,7 +56,7 @@ obsd_httpd_production
 sftp_production
 
 [gcp_production:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args=-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p"
 checkmk_folder=linux/production
 
 [gcp_staging:children]
@@ -65,7 +65,7 @@ dspace_staging
 obsd_httpd_staging
 
 [gcp_staging:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-staging.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args='-o ProxyCommand="ssh \'-o ForwardAgent yes\' \'-o StrictHostKeyChecking=accept-new\' -q pulsys@bastion-staging.pulcloud.io -W %h:%p"'
 ansible_python_interpreter=/usr/bin/python3
 checkmk_folder=linux/staging
 


### PR DESCRIPTION
More follow-up on #6385 and #6379.

As currently written in the main branch, the ssh options for gcp resources behind the bastion hosts are not correctly pulled into Tower.

We need:
`ansible_ssh_common_args: -o ProxyCommand="ssh -o 'ForwardAgent yes' -o 'StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p"`

Tower has:
`"ansible_ssh_common_args": "'-o ProxyCommand=\"ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p\"'"`

This PR tries three different approaches to quotations and escaping for the gcp inventory. Again, we need to merge these to main so we can test them in Tower. If one of them works correctly, I'll follow up with a PR to fix the other two.

Fingers crossed.