### PR TITLE
Allow Tower to connect to GCP resources 

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -47,7 +47,7 @@ dspace_dev
 obsd_httpd_dev
 
 [gcp_dev:vars]
-ansible_ssh_common_args="-o ProxyCommand=\"ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-dev.pulcloud.io -W %h:%p\""
+ansible_ssh_common_args=-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-dev.pulcloud.io -W %h:%p"
 checkmk_folder=linux/staging
 
 [gcp_production:children]
@@ -65,7 +65,7 @@ dspace_staging
 obsd_httpd_staging
 
 [gcp_staging:vars]
-ansible_ssh_common_args='-o ProxyCommand="ssh \'-o ForwardAgent yes\' \'-o StrictHostKeyChecking=accept-new\' -q pulsys@bastion-staging.pulcloud.io -W %h:%p"'
+ansible_ssh_common_args=-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-staging.pulcloud.io -W %h:%p"
 ansible_python_interpreter=/usr/bin/python3
 checkmk_folder=linux/staging
 


### PR DESCRIPTION
Final piece of GCP connectivity through our bastion hosts.

Related to #6388, #6385, #6379, #6378, and #6376.

In #6388 we tried three different options for the ProxyCommand. The vars for the GCP prod group worked. This PR updates the other two groups to use the same syntax.