### PR TITLE
removes pas upgrade VMs from inventory

### DIFF
--- a/inventory/all_projects/pas
+++ b/inventory/all_projects/pas
@@ -4,6 +4,3 @@ slavery-prod2.princeton.edu
 [pas_staging]
 slavery-staging1.lib.princeton.edu
 slavery-staging2.lib.princeton.edu
-[pas_staging_upgrade]
-slavery-staging-upgrade1.lib.princeton.edu
-slavery-staging-upgrade2.lib.princeton.edu

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -34,7 +34,6 @@ obsd_httpd_staging
 orangelight_staging
 orcid_staging
 pas_staging
-pas_staging_upgrade
 pdc_staging
 pdc_describe_staging
 pdc_describe_redis_staging


### PR DESCRIPTION
Partial fix for #6306.

Partial fix for #6357.

We no longer need staging-upgrade VMs for the PAS project. They've already been shut off and will be deleted soon. 

This PR removes them from our Ansible inventory. 