### PR TITLE
updates all mentions of python-setuptools to python3-setuptools

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -26,7 +26,7 @@ common_ubuntu_packages:
   - plocate
   - python3-apt
   - python3-pip
-  - python-setuptools
+  - python3-setuptools
   - silversearcher-ag
   - zlib1g-dev
 common_rhel_packages:

--- a/roles/common/molecule/default/group_vars/all.yml
+++ b/roles/common/molecule/default/group_vars/all.yml
@@ -43,7 +43,7 @@ common_ubuntu_packages:
   - plocate
   - python3-apt
   - python3-pip
-  - python-setuptools
+  - python3-setuptools
   - silversearcher-ag
   - zlib1g-dev
 

--- a/roles/shibboleth/molecule/default/converge.yml
+++ b/roles/shibboleth/molecule/default/converge.yml
@@ -17,7 +17,7 @@
       - unzip
       - zip
       - python3-pip
-      - python-setuptools
+      - python3-setuptools
       - libssl-dev
       - zlib1g-dev
       - tmux


### PR DESCRIPTION
As part of #6357, we discovered that Ubuntu 24.04 LTS "Noble Nombat" requires `python3-setuptools` instead of  `python-setuptools` as a package name.

I logged into a sandbox VM running Ubuntu 22.04 LTS "Jammy Jellyfish", and it accepted either package name, confirming that the setup tools are installed in both cases.

This PR makes the common role support both Noble and Jammy. 