### PR TITLE
Fix staging failures in Tower

### DIFF
--- a/inventory/all_projects/cantaloupe
+++ b/inventory/all_projects/cantaloupe
@@ -1,4 +1,2 @@
-[cantaloupe_staging]
-iiif-staging1.princeton.edu
 [cantaloupe_production]
 libimages2.princeton.edu

--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -81,7 +81,7 @@ sftp_production
 
 [obsd:vars]
 ansible_become_method=doas
-ansible_python_interpreter=/usr/bin/python
+ansible_python_interpreter=/usr/local/bin/python3
 
 [gcp_operations:children]
 bastion_dev

--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -6,7 +6,6 @@ approvals_staging
 bastion_staging
 bibdata_staging
 byzantine_staging
-cantaloupe_staging
 cdh_staging
 derrida_staging
 dpul_staging
@@ -67,7 +66,6 @@ approvals_staging
 bastion_staging
 bibdata_staging
 byzantine_staging
-cantaloupe_staging
 cdh_staging
 derrida_staging
 dpul_staging

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,6 +12,10 @@
     state: present
   loop:
     - "{{ common_shared_packages }}"
+  when:
+    - ansible_os_family != "OpenBSD"
+    # our openBSD servers are minimalist
+    # we don't install tools on them
 
 - name: Common | Install common ubuntu packages
   ansible.builtin.package:


### PR DESCRIPTION
Partial fix for #6357.

This exempts the OpenBSD machines from our usual tool-installation tasks. Most things (like tmux) are already built into OpenBSD. Everything else is unnecessary on the few OpenBSD machines we run.

Also removes iiif-staging1 from inventory. It doesn't exist any more, which is why it was unreachable.