### PR TITLE
[LIB-JOBS] Remove the lib-jobs specific app config sfx_wroldcat

### DIFF
--- a/roles/lib_jobs/molecule/default/verify.yml
+++ b/roles/lib_jobs/molecule/default/verify.yml
@@ -9,7 +9,7 @@
       stat:
         path: "{{ item }}"
       loop:
-        - "/home/deploy/app_configs/sfx_worldcat"
+        - "/home/deploy/app_configs/lib-jobs"
       register: file
       failed_when:
         - not file.stat.exists

--- a/roles/lib_jobs/tasks/main.yml
+++ b/roles/lib_jobs/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 # tasks file for roles/lib_jobs
-# needed for capistrano to have access
-- name: lib_jobs | Install site configuration
-  ansible.builtin.template:
-    src: 'ruby_app_config'
-    dest: '/home/{{ deploy_user }}/app_configs/{{ ruby_app_name }}'
-    owner: '{{ deploy_user }}'
-    group: '{{ deploy_user }}'
-    mode: 0644
-
 - name: lib_jobs | Create app directory structure
   ansible.builtin.file:
     path: '/opt/{{ app_directory }}/shared/tmp'

--- a/roles/lib_jobs/templates/ruby_app_config
+++ b/roles/lib_jobs/templates/ruby_app_config
@@ -1,3 +1,0 @@
-{% for variable in rails_app_vars %}
-export {{variable.name}}={{variable.value}}
-{% endfor %}


### PR DESCRIPTION
Rely on the app config created by the ruby app role