### PR TITLE
[orangelight] Remove unnecessary duplicate quotes from environment variable

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -115,7 +115,7 @@ rails_app_vars:
   - name: OL_SECRET_KEY_BASE
     value: "{{ ol_secret_key }}"
   - name: ORANGELIGHT_ADMIN_NETIDS
-    value: '"{{ ol_admin_netids | join(" ") }}"'
+    value: '{{ ol_admin_netids | join(" ") }}'
   - name: SCSB_AUTH_KEY
     value: "{{ scsb_auth_key }}"
   - name: SECRET_KEY_BASE


### PR DESCRIPTION
With the duplicate quotes, only the first username in the array actually gets added to the `ORANGELIGHT_ADMIN_NETIDS` environment variable, and everybody else does not get access to the flipflop features.