### PR TITLE
Put dpulc-prod behind the load bot wall.

### DIFF
--- a/roles/nginxplus/files/conf/http/dpul-collections-prod.conf
+++ b/roles/nginxplus/files/conf/http/dpul-collections-prod.conf
@@ -3,7 +3,7 @@ proxy_cache_path /var/cache/nginx/dpul-collections-prod/ keys_zone=dpul-collecti
 
 upstream dpul-collections-prod {
     zone dpul-collections-prod 64k;
-    server service.consul service=frontend.dpulc-production-web resolve;
+    server service.consul service=highchallenge.traefik-wall-production resolve max_fails=0;
     sticky learn
           create=$upstream_cookie_dpulcollectionsprodcookie
           lookup=$cookie_dpulcollectionsprodcookie
@@ -37,6 +37,8 @@ server {
         proxy_pass http://dpul-collections-prod;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_cache dpul-collections-prodcache;
         # Block public access for now, until content warnings are done.
         # allow princeton network


### PR DESCRIPTION
Closes pulibrary/dpul-collections#492
