### PR TITLE
Tidy inventory, get rid of playbook warnings

### DIFF
--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -94,7 +94,6 @@ obsd_httpd_staging
 orangelight_staging
 orcid_staging
 pas_staging
-pas_staging_upgrade
 pdc_staging
 pdc_describe_staging
 pdc_discovery_staging


### PR DESCRIPTION
Closes #6406.

After we got rid of the `lib_svn` groups in #6419, Ansible started complaining about the `pas_staging_upgrade` group.

The warnings about `allsearch_api_*` seem to be generic "this inventory file has issues" warnings that just return the first group name in the file. They have disappeared on this branch.

Removes a stray reference to the `pas_staging_upgrade` group. 