### PR TITLE
[common] check for checkmk

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -134,6 +134,12 @@
     - running_on_server
     - dua_version_result.stdout is defined and dua_version_result.rc == 0
 
+- name: Common | Check for checkmk agent binary
+  ansible.builtin.stat:
+    path: /usr/bin/cmk-agent-ctl
+  register: checkmk_binary_stat
+  when: running_on_server
+
 - name: Common | install logrotate check
   ansible.builtin.copy:
     src: logrotatecheck.sh
@@ -141,7 +147,9 @@
     mode: "0755"
     owner: root
     group: root
-  when: running_on_server
+  when:
+    - running_on_server
+    - checkmk_binary_stat.stat.exists
 
 - name: Common | install vector, but not in testing
   ansible.builtin.include_tasks: vector.yml


### PR DESCRIPTION
Our common role is setup assuming our virtual machines have checkmk
we add a task that checks for the checkmk binary. If it is present the
logrotate file is added. Otherwise it skips
