### PR TITLE
[ponyexpr] remove acme certs

### DIFF
--- a/roles/postfix/molecule/default/verify.yml
+++ b/roles/postfix/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: check postfix package status
+  - name: Check postfix package status
     ansible.builtin.apt:
       name: "{{ item }}"
       state: present
@@ -12,7 +12,7 @@
     loop:
       - postfix
 
-  - name: test for postfix packages
+  - name: Test for postfix packages
     assert:
       that:
         - not pkg_status.changed

--- a/roles/postfix/molecule/default/verify.yml
+++ b/roles/postfix/molecule/default/verify.yml
@@ -3,16 +3,16 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: Check postfix package status
-    ansible.builtin.apt:
-      name: "{{ item }}"
-      state: present
-    check_mode: true
-    register: pkg_status
-    loop:
-      - postfix
+    - name: Check postfix package status
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+      check_mode: true
+      register: pkg_status
+      loop:
+        - postfix
 
-  - name: Test for postfix packages
-    assert:
-      that:
-        - not pkg_status.changed
+    - name: Test for postfix packages
+      ansible.builtin.assert:
+        that:
+          - not pkg_status.changed

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 # tasks file for roles/postfix
+- name: Postfix | Install postfix
+  ansible.builtin.apt:
+    name: postfix
+    state: present
+    update_cache: true
+
 - name: Postfix | add mailname
   ansible.builtin.copy:
     dest: "/etc/mailname"
@@ -15,14 +21,6 @@
     path: "{{ postfix_main_cf }}"
     regexp: "^(smtpd_tls_cert_file|smtpd_tls_key_file) = /etc/ssl/certs/ssl-cert-snakeoil.(pem|key)$"
     state: absent
-
-- name: Postfix - ensure postfix directory
-  ansible.builtin.file:
-    path: /etc/postfix
-    owner: root
-    group: root
-    mode: '0600'
-    state: directory
 
 - name: Postfix | create networks file
   ansible.builtin.template:

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -16,15 +16,6 @@
     regexp: "^(smtpd_tls_cert_file|smtpd_tls_key_file) = /etc/ssl/certs/ssl-cert-snakeoil.(pem|key)$"
     state: absent
 
-- name: Postfix | Install Postfix and certbot
-  ansible.builtin.apt:
-    name: "{{ item }}"
-    state: present
-    update_cache: true
-  loop:
-    - postfix
-    - certbot
-
 - name: Postfix | create networks file
   ansible.builtin.template:
     src: "mynetworks.j2"
@@ -64,47 +55,6 @@
   changed_when: false
   when: running_on_server
   notify: restart postfix
-
-- name: Postfix | update acme certificates for {{ domain_name }}
-  ansible.builtin.command: /usr/bin/certbot certonly --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ domain_name }} --cert-name {{ domain_name }}
-  changed_when: false
-  when: running_on_server
-
-- name: Postfix | Configure TLS in main.cf
-  ansible.builtin.blockinfile:
-    path: "{{ postfix_main_cf }}"
-    block: |
-      smtpd_tls_cert_file = /etc/letsencrypt/live/{{ domain_name }}/fullchain.pem
-      smtpd_tls_key_file = /etc/letsencrypt/live/{{ domain_name }}/privkey.pem
-      smtpd_use_tls = yes
-      smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
-      smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
-
-  notify: restart postfix
-  when: running_on_server
-
-- name: Postfix | Update master.cf for submission service
-  ansible.builtin.blockinfile:
-    path: "/etc/postfix/master.cf"
-    block: |
-      # Enable the SMTP service on port 25
-      smtp      inet  n       -       n       -       -       smtpd
-      # Enable the submission service on port 587
-      submission inet n - n - - smtpd
-        -o syslog_name=postfix/submission
-        -o smtpd_tls_wrappermode=no
-        -o smtpd_tls_security_level=encrypt
-        -o smtpd_sasl_auth_enable=yes
-        -o smtpd_reject_unlisted_recipient=no
-        -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-        -o smtpd_sender_restrictions=permit_sasl_authenticated,reject
-        -o smtpd_recipient_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
-        -o smtpd_relay_restrictions=permit_sasl_authenticated,reject_unauth_destination
-    owner: root
-    group: root
-    mode: "0644"
-  notify: restart postfix
-  when: running_on_server
 
 - name: Postfix | Add relay host
   ansible.builtin.include_tasks: update_config.yml

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -16,6 +16,14 @@
     regexp: "^(smtpd_tls_cert_file|smtpd_tls_key_file) = /etc/ssl/certs/ssl-cert-snakeoil.(pem|key)$"
     state: absent
 
+- name: Postfix - ensure postfix directory
+  ansible.builtin.file:
+    path: /etc/postfix
+    owner: root
+    group: root
+    mode: '0600'
+    state: directory
+
 - name: Postfix | create networks file
   ansible.builtin.template:
     src: "mynetworks.j2"

--- a/roles/postfix/vars/main.yml
+++ b/roles/postfix/vars/main.yml
@@ -121,7 +121,6 @@ postfix_relay_hosts_addresses:
   - pdc-describe-prod3.princeton.edu
   - pdc-discovery-prod1.princeton.edu
   - pdc-discovery-prod2.princeton.edu
-  - prds-prod2.princeton.edu
   - pulfalight-jammy-prod1.princeton.edu
   - pulfalight-jammy-prod2.princeton.edu
   - pulfalight-prod-worker1.princeton.edu


### PR DESCRIPTION
our relayhost has a different domain name than the upstream relay.
we do not actually send mail but route to another relay

closes #6322
