### PR TITLE
Enable back support for SHA1 certs in CI Deployer for podman

### DIFF
--- a/nomad/circleci_deployer/Dockerfile
+++ b/nomad/circleci_deployer/Dockerfile
@@ -72,7 +72,7 @@ uidmap \
 slirp4netns
 
 # Enabling back support for SHA1 signed certificates
-RUN sudo apt-get crypto-policies
-RUN update-crypto-policies --set DEFAULT:SHA1
+RUN sudo apt-get install crypto-policies
+RUN sudo update-crypto-policies --set DEFAULT:SHA1
 
 RUN echo "$(ruby --version)"

--- a/nomad/circleci_deployer/Dockerfile
+++ b/nomad/circleci_deployer/Dockerfile
@@ -71,4 +71,7 @@ RUN sudo apt-get update -qq && DEBIAN_FRONTEND=noninteractive sudo apt-get insta
 uidmap \
 slirp4netns
 
+# Enabling back support for SHA1 signed certificates
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 RUN echo "$(ruby --version)"

--- a/nomad/circleci_deployer/Dockerfile
+++ b/nomad/circleci_deployer/Dockerfile
@@ -73,6 +73,6 @@ slirp4netns
 
 # Enabling back support for SHA1 signed certificates
 RUN sudo apt-get install crypto-policies
-RUN sudo update-crypto-policies --set DEFAULT:SHA1
+# RUN sudo update-crypto-policies --set DEFAULT:SHA1
 
 RUN echo "$(ruby --version)"

--- a/nomad/circleci_deployer/Dockerfile
+++ b/nomad/circleci_deployer/Dockerfile
@@ -72,6 +72,7 @@ uidmap \
 slirp4netns
 
 # Enabling back support for SHA1 signed certificates
+RUN sudo apt-get crypto-policies
 RUN update-crypto-policies --set DEFAULT:SHA1
 
 RUN echo "$(ruby --version)"


### PR DESCRIPTION
Allows SHA1 in a podman container, done for https://github.com/pulibrary/tigerdata-app/issues/1662