### PR TITLE
Tidy up config for EAL websites

### DIFF
--- a/group_vars/ealapps/production.yml
+++ b/group_vars/ealapps/production.yml
@@ -39,7 +39,7 @@ datadog_typed_checks:
     configuration:
       init_config:
       instances:
-        - server: eal-apps-prod1.princeton.edu
+        - server: eal-prod1.princeton.edu
           port: 443
   - type: process
     configuration:

--- a/group_vars/ealapps/staging.yml
+++ b/group_vars/ealapps/staging.yml
@@ -7,7 +7,7 @@ mailcatcher_user: "pulsys"
 mailcatcher_group: "pulsys"
 mysql_server: false
 
-ealapp_domain_name: "eal-apps-staging.princeton.edu"
+ealapp_domain_name: "eal-staging.lib.princeton.edu"
 
 ealapp_db_name: "ealapps_staging_db"
 ealapp_db_user: "ealapps_staging_db_user"

--- a/roles/nginxplus/files/conf/http/dev/templates/libwww-proxy-pass-staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/templates/libwww-proxy-pass-staging.conf
@@ -119,19 +119,19 @@
 
    # East Asian Library utilities
     location /eastasian/newtitles/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/newtitles/;
+        proxy_pass https://eal-staging.lib.princeton.edu/newtitles/;
     }
     location /eastasian/stafftools/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/stafftools/;
+        proxy_pass https://eal-staging.lib.princeton.edu/stafftools/;
     }
     location /eastasian/assets/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/assets/;
+        proxy_pass https://eal-staging.lib.princeton.edu/assets/;
     }
     location /eastasian/EALJ/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/EALJ/;
+        proxy_pass https://eal-staging.lib.princeton.edu/EALJ/;
     }
     location /eastasian/shadowfigures/ {
-        proxy_pass https://eal-apps-staging.princeton.edu/shadowfigures/;
+        proxy_pass https://eal-staging.lib.princeton.edu/shadowfigures/;
     }
 # Libguide Redirects
 #

--- a/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
+++ b/roles/nginxplus/files/conf/http/templates/libwww-proxy-pass-prod.conf
@@ -71,19 +71,19 @@
 
     # eastasian library utilities
     location /eastasian/newtitles/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/newtitles/;
+        proxy_pass https://eal.lib.princeton.edu/newtitles/;
     }
     location /eastasian/stafftools/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/stafftools/;
+        proxy_pass https://eal.lib.princeton.edu/stafftools/;
     }
     location /eastasian/assets/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/assets/;
+        proxy_pass https://eal.lib.princeton.edu/assets/;
     }
     location /eastasian/EALJ/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/EALJ/;
+        proxy_pass https://eal.lib.princeton.edu/EALJ/;
     }
     location /eastasian/shadowfigures/ {
-        proxy_pass https://eal-apps-prod.princeton.edu/shadowfigures/;
+        proxy_pass https://eal.lib.princeton.edu/shadowfigures/;
     }
 
 # Libguide Redirects


### PR DESCRIPTION
Follows up on #5231.

We stopped using the `eal-apps` name last year, but we missed a couple of places where the old name persisted. 

This PR updates updates vars and proxy passes to use the new names. I'll also revoke the SSL certs for the old site names.