### PR TITLE
[CircleCI Runner] Clean up CircleCI Deployer Working Directory

### DIFF
--- a/nomad/circleci_deployer/deploy/all.hcl
+++ b/nomad/circleci_deployer/deploy/all.hcl
@@ -40,6 +40,7 @@ job "circleci-runner" {
         CIRCLECI_API_TOKEN = {{.CIRCLECI_API_TOKEN}}
         CIRCLECI_RUNNER_API_AUTH_TOKEN = {{.CIRCLECI_API_TOKEN}}
         CIRCLECI_RUNNER_NAME = "circleci-deployer-{{ env "NOMAD_ALLOC_INDEX" }}"
+        CIRCLECI_RUNNER_CLEANUP_WORK_DIR = true
         {{- end -}}
         EOF
       }


### PR DESCRIPTION
The nomad boxes were running out of disk space because the deployer
wasn't cleaning up after itself.
