### PR TITLE
Playbook to revoke SSL certs should check `nginx -t` for safety

### DIFF
--- a/playbooks/utils/incommon_certbot_revoke.yml
+++ b/playbooks/utils/incommon_certbot_revoke.yml
@@ -3,7 +3,7 @@
 # to run in production, you must add '-e runtime_env=production'
 # Run the playbook on the inactive load balancer first
 # if the 'nginx -t' check fails, we probably didn't delete an obsolete config file
-# run 'playbooks/nginx.yml' following the comments for removing obsolete config
+# run 'playbooks/nginx.yml' (or nginx_staging.yml) following the comments for removing obsolete config
 
 - name: revoke incommon acme for {{ domain_name }}
   hosts: nginxplus_{{ runtime_env | default('staging') }}
@@ -18,8 +18,6 @@
       msg: "you must use -l or --limit"
     when: ansible_limit is not defined
     run_once: true
-  vars_files:
-    - ../group_vars/all/vault.yml
 
   tasks:
     - name: install certbot software
@@ -42,7 +40,7 @@
       rescue:
         - name: issue warning if nginx -t fails
           ansible.builtin.debug:
-            msg: 'config check failed, something (probably obsolete config) is pointing to the cert you just revoked; make nginx -t succeed before you revoke the cert on the other server'
+            msg: 'config check failed, something is broken (probably obsolete config pointing to the cert you revoked); make nginx -t succeed before you revoke the cert on the other server'
 
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:

--- a/playbooks/utils/incommon_certbot_revoke.yml
+++ b/playbooks/utils/incommon_certbot_revoke.yml
@@ -1,7 +1,10 @@
 ---
 # you MUST run this playbook on a single host with '--limit' for example `ansible-playbook -e domain_name=orcid-staging --limit adc-dev2.princeton.edu playbooks/utils/incommon_certbot_revoke.yml`
 # to run in production, you must add '-e runtime_env=production'
-# Run the playbook on both load balancers (both dev or both prod) sequentially
+# Run the playbook on the inactive load balancer first
+# if the 'nginx -t' check fails, we probably didn't delete an obsolete config file
+# run 'playbooks/nginx.yml' following the comments for removing obsolete config
+
 - name: revoke incommon acme for {{ domain_name }}
   hosts: nginxplus_{{ runtime_env | default('staging') }}
   remote_user: pulsys
@@ -31,8 +34,19 @@
       become_user: root
       become: true
 
+    - name: check nginx config, alert if it fails
+      block:
+        - name: make sure nginx configs are valid
+          command: /usr/sbin/nginx -t
+          become: true
+      rescue:
+        - name: issue warning if nginx -t fails
+          ansible.builtin.debug:
+            msg: 'config check failed, something (probably obsolete config) is pointing to the cert you just revoked; make nginx -t succeed before you revoke the cert on the other server'
+
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: "{{ slack_alerts_channel }}"
+        channel: ansible-alerts
+        # channel: "{{ slack_alerts_channel }}"


### PR DESCRIPTION
When we changed the name of the EAL site from eal-apps.princeton.edu to eal.lib.princeton.edu, we changed the config file name and generated new SSL certificates, but the old certs and the old config file were still on the load balancers. When the certs came up for renewal, we revoked the obsolete ones . . . which meant the obsolete config file was looking for cert files that no longer existed.

This PR adds a safety check to the revoke-a-cert playbook, with a message if the `nginx -t` config check fails.

It also removes the duplicate entry for `vars_files` and hard-codes the slack alerts channel. 