### PR TITLE
[common] show history timestamps

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -158,3 +158,17 @@
 - name: Common | install and update chronyd
   ansible.builtin.include_tasks: chronyd.yml
   # when: running_on_server
+  #
+- name: Common | ensure /etc/profile.d exists
+  ansible.builtin.file:
+    path: /etc/profile.d
+    state: directory
+    mode: "0755"
+
+- name: Common | enable timestamped history for bash globally
+  ansible.builtin.template:
+    src: history-timestamp.sh.j2
+    dest: /etc/profile.d/history-timestamp.sh
+    mode: "0644"
+    owner: root
+    group: root

--- a/roles/common/templates/history-timestamp.sh.j2
+++ b/roles/common/templates/history-timestamp.sh.j2
@@ -1,0 +1,21 @@
+{{ ansible_managed | comment  }}
+# Global bash history timestamps behavior
+
+# Only act in interactive shells
+case "$-" in *i*) : ;; *) return ;; esac
+
+# Write and show timestamps for each history entry
+# Example: 2025-08-25 14:22:03  ls -la
+export HISTTIMEFORMAT='%F %T '
+
+# Keep the history and append rather than overwrite
+export HISTSIZE="${HISTSIZE:-100000}"
+export HISTFILESIZE="${HISTFILESIZE:-200000}"
+export HISTCONTROL="${HISTCONTROL:-ignoredups:erasedups}"
+
+if [ -n "$BASH_VERSION" ]; then
+  shopt -s histappend cmdhist
+  # Append the current session's command to the history file immediately.
+  # This helps when correlating in multi-session incidents.
+  PROMPT_COMMAND="history -a${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+fi


### PR DESCRIPTION
the template works for bash shells and appends immediately to correlate multiple sessions. prevent recording duplicate commands

related to #6456
