### PR TITLE
Ensuring that oawaiver production deployments only use lib-solr-prod1

### DIFF
--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -24,7 +24,7 @@ postgres_version: 15
 application_db_name: "{{ vault_oawaiver_prod_db_name }}"
 application_dbuser_name: "{{ vault_oawaiver_prod_db_user }}"
 application_dbuser_password: "{{ vault_oawaiver_prod_db_password }}"
-application_dbuser_role_attr_flags: 'CREATEDB'
+application_dbuser_role_attr_flags: "CREATEDB"
 
 # Use Ruby 3.0.3 and install from source
 install_ruby_from_source: true
@@ -53,7 +53,7 @@ app_db_user: "{{ vault_oawaiver_prod_db_user }}"
 app_db_password: "{{ vault_oawaiver_prod_db_password }}"
 
 ## Apache Solr
-app_solr_host: 'lib-solr-prod7.princeton.edu'
+app_solr_host: "lib-solr-prod1.princeton.edu"
 app_solr_port: 8983
 app_solr_path: "/solr/{{ oawaiver_solr_core }}"
 


### PR DESCRIPTION
This ensures that deployments relying upon lib-solr-prod7 are deprecated. Advances https://github.com/pulibrary/oawaiver/issues/261