### PR TITLE
[CircleCI Deployer] Restart worker after every job.

### DIFF
--- a/nomad/circleci_deployer/deploy/all.hcl
+++ b/nomad/circleci_deployer/deploy/all.hcl
@@ -41,6 +41,7 @@ job "circleci-runner" {
         CIRCLECI_RUNNER_API_AUTH_TOKEN = {{.CIRCLECI_API_TOKEN}}
         CIRCLECI_RUNNER_NAME = "circleci-deployer-{{ env "NOMAD_ALLOC_INDEX" }}"
         CIRCLECI_RUNNER_CLEANUP_WORK_DIR = true
+        CIRCLECI_RUNNER_MODE = "single-task"
         {{- end -}}
         EOF
       }


### PR DESCRIPTION
The Nomad boxes that ran the CircleCI jobs were running out of disk. The
disk clears out when the job on Nomad ends, so this setting makes it so
the runner restarts after every task. When it finishes a task, it shuts
it down, and Nomad spins it back up.

Yay containers.
