### PR TITLE
allow redirects to download

### DIFF
--- a/roles/solr9cloud/defaults/main.yml
+++ b/roles/solr9cloud/defaults/main.yml
@@ -2,7 +2,18 @@
 solr_cloud_download_version: "{{ solr_version | default('9.2.0') }}"
 solr_cloud_build_name: "solr-{{ solr_cloud_download_version }}"
 solr_cloud_package: "{{ solr_cloud_build_name }}.tgz"
-solr_cloud_url: "https://pulmirror.princeton.edu/mirror/solr/dist/lucene/solr/{{ solr_cloud_download_version }}/{{ solr_cloud_package }}"
+
+# Choose canonical base (no redirects). Use regex_search FILTER, not "is match".
+solr_cloud_base: >-
+  {%- if solr_cloud_download_version | regex_search('^[0-8]\\.') -%}
+    https://pulmirror.princeton.edu/mirror/apache/solr/archive/legacy
+  {%- elif (solr_cloud_download_version | regex_search('^9\\.')) and (solr_cloud_download_version != solr_current_version) -%}
+    https://pulmirror.princeton.edu/mirror/apache/solr/archive/9x
+  {%- else -%}
+    https://pulmirror.princeton.edu/mirror/apache/solr
+  {%- endif -%}
+
+solr_cloud_url: "{{ solr_cloud_base }}/{{ solr_cloud_download_version }}/{{ solr_cloud_package }}"
 
 ## Service options
 # Owner

--- a/roles/solr9cloud/tasks/main.yml
+++ b/roles/solr9cloud/tasks/main.yml
@@ -97,6 +97,35 @@
   register: solr_install_check
   tags: [download, install]
 
+- name: Solrcloud - Build candidate URLs for this version
+  ansible.builtin.set_fact:
+    solr_candidate_urls:
+      - "https://pulmirror.princeton.edu/mirror/apache/solr/{{ solr_cloud_download_version }}/{{ solr_cloud_package }}"
+      - "https://pulmirror.princeton.edu/mirror/apache/solr/archive/9x/{{ solr_cloud_download_version }}/{{ solr_cloud_package }}"
+      - "https://pulmirror.princeton.edu/mirror/apache/solr/archive/legacy/{{ solr_cloud_download_version }}/{{ solr_cloud_package }}"
+
+- name: Solrcloud - Probe candidates (HEAD)
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    method: HEAD
+    return_content: no
+    status_code: 200
+    validate_certs: true
+  loop: "{{ solr_candidate_urls }}"
+  register: solr_head
+  failed_when: false
+  changed_when: false
+
+- name: Solrcloud - Pick the first working URL
+  ansible.builtin.set_fact:
+    solr_cloud_url: "{{ (solr_head.results | selectattr('status','defined') | selectattr('status','equalto',200) | map(attribute='item') | list).0 }}"
+  when: (solr_head.results | selectattr('status','defined') | selectattr('status','equalto',200) | list) | length > 0
+
+- name: Solrcloud - Fail if no URL works
+  ansible.builtin.fail:
+    msg: "Could not locate Solr {{ solr_cloud_download_version }} at any mirror path."
+  when: solr_cloud_url is not defined
+
 # Download SolrCloud package
 - name: Solrcloud | Download SolrCloud archive
   ansible.builtin.get_url:
@@ -104,6 +133,7 @@
     dest: "/tmp/{{ solr_cloud_package }}"
     timeout: 300
     mode: "0644"
+    validate_certs: true
   register: solr_downloaded
   retries: 3
   delay: 10


### PR DESCRIPTION
the Apache (sic) Software Foundation recommends strict paths for the mirrors. Our old paths are not working. This makes solr9 download
related to #6464 