### PR TITLE
[husby] update redirect in nginxplus conf 

### DIFF
--- a/roles/nginxplus/files/conf/http/husby.conf
+++ b/roles/nginxplus/files/conf/http/husby.conf
@@ -2,7 +2,7 @@
 server {
     listen 80;
     server_name husby.princeton.edu;
-    #rewrite ^/(.*)$ https://pul-confluence.atlassian.net/wiki/spaces/IT/pages/84639768/Husby+Database+of+Bookbindings+on+Incunables/$1 permanent;
+    #rewrite ^/(.*)$ https://libguides.princeton.edu/az/husby-database-of-bookbindings-on-incunables permanent;
     location / {
         return 301 https://$server_name$request_uri;
     }
@@ -12,9 +12,9 @@ server {
     listen 443 ssl;
     http2 on;
     server_name husby.princeton.edu;
-    #rewrite ^/(.*)$ https://pul-confluence.atlassian.net/wiki/spaces/IT/pages/84639768/Husby+Database+of+Bookbindings+on+Incunables/$1 permanent;
+    #rewrite ^/(.*)$ https://libguides.princeton.edu/az/husby-database-of-bookbindings-on-incunables permanent;
     location / {
-        return 301 https://pul-confluence.atlassian.net/wiki/spaces/IT/pages/84639768/Husby+Database+of+Bookbindings+on+Incunables/;
+        return 301 https://libguides.princeton.edu/az/husby-database-of-bookbindings-on-incunables;
     }
     ssl_certificate            /etc/letsencrypt/live/husby/fullchain.pem;
     ssl_certificate_key        /etc/letsencrypt/live/husby/privkey.pem;


### PR DESCRIPTION
Update Husby redirect to point to new LibGuides A-Z Databases entry instead of Confluence page. Related to ServiceNow ticket INC0702503. 