### PR TITLE
simplify the backup mounts in solr8

### DIFF
--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -11,8 +11,8 @@
     mode: 0755
     group: deploy
     owner: deploy
-  loop:
-    - solr_backup
+  tags:
+    - fix_backups
 
 - name: solrcloud | Copy smb credentials
   ansible.builtin.copy:
@@ -23,6 +23,8 @@
     - running_on_server
   loop:
     - solr.smb.credentials
+  tags:
+    - fix_backups
 
 - name: solrcloud | Create mount to diglibdata shares
   ansible.posix.mount:

--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: solrcloud | create directories for mounts
   ansible.builtin.file:
-    path: "/mnt/{{ item }}"
+    path: "/solr/data/backup"
     state: "directory"
     mode: 0755
     group: deploy
@@ -26,45 +26,15 @@
 
 - name: solrcloud | Create mount to diglibdata shares
   ansible.posix.mount:
-    path: "/mnt/{{ item.path }}"
-    src: "//diglibdata1.princeton.edu/{{ item.src }}"
+    path: "/solr/data/backup"
+    src: "//diglibdata1.princeton.edu/solrbackup"
     fstype: cifs
-    opts: "credentials=/etc/{{ item.opts }}.smb.credentials,uid=1001,gid=1001"
+    opts: "credentials=/etc/solr.smb.credentials,uid=1001,gid=1001"
     state: mounted
   when:
     - running_on_server
-  loop:
-    - { path: "solr_backup", src: "solrbackup", opts: "solr" }
   tags:
     - fix_backups
-
-- name: Solrcloud | Ensure the bind mount is active
-  ansible.posix.mount:
-    src: /mnt/solr_backup
-    path: "{{ solr_data_dir }}/backup"
-    state: mounted
-    opts: bind
-    fstype: none
-
-- name: Solrcloud | Create Solr bind mount directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: "0755"
-    owner: "{{ solr_user }}"
-    group: "{{ solr_group }}"
-  loop:
-    - "{{ solr_data_dir }}/backup"          # /solr/data
-
-- name: Solrcloud | Ensure the bind mount is configured in /etc/fstab
-  ansible.posix.mount:
-    src: /mnt/solr_backup
-    path: "{{ solr_data_dir }}/backup"
-    state: present
-    fstype: none
-    opts: bind
-    dump: '0'
-    passno: '0'
 
 - name: solrcloud | update host file
   ansible.builtin.lineinfile:


### PR DESCRIPTION
Partial fix for #6476.

We mount the Isilon share directly to `/solr/data/backup` instead of mounting it to `/mnt/solrbackup` and then adding a bind mount from `/mnt/solrbackup` to `/solr/data/backup`.

Once we confirm that this allows the lead Solr box to write backups and reboot with no drama, the next step is to send backups to GCE.