### PR TITLE
[bibdata] Remove unnecessary duplicate quotes from environment variable

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -69,7 +69,7 @@ rails_app_vars:
   - name: TRAJECT_CONFIG
     value: 'marc_to_solr/lib/traject_config.rb'
   - name: BIBDATA_ADMIN_NETIDS
-    value: '"{{ bibdata_admin_netids | join(" ") }}"'
+    value: '{{ bibdata_admin_netids | join(" ") }}'
   - name: SCSB_FILE_DIR
     value: "/data/bibdata_files/scsb_update_files"
   - name: HATHI_INPUT_DIR

--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -65,7 +65,7 @@ rails_app_vars:
   - name: TRAJECT_CONFIG
     value: 'marc_to_solr/lib/traject_config.rb'
   - name: BIBDATA_ADMIN_NETIDS
-    value: '"{{ bibdata_admin_netids | join(" ") }}"'
+    value: '{{ bibdata_admin_netids | join(" ") }}'
   - name: SCSB_FILE_DIR
     value: "/data/bibdata_files/scsb_update_files"
   - name: HATHI_INPUT_DIR

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -69,7 +69,7 @@ rails_app_vars:
   - name: TRAJECT_CONFIG
     value: 'marc_to_solr/lib/traject_config.rb'
   - name: BIBDATA_ADMIN_NETIDS
-    value: '"{{ bibdata_admin_netids | join(" ") }}"'
+    value: '{{ bibdata_admin_netids | join(" ") }}'
   - name: SCSB_FILE_DIR
     value: "/data/bibdata_files/scsb_update_files"
   - name: HATHI_INPUT_DIR


### PR DESCRIPTION
Similar to #6418, this leads to the environment variable being surrounded with `""` when we try to export it.  This prevents anyone other than Christina (as the first username in the admin list) from being recognized as an admin user.