### PR TITLE
[solr9] install analysis_extras_jars to the relevant directory

### DIFF
--- a/roles/solr9cloud/tasks/plugins.yml
+++ b/roles/solr9cloud/tasks/plugins.yml
@@ -19,5 +19,5 @@
     mode: "0644"
   when:
     - running_on_server
-  loop: "{{ plugin_jars }}"
+  loop: "{{ analysis_extras_jars }}"
   notify: Restart solr


### PR DESCRIPTION
This fixes a bug I introduced in #6473.  Previously, the playbook would install all JARs in the `plugin_jars` list to both /opt/solr/lib and /opt/solr/modules/analysis-extras/lib.  What is actually needed is that we install `plugin_jars` to /opt/solr/lib and `analysis_extras_jars` to /opt/solr/modules/analysis-extras/lib.