### PR TITLE
block non-pul traffic from accessing staging

### DIFF
--- a/roles/nginxplus/files/conf/http/datacommons_staging.conf
+++ b/roles/nginxplus/files/conf/http/datacommons_staging.conf
@@ -59,6 +59,10 @@ server {
         proxy_cache discovery-stagingcache;
         # handle errors using errors.conf
         proxy_intercept_errors on;
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
 	}
 
     location /describe/ {
@@ -70,6 +74,10 @@ server {
         proxy_cache describe-stagingcache;
         # handle errors using errors.conf
         proxy_intercept_errors on;
+        # allow princeton network
+        include /etc/nginx/conf.d/templates/restrict.conf;
+        # block all
+        deny all;
 	}
 
     include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
current behavior for the name datacommons-staging allows external traffic.
the princeton network block happens one the server routes to the pdc-{describe,discovery}-name
we add a block to the two locations on the datacommons-staging so the servers never serve anything.
related to https://github.com/PrincetonUniversityLibrary/security/issues/81