### PR TITLE
[Figgy + Postgresql] Set keepalive timeout lower.

### DIFF
--- a/group_vars/figgy_production_cluster.yml
+++ b/group_vars/figgy_production_cluster.yml
@@ -3,3 +3,6 @@ postgresql_cluster:
   leader: figgy-db-prod1.princeton.edu
   followers:
     - figgy-db-prod2.princeton.edu
+# The system default is 2 hours, we've had dropped connections with that -
+# this has proven to be fine in Figgy. This sends a keepalive every 5 minutes.
+postgres_tcp_keepalives_idle: 600

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -102,3 +102,11 @@ pg_hba_postgresql_database: "all"
 # and the user can still create a database
 pg_hba_method: "md5"
 pg_hba_source: "host"
+
+# TCP settings
+# 0 is the default, which means "pull from the system"
+# Documentation: https://www.postgresql.org/docs/current/runtime-config-connection.html#RUNTIME-CONFIG-TCP-SETTINGS
+# The number is in seconds.
+postgres_tcp_keepalives_idle: 0
+postgres_tcp_keepalives_interval: 0
+postgres_tcp_keepalives_count: 0

--- a/roles/postgresql/templates/postgresql.conf.j2
+++ b/roles/postgresql/templates/postgresql.conf.j2
@@ -49,6 +49,11 @@ ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 #ssl_crl_dir = ''
 ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
 
+# TCP Settings
+tcp_keepalives_idle = {{ postgres_tcp_keepalives_idle }}
+tcp_keepalives_interval = {{ postgres_tcp_keepalives_interval }}
+tcp_keepalives_count = {{ postgres_tcp_keepalives_count }}
+
 
 #------------------------------------------------------------------------------
 # RESOURCE USAGE (except WAL)


### PR DESCRIPTION
We were having postgres timeouts which was resulting in some items not
being able to be ingested in Figgy. This value allowed those items to
ingest. The relevant honeybadger error:
https://app.honeybadger.io/projects/53391/faults/119695976

Closes https://github.com/pulibrary/figgy/issues/6800
Related to https://github.com/pulibrary/princeton_ansible/issues/2305

This will only change the setting for Figgy, and keep the default for
the other postgres cluster.
