### PR TITLE
[bibdata] increase number of sidekiq threads from 2 to 3

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -121,7 +121,7 @@ rails_app_vars:
   - name: RUST_LOG
     value: "debug"
 sidekiq_worker_name: bibdata-workers
-sidekiq_worker_threads: 2
+sidekiq_worker_threads: 3
 timezone: "America/New_York"
 bibdata_samba_source_host: 'bibdata-worker-prod1.princeton.edu'
 samba_shares_root: /data

--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -121,7 +121,7 @@ rails_app_vars:
   - name: RUST_LOG
     value: "debug"
 sidekiq_worker_name: bibdata-workers
-sidekiq_worker_threads: 2
+sidekiq_worker_threads: 3
 bibdata_mount_env: 'qa'
 bibdata_db: "bibdata_qa"
 bibdata_db_port: 5432

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -125,7 +125,7 @@ rails_app_vars:
   - name: RUST_LOG
     value: "debug"
 sidekiq_worker_name: bibdata-workers
-sidekiq_worker_threads: 2
+sidekiq_worker_threads: 3
 bibdata_mount_env: 'staging'
 bibdata_db: "bibdata_alma_staging"
 bibdata_db_port: 5432


### PR DESCRIPTION
Now that the worker boxes have 4 CPUs, they are able to handle 3 sidekiq threads comfortably.  This amount of simultaneous indexing does not seem to negatively impact solr 9 performance.