### PR TITLE
[prancible] only use necessary IP addresses in cloud inventory

### DIFF
--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -37,7 +37,7 @@ prod.pulcloud.io ansible_host=10.246.0.2
 staging.pulcloud.io ansible_host=10.140.0.3
 
 [pulmirror_production]
-pulmirror.princeton.edu
+pulmirror.princeton.edu ansible_host=10.132.0.20 
 
 [sftp_production]
 proquestdrop.pulcloud.io ansible_host=10.140.0.15

--- a/inventory/by_cloud/google_cloud
+++ b/inventory/by_cloud/google_cloud
@@ -31,16 +31,16 @@ dev.pulcloud.io
 
 [obsd_httpd_production]
 # inventory name is prod.pucloud.io but the VM name in google cloud is pul-gcdc-prod-adc
-prod.pulcloud.io ansible_host=10.246.0.2
+prod.pulcloud.io
 
 [obsd_httpd_staging]
-staging.pulcloud.io ansible_host=10.140.0.3
+staging.pulcloud.io
 
 [pulmirror_production]
-pulmirror.princeton.edu ansible_host=10.132.0.20 
+pulmirror.princeton.edu
 
 [sftp_production]
-proquestdrop.pulcloud.io ansible_host=10.140.0.15
+proquestdrop.pulcloud.io
 
 [gcp_dev:children]
 dspace_dev


### PR DESCRIPTION
Only the VMs that are behind the bastion hosts need IP addresses. 