### PR TITLE
[nginxplus] illiad redirects

### DIFF
--- a/roles/nginxplus/files/conf/http/illiad_prod.conf
+++ b/roles/nginxplus/files/conf/http/illiad_prod.conf
@@ -1,0 +1,10 @@
+# this file is ansible managed
+server {
+    listen 80;
+    server_name lib-illiad.princeton.edu;
+    rewrite ^/(.*)$ https://princeton.illiad.oclc.org/logon/$1 permanent;
+        location / {
+        rewrite ^illiad\/illiad.dll\/Openurl$ https://princeton.illiad.oclc.org/logon/$1 permanent;
+    }
+}
+


### PR DESCRIPTION
set up nginxplus conf file to redirect hosted lib-illiad site to hosted oclc site

related to #6514 