### PR TITLE
Fix GCP backups for solr8 and solr9

### DIFF
--- a/roles/solr9cloud/tasks/backup_gcs_mount.yml
+++ b/roles/solr9cloud/tasks/backup_gcs_mount.yml
@@ -178,7 +178,7 @@
   tags: [google_cloud]
 
 #  run once to display current output during deploy
-- name: Solrcloud | Verify Solr 9 backup local check
+- name: Solrcloud | Verify Solr 9 backup local check 
   ansible.builtin.command: /usr/lib/check_mk_agent/local/check_solr_backup.sh
   register: solr_backup_check_output
   changed_when: false
@@ -202,8 +202,8 @@
     src: '../../common/templates/logrotate_rules.j2'
     dest: "/etc/logrotate.d/{{ item.name | basename }}"
     mode: "0644"
-    owner: root
-    group: root
+    owner: deploy
+    group: deploy
   loop: "{{ solr9_gcsfuse_logrotate_rules }}"
   when:
     - running_on_server

--- a/roles/solrcloud/tasks/backup_gcs_mount.yml
+++ b/roles/solrcloud/tasks/backup_gcs_mount.yml
@@ -10,14 +10,12 @@
     state: present
     update_cache: true
   when: running_on_server
-  tags: [google_cloud]
 
 - name: Solrcloud | Add gcsfuse apt key
   ansible.builtin.apt_key:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
     state: present
   when: running_on_server
-  tags: [google_cloud]
 
 - name: Solrcloud | Add gcsfuse apt repository
   ansible.builtin.apt_repository:
@@ -25,7 +23,6 @@
     state: present
     filename: gcsfuse
   when: running_on_server
-  tags: [google_cloud]
 
 - name: Solrcloud | Install gcsfuse
   ansible.builtin.apt:
@@ -33,7 +30,6 @@
     state: present
     update_cache: true
   when: running_on_server
-  tags: [google_cloud]
 
 # Copy GCS service account key
 - name: Solrcloud | Copy GCS service account key
@@ -44,7 +40,6 @@
     owner: root
     group: root
   when: running_on_server
-  tags: [google_cloud]
 
 # Allow deploy to read the key without changing ownership/mode
 - name: Solrcloud | Grant deploy read access to SA key
@@ -55,7 +50,6 @@
     permissions: r
     state: present
   when: running_on_server
-  tags: [google_cloud]
 
 # Ensure FUSE allows -o allow_other
 - name: Solrcloud | Ensure fuse allows allow_other
@@ -68,7 +62,6 @@
     mode: '0644'
   when: running_on_server
   notify: reload systemd
-  tags: [google_cloud]
 
 - name: Solrcloud | Ensure gcsfuse log dir exists
   ansible.builtin.file:
@@ -78,7 +71,6 @@
     group: "{{ solr_group | default('deploy') }}"
     mode: "0755"
   when: running_on_server
-  tags: [google_cloud]
 
 # Create systemd service for gcsfuse mount
 - name: Solrcloud | Create gcsfuse systemd service
@@ -123,7 +115,6 @@
     group: root
   when: running_on_server
   notify: reload systemd
-  tags: [google_cloud]
 
 - name: Solrcloud | Enable and start gcsfuse service
   ansible.builtin.systemd:
@@ -132,7 +123,7 @@
     state: started
     daemon_reload: yes
   when: running_on_server
-  tags: [google_cloud, fix_backups]
+  tags: [fix_backups]
 
 # Verify mount is working
 - name: Solrcloud | Wait for GCS mount to be available
@@ -141,7 +132,7 @@
     state: present
     timeout: 30
   when: running_on_server
-  tags: [google_cloud, fix_backups]
+  tags: [fix_backups]
 
 - name: Solrcloud | Verify GCS mount is active
   ansible.builtin.command: mountpoint -q /solr/data/cloud_backup
@@ -163,8 +154,8 @@
     src: '../../common/templates/logrotate_rules.j2'
     dest: "/etc/logrotate.d/{{ item.name | basename }}"
     mode: "0644"
-    owner: root
-    group: root
+    owner: deploy
+    group: deploy
   loop: "{{ solr9_gcsfuse_logrotate_rules }}"
   when:
     - running_on_server

--- a/roles/solrcloud/tasks/main.yml
+++ b/roles/solrcloud/tasks/main.yml
@@ -19,6 +19,13 @@
     - google_cloud
     - fix_backups
 
+- name: Solrcloud | Configure cloud backup mounts
+  ansible.builtin.import_tasks: backup_gcs_mount.yml
+  #  apply:
+  #     tags: google_cloud
+  tags:
+    - google_cloud
+
 - name: Solrcloud | Copy smb credentials
   ansible.builtin.copy:
     src: "files/{{ item }}"


### PR DESCRIPTION
The google cloud drive needs to be mounted on all the VMs in the Solr cluster.

This PR ensures that the logs for gcsfuse are owned by the deploy user, which is the user that runs the solr backups.

It also uses `import` instead of `include` to pull in the gcsfuse tasks, which means we can use a tag without the need to put the tag on every single task inside the imported tasks file. 

Future work / cleanup: 
- [ ] remove the tasks with the tag `fix_backups` - we won't need these to build future solr boxes
- [ ] remove the Isilon mount (the old backup path) 
- [ ] remove the stuff we only installed to make the Isilon mount work (CIFS tools ,etc)
