### PR TITLE
provide leadbox information

### DIFF
--- a/playbooks/solr9cloud.yml
+++ b/playbooks/solr9cloud.yml
@@ -2,6 +2,8 @@
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
 # to run in qa, pass '-e runtime_env=qa'
+# lead box for [staging](https://github.com/pulibrary/pul_solr/blob/main/config/deploy/solr9_staging.rb)
+# lead box for [production](https://github.com/pulibrary/pul_solr/blob/main/config/deploy/solr9_production.rb)
 - name: build the solr9cloud
   hosts: solr9cloud_{{ runtime_env | default('staging') }}
   remote_user: pulsys


### PR DESCRIPTION
providing information about what solr is our "leadbox" the solr backups are deployed via capistrano from one server. Finding the server that does it can be tricky.

This reduces our search