### PR TITLE
make gcsfuse logrotate with deploy user, set solr8 to solr8

### DIFF
--- a/group_vars/solr8cloud/production.yml
+++ b/group_vars/solr8cloud/production.yml
@@ -18,7 +18,7 @@ cjkfoldingfilter: https://github.com/pulibrary/pul_solr/raw/master/solr8_jars/CJ
 # gcsfuse logrotate
 gcsfuse_directory: "/var/log/gcsfuse"
 
-solr9_gcsfuse_logrotate_rules:
+solr8_gcsfuse_logrotate_rules:
   - name: "gcsfuse"
     paths:
       - "{{ gcsfuse_directory }}/*.log"
@@ -26,8 +26,8 @@ solr9_gcsfuse_logrotate_rules:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"
       create_mode: "{{ logrotate_global_defaults.create_mode }}"
-      create_owner: "root"
-      create_group: "root"
+      create_owner: "deploy"
+      create_group: "deploy"
       su_user: "{{ logrotate_global_defaults.su_user }}"
       su_group: "{{ logrotate_global_defaults.su_group }}"
       postrotate: |

--- a/group_vars/solr8cloud/staging.yml
+++ b/group_vars/solr8cloud/staging.yml
@@ -18,7 +18,7 @@ cjkfoldingfilter: https://github.com/pulibrary/pul_solr/raw/master/solr8_jars/CJ
 # gcsfuse logrotate
 gcsfuse_directory: "/var/log/gcsfuse"
 
-solr9_gcsfuse_logrotate_rules:
+solr8_gcsfuse_logrotate_rules:
   - name: "gcsfuse"
     paths:
       - "{{ gcsfuse_directory }}/*.log"
@@ -26,8 +26,8 @@ solr9_gcsfuse_logrotate_rules:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"
       create_mode: "{{ logrotate_global_defaults.create_mode }}"
-      create_owner: "root"
-      create_group: "root"
+      create_owner: "deploy"
+      create_group: "deploy"
       su_user: "{{ logrotate_global_defaults.su_user }}"
       su_group: "{{ logrotate_global_defaults.su_group }}"
       postrotate: |

--- a/group_vars/solr9cloud/production.yml
+++ b/group_vars/solr9cloud/production.yml
@@ -34,8 +34,8 @@ solr9_gcsfuse_logrotate_rules:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"
       create_mode: "{{ logrotate_global_defaults.create_mode }}"
-      create_owner: "root"
-      create_group: "root"
+      create_owner: "deploy"
+      create_group: "deploy"
       su_user: "{{ logrotate_global_defaults.su_user }}"
       su_group: "{{ logrotate_global_defaults.su_group }}"
       postrotate: |

--- a/group_vars/solr9cloud/staging.yml
+++ b/group_vars/solr9cloud/staging.yml
@@ -42,8 +42,8 @@ solr9_gcsfuse_logrotate_rules:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"
       create_mode: "{{ logrotate_global_defaults.create_mode }}"
-      create_owner: "root"
-      create_group: "root"
+      create_owner: "deploy"
+      create_group: "deploy"
       su_user: "{{ logrotate_global_defaults.su_user }}"
       su_group: "{{ logrotate_global_defaults.su_group }}"
       postrotate: |


### PR DESCRIPTION
Log rotation was set to create a log for google cloud backups that was owned by `root:root` - this caused problems. This PR makes all instances of the logrotation cron job set the file to be owned by `deploy:deploy`.

Also, the google cloud backups were using a variable with `solr9` in it on both solr8 and solr9 - this PR fixes the solr8 reference.
