### PR TITLE
Add a playbook that removes apt/yum packages

### DIFF
--- a/playbooks/utils/uninstall_package.yml
+++ b/playbooks/utils/uninstall_package.yml
@@ -1,0 +1,21 @@
+---
+# you MUST run this playbook on a host or group with '--limit' for example `ansible-playbook -v ---limit pdc_describe_staging playbooks/utils/common_only.yml`
+#
+- name: Uninstall a package/service previously installed with yum/apt
+  hosts: all
+  # hosts: staging:qa:production
+  remote_user: pulsys
+  become: true
+
+  pre_tasks:
+    - name: stop playbook if you didn't pass --limit
+      fail:
+        msg: "you must use -l or --limit"
+      when: ansible_limit is not defined
+      run_once: true
+
+  tasks:
+    - name: uninstall a package
+      ansible.builtin.package:
+       name: "{{ package_to_remove }}"
+       state: absent

--- a/playbooks/utils/uninstall_package.yml
+++ b/playbooks/utils/uninstall_package.yml
@@ -1,5 +1,5 @@
 ---
-# you MUST run this playbook on a host or group with '--limit' for example `ansible-playbook -v ---limit pdc_describe_staging playbooks/utils/common_only.yml`
+# you MUST run this playbook on a host or group with '--limit' for example `ansible-playbook -v ---limit pdc_describe_staging playbooks/utils/uninstall_package.yml -e package_to_remove=vector`
 #
 - name: Uninstall a package/service previously installed with yum/apt
   hosts: all


### PR DESCRIPTION
Closes #6546 

Adds a utils playbook for removing a package.

Tested against the Solr9 boxes:

`ansible-playbook --limit solr9cloud_production -e package_to_remove=vector playbooks/utils/uninstall_package.yml` successfully removed the vector package and service. 