### PR TITLE
updates version of checkmk to match what we are running

### DIFF
--- a/group_vars/checkmk/shared.yml
+++ b/group_vars/checkmk/shared.yml
@@ -42,7 +42,7 @@ checkmk_agent_server_url: "{{ checkmk_agent_protocol }}://{{ checkmk_agent_serve
 checkmk_agent_server_validate_certs: "true"
 checkmk_agent_tls: 'true'
 checkmk_agent_update: 'true'
-checkmk_agent_version: "2.3.0p30"
+checkmk_agent_version: "2.4.0p7"
 
 
 # Server Role
@@ -51,7 +51,7 @@ checkmk_server_download_pass: "{{ vault_checkmk_download_pass }}"
 checkmk_server_download_user: "{{ vault_checkmk_download_user }}"
 checkmk_server_edition: cee
 checkmk_server_verify_setup: 'true'
-checkmk_server_version: 2.3.0p30
+checkmk_server_version: 2.4.0p7
 # sites listing
 checkmk_server_sites:
   - name: production


### PR DESCRIPTION
I hope this will fix the Tower error in the checkmk playbook about "a later version is already installed". 

Also, our automation should reflect the current reality.