### PR TITLE
[lib-jobs] More svn cleanup

### DIFF
--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -190,8 +190,6 @@ rails_app_vars:
     value: 'libjobs'
   - name: SVN_PASSWORD
     value: '{{ vault_lib_jobs_svn_secret }}'
-  - name: SVN_HOST
-    value: '{{ svn_host }}'
   - name: GIT_LAB_HOST
     value: '{{ git_lab_host }}'
   - name: TRANSACTION_ERROR_FEED_RECIPIENTS

--- a/roles/lib_jobs/tasks/main.yml
+++ b/roles/lib_jobs/tasks/main.yml
@@ -20,20 +20,6 @@
     - lib_jobs_logrotate_rules is defined
     - lib_jobs_logrotate_rules | length > 0
 
-# SVN
-- name: Install subversion client
-  ansible.builtin.apt:
-    name: subversion
-    state: present
-
-- name: lib_jobs | checkout the EADs subversion repository
-  ansible.builtin.subversion:
-    repo: 'svn://{{ svn_host }}/libsvn/trunk/eads'
-    dest: '/opt/{{ app_directory }}/shared/subversion_eads'
-    update: no
-  when: running_on_server
-  become_user: '{{ deploy_user }}'
-
 # GitLab
 - name: lib_jobs | Install gitlab private key
   ansible.builtin.copy:


### PR DESCRIPTION
Previously, the playbook failed with the error:

```
'svn_host' is undefined
```

I successfully ran this on lib-jobs staging