### PR TITLE
[lib-jobs / aspace-helpers] add an environment variable for the Alma set used by aspace2alma

### DIFF
--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -73,6 +73,8 @@ rails_app_vars:
     value: '/alma/fund_adjustment'
   - name: ALMA_PERSON_FEED_OUTPUT_FTP
     value: '/alma/people'
+  - name: ALMA_SC_BARCODES_SET
+    value: '{{ alma_sc_barcodes_set }}'
   - name: APP_DB
     value: '{{ app_db_name }}'
   - name: APP_DB_HOST

--- a/group_vars/lib_jobs/production.yml
+++ b/group_vars/lib_jobs/production.yml
@@ -15,6 +15,7 @@ alma_bib_norm_error_recipients:  '{{ vault_alma_bib_norm_prod_error_recipients }
 alma_config_api_key: '{{ vault_alma_prod_config_api_key }}'
 alma_bib_api_key: '{{ vault_alma_prod_bib_api_key }}'
 alma_recap_output_dir: '/alma/recap'
+alma_sc_barcodes_set: '44497402430006421'
 # OIT
 app_oit_base_url: 'https://api.princeton.edu:443'
 app_oit_client_key: '{{ vault_oit_prod_client_key }}'

--- a/group_vars/lib_jobs/staging.yml
+++ b/group_vars/lib_jobs/staging.yml
@@ -12,6 +12,7 @@ alma_bib_norm_error_recipients:  '{{ vault_alma_bib_norm_staging_error_recipient
 alma_config_api_key: '{{ vault_alma_staging_config_api_key }}'
 alma_bib_api_key: '{{ vault_alma_staging_bib_api_key }}'
 alma_recap_output_dir: '/alma/recap'
+alma_sc_barcodes_set: '43977868370006421'
 # OIT
 app_oit_base_url: 'https://api.princeton.edu:443'
 app_oit_client_key: '{{ vault_oit_prod_client_key }}'


### PR DESCRIPTION
This set ID can be used to get a list of all barcodes in SC locations, so that we can avoid submitting duplicate barcodes.

Helps with https://github.com/pulibrary/aspace_helpers/issues/759

I have not yet run this