### PR TITLE
Remove vector tasks from nginxplus role

### DIFF
--- a/roles/nginxplus/tasks/localhost.yml
+++ b/roles/nginxplus/tasks/localhost.yml
@@ -65,13 +65,6 @@
     - "too_large.json"
     - "tigerdata-error.html"
 
-- name: Nginxplus | Ensure Vector is running and enabled
-  ansible.builtin.service:
-    name: vector
-    state: started
-    enabled: true
-  when: running_on_server
-
 - name: Nginxplus | Add nginxplus config syntax check
   ansible.builtin.copy:
     src: nginxplus_config_syntax.sh


### PR DESCRIPTION
As part of removing a bunch of obsolete config, we discovered that we were still starting the vector service as part of the nginxplus role.

We do not use vector any more. This PR removes the last reference to it so our nginxplus playbook will run smoothly. 

Related to https://github.com/pulibrary/princeton_ansible/issues/6546