### PR TITLE
Redirect digitalcollections.princeton.edu

### DIFF
--- a/roles/nginxplus/files/conf/http/dpul-collections-prod.conf
+++ b/roles/nginxplus/files/conf/http/dpul-collections-prod.conf
@@ -22,6 +22,26 @@ server {
 }
 
 server {
+    listen 80;
+    server_name digitalcollections.princeton.edu;
+    location / {
+        return 301 https://digital-collections.princeton.edu$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name digitalcollections.princeton.edu;
+
+    ssl_certificate            /etc/letsencrypt/live/digitalcollections/fullchain.pem;
+    ssl_certificate_key        /etc/letsencrypt/live/digitalcollections/privkey.pem;
+    ssl_session_cache          shared:SSL:1m;
+    ssl_prefer_server_ciphers  on;
+
+    rewrite ^ https://digital-collections.princeton.edu$request_uri? permanent;
+}
+
+server {
     listen 443 ssl;
     http2 on;
     server_name digital-collections.princeton.edu;


### PR DESCRIPTION
Currently deployed. Closes #6582 

Test URLs: 

https://digitalcollections.princeton.edu/i/mochilazo-estudiantil-educación-mer/item/acd21508-e973-4e5b-aef7-56b57360e297

http://digitalcollections.princeton.edu/i/night-city/item/af209853-2d1d-4995-b902-ca636e763aa0
