### PR TITLE
Makes removing packages more robust but still slim

### DIFF
--- a/playbooks/utils/uninstall_package.yml
+++ b/playbooks/utils/uninstall_package.yml
@@ -15,7 +15,33 @@
       run_once: true
 
   tasks:
-    - name: uninstall a package
-      ansible.builtin.package:
-       name: "{{ package_to_remove }}"
-       state: absent
+    # - name: uninstall a package
+    #   ansible.builtin.package:
+    #    name: "{{ package_to_remove }}"
+    #    state: absent
+
+    - name: Remove package on Debian/Ubuntu systems
+      ansible.builtin.apt:
+        name: "{{ package_to_remove }}"
+        state: absent
+        purge: true
+        autoremove: true
+      when: ansible_os_family == "Debian"
+
+    - name: Remove package on RHEL/CentOS/Fedora systems (using dnf)
+      ansible.builtin.dnf:
+        name: "{{ package_to_remove }}"
+        state: absent
+        autoremove: true
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version | int >= 8
+
+    - name: Remove package on older RHEL/CentOS systems (using yum)
+      ansible.builtin.yum:
+        name: "{{ package_to_remove }}"
+        state: absent
+        autoremove: yes
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version | int < 8


### PR DESCRIPTION
Supersedes #6550.

Removes packages installed with apt, dnf, and yum.

Francis and I paired on this - the playbook now removes packages from all flavors of Linux we run. It does not give a ton of diagnostic information, especially about dependencies. However, we decided that if we really need to eradicate dependencies from a VM, we probably want to replace it.
