### PR TITLE
supports non-standard health check URLs for checkMK checks

### DIFF
--- a/roles/ruby_app/tasks/main.yml
+++ b/roles/ruby_app/tasks/main.yml
@@ -100,8 +100,8 @@
     - site_config
 
 - name: Ruby_app | add local checkmk check
-  ansible.builtin.copy:
-    src: ruby_app_health_check.sh
+  ansible.builtin.template:
+    src: ruby_app_health_check.j2
     dest: "/usr/lib/check_mk_agent/local/ruby_app_health_check.sh"
     mode: "0755"
     owner: root

--- a/roles/ruby_app/templates/ruby_app_health_check.j2
+++ b/roles/ruby_app/templates/ruby_app_health_check.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script check to see if the health page is ok
-#   This can either be a health-moitor-rails (https://github.com/lbeder/health-monitor-rails) or 
+#   This can either be a health-monitor-rails (https://github.com/lbeder/health-monitor-rails) or 
 #   some other page that conforms to the same json output where `"status":"ok"` is part of the json output 
 #   If all the items monitored are ok the status is ok
 #   If any items are not ok the status is critical
@@ -8,9 +8,9 @@
 # required vars:
 #  check_mk_health_url - the url to curl for the health page ( for example localhost/health)
 #
-message=$(sudo -u deploy curl localhost/health.json |grep \"status\":\"ok\" | wc -l)
+message=$(sudo -u deploy curl {{ check_mk_health_url | default('localhost/health.json') }} |grep \"status\":\"ok\" | wc -l)
 if [ $message =  1 ]; then   
    echo "0 \"Ruby App Health Status\" - Ruby App is healthy"; 
 else
-   echo "2 \"Ruby App Health Status\" - Check the Ruby App health page {{ check_mk_health_url }} for details";
+   echo "2 \"Ruby App Health Status\" - Check the Ruby App health page {{ check_mk_health_url | default('localhost/health.json' }} for details";
 fi


### PR DESCRIPTION
Closes #6617.

We have not been monitoring the PDC* applications' health pages in CheckMK. Those pages use a non-standard URL for the health page.

This PR moves the script from `files` into `templates`, reinstates the variable for the URL, sets `localhost/health.json` as the default value, and changes the task to use the `template` module instead of the `file` module. 

The values for this variable are in the inventory, so we can run the playbook to add the checkmk agent on a wide variety of hosts and get the correct values. Once we're happy with this change, we can remove the inventory vars for projects that use the default (which I think is all our ruby apps except for the PDC* apps). 