### PR TITLE
Update existing Ubuntu VMs to prefer the PU mirror for apt updates

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -6,6 +6,25 @@
     "ansible_hostname not in inventory_hostname"
   tags: "update_hostname"
 
+- name: Common | Determine Ubuntu codename
+  ansible.builtin.set_fact:
+    ubuntu_codename: "{{ ansible_distribution_release | default(ansible_lsb.codename) }}"
+  when:
+    - ansible_os_family == "Debian"
+
+- name: Common | Prefer Princeton mirror for apt
+  ansible.builtin.apt_repository:
+    repo: deb https://mirror.math.princeton.edu/pub/ubuntu {{ item }} main restricted universe multiverse
+    state: present
+    filename: "00-princeton"
+    update_cache: true
+  loop:
+    - "{{ ubuntu_codename }}"
+    - "{{ ubuntu_codename }}-updates"
+    - "{{ ubuntu_codename }}-backports"
+  when:
+    - ansible_os_family == "Debian"
+
 - name: Common | Install common shared packages
   ansible.builtin.package:
     name: "{{ item }}"


### PR DESCRIPTION
Closes #6594.

Adds tasks to the common role that add a reference to the Princeton mirrors and set it as the preferred source for package updates with apt.

The more durable fix for this issue is to build the preference into our VM templates. That work was done in https://github.com/pulibrary/vm-builds/pull/37. This PR will let us update existing VMs. 