### PR TITLE
We no longer need to include this in our playbook runs.

### DIFF
--- a/playbooks/dacs_playbooks.yml
+++ b/playbooks/dacs_playbooks.yml
@@ -35,10 +35,6 @@
 - ansible.builtin.import_playbook: static_tables.yml runtime_env={{runtime_env|default('staging')}}
   tags:
     - vue
-- ansible.builtin.import_playbook: byzantine.yml runtime_env={{runtime_env|default('staging')}}
-  tags:
-    - php
-    - drupal
 - ansible.builtin.import_playbook: pas.yml runtime_env={{runtime_env|default('staging')}}
   tags:
     - php


### PR DESCRIPTION
Remove byzantine from list of dacs playbooks. 