### PR TITLE
Make sure CircleCI runners never stop trying to restart.

### DIFF
--- a/nomad/circleci_deployer/deploy/production.hcl
+++ b/nomad/circleci_deployer/deploy/production.hcl
@@ -30,6 +30,13 @@ job "circleci-runner" {
       mode = "delay"
     }
 
+    reschedule {
+      delay          = "30s"
+      delay_function = "exponential"
+      max_delay      = "120s"
+      unlimited      = true
+    }
+
     task "deploy-runner" {
       driver = "podman"
 


### PR DESCRIPTION
They should spin up very fast when they crash and never stop trying,
because they fail on purpose.
