### PR TITLE
modify the fits role to use a dif source

### DIFF
--- a/roles/fits/defaults/main.yml
+++ b/roles/fits/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-fits_version: "{{ '0.8.5' }}"
-fits_download_url: http://projects.iq.harvard.edu/files/fits/files
+fits_version: "{{ '1.6.0' }}"
+fits_download_url: https://github.com/harvard-lts/fits/releases/download/

--- a/roles/fits/tasks/main.yml
+++ b/roles/fits/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: fits | download fits
   ansible.builtin.get_url:
-    url: "{{ fits_download_url }}/fits-{{ fits_version }}.zip"
+    url: "{{ fits_download_url }}/{{ fits_version }}/fits-{{ fits_version }}.zip"
     dest: /tmp/fits-{{ fits_version }}.zip
     timeout: 100
     owner: root
@@ -30,17 +30,18 @@
     flat: true
   when: ansible_virtualization_type == 'virtualbox'
 
-- name: fits | unarchive fits
-  ansible.builtin.unarchive:
-    src: /tmp/fits-{{ fits_version }}.zip
-    dest: /opt
-    copy: no
-    creates: /opt/fits-{{ fits_version }}/fits.sh
-
 - name: fits | make fits directory accessible
   ansible.builtin.file:
     path: /opt/fits-{{ fits_version }}
+    state: directory
     mode: a+x
+
+- name: fits | unarchive fits
+  ansible.builtin.unarchive:
+    src: /tmp/fits-{{ fits_version }}.zip
+    dest: /opt/fits-{{ fits_version }}
+    copy: no
+    creates: /opt/fits-{{ fits_version }}/fits.sh
 
 - name: fits | create sane scripting symbolic link
   ansible.builtin.file:


### PR DESCRIPTION
Updated the fits role to a new source to download the fits files.

This addresses a CI failure that was returning this error:
`request failed (403) for http://projects.iq.harvard.edu/files/fits/files/fits-0.8.5.zip`