### PR TITLE
reinstates SSL for redirects for 'theprince'

### DIFF
--- a/roles/nginxplus/files/conf/http/veridian-sites.conf
+++ b/roles/nginxplus/files/conf/http/veridian-sites.conf
@@ -118,6 +118,9 @@ server {
         # health_check interval=10 fails=3 passes=2;
         proxy_intercept_errors on;
     }
+
+    include /etc/nginx/conf.d/templates/errors.conf;
+
 }
 
 server {


### PR DESCRIPTION
Closes #6661.

Instead of redirecting HTTP, we want to maintain a certificate for this site and redirect from HTTPS, so users don't get a warning about the site being insecure or dangerous. 