### PR TITLE
[devbox] Run gem install no matter what on devbox init

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -32,7 +32,7 @@
         "./.venv/bin/python -m pip install --upgrade pip",
         "./.venv/bin/python -m pip install -r requirements.txt",
         "touch .venv/.requirements_installed",
-        "command -v lastpass-ansible || gem install --no-document lastpass-ansible",
+        "gem install --no-document lastpass-ansible",
         "echo 'Setup complete!'"
       ],
       "setup": [


### PR DESCRIPTION
This way it doesn't pick up an asdf-provided lastpass-ansible, and then
not install the devbox one