### PR TITLE
[tigerdata] adding tigerdata-ci1 to staging group

### DIFF
--- a/inventory/by_environment/staging
+++ b/inventory/by_environment/staging
@@ -53,6 +53,7 @@ solr8cloud_staging
 solr9cloud_staging
 static_staging
 static_tables_staging
+tigerdata_ci
 tigerdata_staging
 whichiso_staging
 zookeeper_staging
@@ -109,6 +110,7 @@ solr8cloud_staging
 solr9cloud_staging
 static_staging
 static_tables_staging
+tigerdata_ci
 tigerdata_staging
 whichiso_staging
 zookeeper_staging


### PR DESCRIPTION
we found that tigerdata-ci1 had not been patched for a while while it is in the inventory it was not part of any of the environments