### PR TITLE
include all rdss groups in rdss team group

### DIFF
--- a/inventory/all_projects/mflux
+++ b/inventory/all_projects/mflux
@@ -1,8 +1,17 @@
 [mflux_ci]
 mflux-ci1.lib.princeton.edu
+
 [mflux_qa]
 mflux-qa1.lib.princeton.edu
+
 [mflux_production]
 mflux-prod1.lib.princeton.edu
+
 [mflux_staging]
 mflux-staging1.lib.princeton.edu
+
+[mflux:children]
+mflux_ci
+mflux_production
+mflux_qa
+mflux_staging

--- a/inventory/by_team/rdss
+++ b/inventory/by_team/rdss
@@ -1,7 +1,9 @@
 [rdss:children]
+mflux
 oawaiver
 orcid
 pdc_describe
+pdc_describe_redis
 pdc_discovery
 tigerdata
 [rdss:vars]


### PR DESCRIPTION
I ran a playbook with `--limit rdss` today and noticed that the mflux VMs were not included.

This PR adds some group entries to inventory so that all RDSS VMs roll up into the `rdss` group.
