### PR TITLE
remove obsolete crawl VMs from inventory for CDH

### DIFF
--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -1,8 +1,6 @@
 [cdh_production]
 cdh-derrida1.princeton.edu
 cdh-derrida2.princeton.edu
-cdh-derrida-crawl1.princeton.edu
-cdh-derrida-crawl2.princeton.edu
 cdh-geniza1.princeton.edu
 cdh-geniza2.princeton.edu
 cdh-prodigy1.princeton.edu
@@ -18,8 +16,6 @@ cdh-web4.princeton.edu
 [cdh_staging]
 cdh-test-derrida1.princeton.edu
 cdh-test-derrida2.princeton.edu
-cdh-test-derrida-crawl1.princeton.edu
-cdh-test-derrida-crawl2.princeton.edu
 cdh-test-geniza1.princeton.edu
 cdh-test-geniza2.princeton.edu
 cdh-test-htr1.lib.princeton.edu


### PR DESCRIPTION
Related to #6637.

Also related to https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/174. 

Removes the old cdh-crawl VMs from inventory. 