### PR TITLE
[apt] modify fix_apt_issues playbook 

### DIFF
--- a/playbooks/utils/fix_apt_issues.yml
+++ b/playbooks/utils/fix_apt_issues.yml
@@ -23,18 +23,6 @@
         id: "{{ recv_key | default(omit) }}"
       when: recv_key is defined
 
-    # we won't be using crowdstrike for much longer
-    # - name: install crowdstrike key from a file
-    #   ansible.builtin.apt_key:
-    #     file: roles/common/files/falcon_key.asc
-    #     state: present
-    #   become: true
-
-    # - name: add crowdstrike apt GPG key from file
-    #   ansible.builtin.apt_key:
-    #     data: "{{ lookup('{{ ../../roles/common/files/{{ falcon_key.gpg }}') }}"
-    #     state: present
-
     - name: update release info
       ansible.builtin.command: apt-get --allow-releaseinfo-change update
 


### PR DESCRIPTION
Commenting out the task that installs Crowdstrike key from file, since we are moving away from Crowdstrike