### PR TITLE
remove the time limit for roles

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -119,7 +119,6 @@ jobs:
           docker pull ghcr.io/pulibrary/vm-builds/ubuntu-22.04:latest
 
       - name: Run tests
-        timeout-minutes: 15
         env:
           MOLECULE_DOCKER_PLATFORM: linux/amd64
         run: |


### PR DESCRIPTION
we added the time limit while trying to determine why our systemd based images were taking so long to pull and build.
We solved the problem by pulling the image earlier than tests and left this timer.
this will unbreak main
closes #6699 