### PR TITLE
[passenger] add new key to passenger role

### DIFF
--- a/inventory/all_projects/approvals
+++ b/inventory/all_projects/approvals
@@ -1,7 +1,6 @@
 [approvals_staging]
 lib-approvals-staging1.princeton.edu
 lib-approvals-staging2.princeton.edu
-sandbox-vkarasic.lib.princeton.edu
 [approvals_production]
 lib-approvals-prod1.princeton.edu
 lib-approvals-prod2.princeton.edu


### PR DESCRIPTION
the phusion folks have switched to new signing infrastructure. Rather than use onesie twosies we bolt on the new key to the passenger role

closes https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/204