### PR TITLE
[ezproxy] use vm build image

### DIFF
--- a/roles/ezproxy/molecule/default/molecule.yml
+++ b/roles/ezproxy/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: "quay.io/pulibrary/jammy-ansible:latest"
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw


### PR DESCRIPTION
this https://github.com/pulibrary/princeton_ansible/pull/6716 breaks main when using our image on quay. 

We fix that by updating our image with a new version of python. 