### PR TITLE
[bots] Use Traefik high challenge on the catalog for now

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -18,10 +18,10 @@ upstream catalog-prod {
     # server service.consul service=lowchallenge.traefik-wall-production resolve max_fails=0;
     # Temporarily use a testing traefik wall, for accessibility testing of the
     # bot challenge.
-    server service.consul service=testchallenge.traefik-wall-testing resolve max_fails=0;
+    # server service.consul service=testchallenge.traefik-wall-testing resolve max_fails=0;
     # highchallenge challenges everyone. Comment above and uncomment
     # this when you're being swarmed by bots.
-    # server service.consul service=highchallenge.traefik-wall-staging resolve max_fails=0;
+    server service.consul service=highchallenge.traefik-wall-staging resolve max_fails=0;
     # If Traefik crashes, fall down to the box directly.
     server catalog1.princeton.edu max_fails=0 resolve backup;
     server catalog2.princeton.edu max_fails=0 resolve backup;


### PR DESCRIPTION
We've seen 3.1m requests to the catalog in the last 24 hours. The high rate of traffic was affecting performance.

We raised the Traefik wall settings to use the high challenge to see if that reduces the pressure.

Run against both prod load balancers today. 