### PR TITLE
Remove lib-sc-prod1 from inventory

### DIFF
--- a/inventory/all_projects/special_collections
+++ b/inventory/all_projects/special_collections
@@ -1,1 +1,0 @@
-lib-sc-prod1.princeton.edu


### PR DESCRIPTION
Closes #6780.

The `lib-sc-prod1` VM does not exist. It has not existed for many months, we just missed removing it from inventory in #5783. 

This PR removes the non-existent VM from inventory.