### PR TITLE
removes getit-dev config, retains prod version

### DIFF
--- a/roles/nginxplus/files/conf/http/getit_dev.conf
+++ b/roles/nginxplus/files/conf/http/getit_dev.conf
@@ -1,8 +1,0 @@
-# Ansible managed
-server {
-    listen 80;
-    server_name getit-dev.princeton.edu;
-
-    rewrite ^/resolve(.*)$ https://princeton.alma.exlibrisgroup.com/discovery/openurl?institution=01PRI_INST&vid=01PRI_INST:Services&$1 permanent;
-    rewrite ^/(.*)$ https://catalog-qa.princeton.edu/?f%5Baccess_facet%5D%5B%5D=Online&f%5Bformat%5D%5B%5D=Journal permanent;
-}


### PR DESCRIPTION
Closes #6786.

The production `getit` project is still in use, so we need the config/redirects for that. However, we are no longer developing on the project.

This PR removes the `getit-dev` config file.