### PR TITLE
Update order of config.txt directives. 

### DIFF
--- a/roles/ezproxy/templates/config.txt.j2
+++ b/roles/ezproxy/templates/config.txt.j2
@@ -61,7 +61,8 @@ LogSPU -strftime log/spu%Y%m%d.log %h %l %u %t "%r" %s %b
 # IncludeFile config/current/admin/non_proxy_stanzas.txt
 
 # Excluded campus IP ranges from proxying
-# IncludeFile princeton_allow.txt
+IncludeFile princeton_allow.txt
+
 # Stanzas that must appear at start of config
 # IncludeFile config/current/includes/positiondependent.txt
 # Keep in A to Z Order


### PR DESCRIPTION
Remove default group duplicate designation, place Princeton IP range configurations before the database stanzas that do not require campus proxy protection.

For #6798. 