### PR TITLE
add idempotence to the common role

### DIFF
--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -3,11 +3,16 @@ scenario:
   name: default
   test_sequence:
     - dependency
+    - cleanup
+    - destroy
     - syntax
     - create
     - prepare
     - converge
+    - idempotence
+    - side_effect
     - verify
+    - cleanup 
     - destroy
 driver:
   name: docker

--- a/roles/example/molecule/default/molecule.yml
+++ b/roles/example/molecule/default/molecule.yml
@@ -3,11 +3,16 @@ scenario:
   name: default
   test_sequence:
     - dependency
+    - cleanup
+    - destroy
     - syntax
     - create
     - prepare
     - converge
+    - idempotence
+    - side_effect
     - verify
+    - cleanup 
     - destroy
 driver:
   name: docker


### PR DESCRIPTION
many roles call on common and we want to ensure it passes CI first we use the example role and we want to ensure when we create new roles in the future they all have idempotence

related to #6789