### PR TITLE
[pdc-describe] swap out the community gem for a command

### DIFF
--- a/roles/mailcatcher/tasks/main.yml
+++ b/roles/mailcatcher/tasks/main.yml
@@ -9,11 +9,9 @@
   tags: mailcatcher
 
 - name: mailcatcher | install global mail catcher
-  community.general.gem:
-    name: mailcatcher
-    user_install: false
-    version: "{{ mailcatcher_version }}"
-  when: install_mailcatcher
+  ansible.builtin.command: gem install mailcatcher
+  register: gem_install
+  changed_when: "'Successfully installed mailcatcher' in gem_install.stdout"
   tags: mailcatcher
 
 - name: mailcatcher | Install startup script for mailcatcher


### PR DESCRIPTION
module itself is issuing an unsupported command to the target's RubyGems binary, we modify it to use the command instead closes #6812