### PR TITLE
[repec] fix repec-staging2.princeton.edu in inventory 

### DIFF
--- a/inventory/all_projects/repec
+++ b/inventory/all_projects/repec
@@ -1,6 +1,6 @@
 [repec_staging]
 repec-staging1.princeton.edu
-repec-staging2.lib.princeton.edu
+repec-staging2.princeton.edu
 [repec_production]
 repec-prod1.princeton.edu
 repec-prod2.princeton.edu


### PR DESCRIPTION
Machine had a `.lib` in the name and was not reachable in inventory