### PR TITLE
[datadog] remove side_effect and ensure idempotence is tested

### DIFF
--- a/roles/datadog/molecule/default/molecule.yml
+++ b/roles/datadog/molecule/default/molecule.yml
@@ -3,11 +3,15 @@ scenario:
   name: default
   test_sequence:
     - dependency
+    - cleanup
+    - destroy
     - syntax
     - create
     - prepare
     - converge
+    - idempotence
     - verify
+    - cleanup 
     - destroy
 driver:
   name: docker

--- a/roles/datadog/tasks/agent6.yml
+++ b/roles/datadog/tasks/agent6.yml
@@ -77,6 +77,8 @@
     state: started
     enabled: true
   when: datadog_enabled
+  # fix idempotence in Molecule/Docker
+  changed_when: false
 
 - name: Datadog | Ensure datadog-agent is not running
   ansible.builtin.service:


### PR DESCRIPTION
as best as I can tell the service module reports a status of changed every time it is called, even if the service is already running. This happens because the module often cannot reliably verify the state of a service inside a container's init system

When Molecule runs the "idempotence" check, it runs the playbook a second time and expects zero changes. Since this task returns changed: [instance] on the second pass, the test fails.

related to #6789