### PR TITLE
[oawaiver] make ruby version match repo

### DIFF
--- a/group_vars/oawaiver/staging.yml
+++ b/group_vars/oawaiver/staging.yml
@@ -34,7 +34,7 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 
 # Use Ruby 3.0.3 and install from source
 install_ruby_from_source: true
-ruby_version_override: "ruby-3.1.3"
+ruby_version_override: "ruby-3.2.3"
 
 # System Node.js
 desired_nodejs_version: "v22.13.1"


### PR DESCRIPTION
there is a discrepancy of ruby version on prancible and https://github.com/pulibrary/oawaiver/tree/i257_pvt_network