### PR TITLE
[figgy] Create new session persistence zone for figgy-downloads upstream

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/figgy-staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/figgy-staging.conf
@@ -30,7 +30,7 @@ upstream figgy-staging-downloads {
     sticky learn
           create=$upstream_cookie_figgycookie
           lookup=$cookie_figgycookie
-          zone=figgyclient_sessions:1m;
+          zone=figgystagingclient_download_sessions:1m;
 }
 
 server {

--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -33,7 +33,7 @@ upstream figgy-downloads {
     sticky learn
           create=$upstream_cookie_figgycookie
           lookup=$cookie_figgycookie
-          zone=figgyclient_sessions:1m;
+          zone=figgyclient_download_sessions:1m;
 }
 
 server {


### PR DESCRIPTION
Part of https://github.com/pulibrary/princeton_ansible/issues/6840
Follow up to https://github.com/pulibrary/princeton_ansible/pull/6841

An nginx config can't use a session persistence zone twice. We need to create a new zone for the figgy-downloads upstream.