### PR TITLE
remove a misplaced when clause

### DIFF
--- a/playbooks/libruby.yml
+++ b/playbooks/libruby.yml
@@ -11,7 +11,6 @@
   vars_files:
   roles:
     - role: deploy_user
-      when: runtime_env | default('staging') == "production"
   post_tasks:
   - name: tell everyone on slack you ran an ansible playbook
     community.general.slack:

--- a/playbooks/zookeeper.yml
+++ b/playbooks/zookeeper.yml
@@ -26,7 +26,6 @@
     - role: roles/zookeeper
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
-      when: runtime_env | default('staging') == "production"
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"


### PR DESCRIPTION
these playbooks have an odd when clause. We want to follow the runtime environment passed by the user and install the deploy role for ruby and the slack alerts should be triggered equally on staging any other environment