### PR TITLE
[postgresql] adjust the tcp connections for postgresql

### DIFF
--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -24,6 +24,10 @@ postgresadmin: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_port: 5432
 postgres_admin_user: "{{ postgresadmin }}"
+# tcp connections
+postgres_tcp_keepalives_idle: 1800
+postgres_tcp_keepalives_interval: 10
+postgres_tcp_keepalives_count: 6
 
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_agent_version: "1:6.46.0-1"


### PR DESCRIPTION
we are adjust the connection to stop relying on the underlying OS setting for TCP connections. This (we hope) will stop zombie connections from using up the postgresql connection

related to #6855 