### PR TITLE
[Nomad] Get molecule setup able to run jobs again.

### DIFF
--- a/roles/pul_nomad/molecule/default/create.yml
+++ b/roles/pul_nomad/molecule/default/create.yml
@@ -27,6 +27,8 @@
         cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
         tmpfs: "{{ item.tmpfs | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
+        published_ports: "{{ item.published_ports | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
         # Only pass command if it’s non-empty; otherwise use image CMD (/sbin/init in your image)
         command: "{{ (item.command | default('') | length > 0) | ternary(item.command, omit) }}"
         log_driver: json-file

--- a/roles/pul_nomad/molecule/default/example_redis.hcl
+++ b/roles/pul_nomad/molecule/default/example_redis.hcl
@@ -1,0 +1,32 @@
+job "redis" {
+  datacenters = ["dc1"]
+  type        = "service"
+  node_pool = "staging"
+
+  group "cache" {
+    network {
+      port "db" { to = 6379 }
+    }
+
+    task "redis" {
+      driver = "podman"
+
+      config {
+        image = "docker.io/library/redis:latest"
+        ports = ["db"]
+      }
+
+      service {
+        name = "redis"
+        port = "db"
+        
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/roles/pul_nomad/molecule/default/prepare.yml
+++ b/roles/pul_nomad/molecule/default/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: prepare
+  hosts: all
+  tasks:
+    # Disable some podman things to let it work in molecule.
+    - name: Create a directory if it does not exist
+      ansible.builtin.file:
+        path: /etc/containers
+        state: directory
+        mode: '0755'
+    - name: prepare | set up Podman storage.conf to use VFS
+      ansible.builtin.copy:
+        dest: /etc/containers/storage.conf
+        content: |
+          [storage]
+          driver = "vfs"
+    - name: refetch facts
+      setup:

--- a/roles/pul_nomad/templates/nomad/client.hcl.j2
+++ b/roles/pul_nomad/templates/nomad/client.hcl.j2
@@ -9,6 +9,10 @@ client {
   }
   {% endfor %}
 
+  {% if pulibrary_nomad_cpu_total_compute -%}
+    cpu_total_compute = {{ pulibrary_nomad_cpu_total_compute }}
+  {% endif %}
+
   {% if nomad_meta -%}
   meta = {
     {% for key, value in nomad_meta.items() %}


### PR DESCRIPTION
I wanted to start trying upgrading Nomad in Molecule, but found that the setup couldn't run jobs anymore. This gets it so that after `molecule converge`, you can go to localhost:4646 and submit that redis job.

It also doesn't end up with a working `dnsmasq` setup, I think because `nmcli` isn't installed in those docker images, but this at least moves things forward.