### PR TITLE
Add options to make tigerdata mount more reliable.

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -1,6 +1,6 @@
 ---
 tigerdata_nfs_src: 'test.rc.princeton.edu:/figgy'
-tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp'
+tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp,actimeo=0,lookupcache=none'
 deploy_ssh_users:
   - name: tpendragon
     key: https://github.com/tpendragon.keys

--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -1,6 +1,6 @@
 ---
 tigerdata_nfs_src: 'test.rc.princeton.edu:/figgy'
-tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp'
+tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp,actimeo=0,lookupcache=none'
 figgy_db_name: 'figgy_staging'
 figgy_db_user: '{{vault_figgy_staging_db_user}}'
 figgy_db_password: '{{vault_figgy_staging_db_password}}'


### PR DESCRIPTION
Our NFS caches were storing bad inode -> path mappings, so these options
should force NFS to re-check that mapping on every read.

This will PROBABLY slow that mount down some, but that's better than
returning random files.

If this still doesn't fix it then there's probably a bug in mediaflux. :(

Documentation for NFS options: https://linux.die.net/man/5/nfs

Closes pulibrary/figgy#7037

This has been deployed everywhere.
