### PR TITLE
[cdh] move prosody to dev load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/cdh_test_prosody.conf
+++ b/roles/nginxplus/files/conf/http/dev/cdh_test_prosody.conf
@@ -87,11 +87,6 @@ server {
         proxy_send_timeout         2h;
         proxy_read_timeout         2h;
         proxy_intercept_errors on;
-#        health_check interval=10 fails=3 passes=2;
-        # allow princeton network
-        include /etc/nginx/conf.d/templates/restrict.conf;
-        # block all
-        deny all;
     }
     include /etc/nginx/conf.d/templates/cdh-errors.conf;
 }


### PR DESCRIPTION
we are moving most non-production properties to our staging environment

related to this ticket https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/259