### PR TITLE
[EZproxy] add IPv6 option to config 

### DIFF
--- a/playbooks/ezproxy.yml
+++ b/playbooks/ezproxy.yml
@@ -15,6 +15,9 @@
     - ../group_vars/ezproxy/common.yml
     - ../group_vars/ezproxy/{{ runtime_env | default('testing') }}.yml
     - ../group_vars/ezproxy/vault.yml
+  pre_tasks:
+    - set_fact:
+        deploy_id_rsa_private_key: "{{  lookup('file', '../roles/ezproxy/files/id_rsa')  }}\n"
   roles:
     - role: ruby_s
     - role: ezproxy


### PR DESCRIPTION
- related to #6913 

- add the IPv6 option to the Ezproxy config directives (per [OCLC's instructions](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/Option_IPv6))