### PR TITLE
[cdh] add keys should be on lib-solr-staging2

### DIFF
--- a/inventory/all_projects/cdh
+++ b/inventory/all_projects/cdh
@@ -38,11 +38,13 @@ lib-ponyexpr-prod.princeton.edu
 lib-postgres-prod1.princeton.edu
 lib-postgres-prod3.princeton.edu
 lib-solr-prod1.princeton.edu
-lib-solr-prod7.princeton.edu
+lib-solr-prod2.princeton.edu
+lib-solr-prod3.princeton.edu
 [cdh_shared_staging]
 adc-dev1.lib.princeton.edu
 adc-dev2.lib.princeton.edu
 lib-fs-staging.princeton.edu
 lib-postgres-staging1.princeton.edu
+lib-solr-staging1.princeton.edu
 lib-solr-staging2.princeton.edu
-lib-solr-staging4d.princeton.edu
+lib-solr-staging3.princeton.edu


### PR DESCRIPTION
we moved the [lead solr server](https://github.com/pulibrary/pul_solr/commit/b5b4cbbde0c39cf0138442fcd18e945aa729052f) to lib-solr-staging2 and failed to add this to the inventory. As a result the cdh keys are missing on the server.

This fixes that.

related to https://github.com/Princeton-CDH/cdh-ansible/pull/305