### PR TITLE
adds lib-vrestlin to inventory

### DIFF
--- a/inventory/all_projects/_orphans
+++ b/inventory/all_projects/_orphans
@@ -10,9 +10,9 @@ libserv35.princeton.edu # also possibly SVN?
 libserv101.princeton.edu # aka 128.112.200.213
 libserv128.princeton.edu # hot, no clues
 [backup]
-# runs our VEEAM VM backups
-lib-bkpsvr.princeton.edu
+lib-bkpsvr.princeton.edu # runs VEEAM VM backups
 libserv122.princeton.edu # lib-reports runs backup reports
+lib-vrestlin # restores linux VMs from VEEAM when needed
 [load_balancers]
 # do not add to 'production' group; these require manual maintenance
 lib-adc1.princeton.edu


### PR DESCRIPTION
Partially addresses #3897.

See also the google [spreadsheet of our prod inventory](https://docs.google.com/spreadsheets/d/1UDuMc7ESjKrqfAN2zm46WNvmLwp1KLoZoKD1ELwygeA/edit?gid=0#gid=0) as of January, 2026.

This PR:
- adds lib-vrestlin to our inventory
- reorganizes the comments on entries in the `backup` inventory group for clarity