### PR TITLE
rm illiad mount points creation

### DIFF
--- a/roles/figgy/tasks/main.yml
+++ b/roles/figgy/tasks/main.yml
@@ -21,12 +21,8 @@
     - figgy_binaries
     - figgy_images
     - diglibdata
-    - illiad
     - 'diglibdata/pudl'
     - 'diglibdata/hydra_binaries'
-    - 'illiad/images'
-    - 'illiad/ocr_scan'
-    - 'illiad/cdl_scans'
     - 'hosted_illiad'
     - 'hosted_illiad/RequestScans'
 


### PR DESCRIPTION
Related to team-handbook i286, remove obsolete mount points for illiad.