### PR TITLE
Update _orphans inventory

### DIFF
--- a/inventory/all_projects/_orphans
+++ b/inventory/all_projects/_orphans
@@ -12,7 +12,7 @@ libserv128.princeton.edu # hot, no clues
 [backup]
 lib-bkpsvr.princeton.edu # runs VEEAM VM backups
 libserv122.princeton.edu # lib-reports runs backup reports
-lib-vrestlin # restores linux VMs from VEEAM when needed
+lib-vrestlin.princeton.edu # restores linux VMs from VEEAM when needed
 [load_balancers]
 # do not add to 'production' group; these require manual maintenance
 lib-adc1.princeton.edu


### PR DESCRIPTION
When I added the `lib-vrestlin` VM to inventory, I forgot the DNS extension. This PR adds `.princeton.edu` to the inventory entry. 

Follows up on #6930 