### PR TITLE
[allsearch-frontend] Make sure it can run on a fresh VM

### DIFF
--- a/roles/allsearch_frontend/tasks/main.yml
+++ b/roles/allsearch_frontend/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: allsearch_frontend | Make sure shared application directory exists
+  ansible.builtin.file:
+    path: "{{ capistrano_base_dir }}/shared"
+    state: directory
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: 0755
 - name: allsearch_frontend | Install .env in shared application directory
   ansible.builtin.template:
     src: "env.j2"


### PR DESCRIPTION
If you run this playbook on a recently built machine, you get the error:

```
Destination directory /opt/allsearch_frontend/shared does not exist
```

See [this failed job on tower](https://ansible-tower.princeton.edu/#/jobs/playbook/42144/output)

This makes sure that the path exists before attempting to create the file.