### PR TITLE
adds bitcur13 to inventory

### DIFF
--- a/inventory/all_projects/bitcurator
+++ b/inventory/all_projects/bitcurator
@@ -11,3 +11,4 @@ lib-vm-bitcur9.princeton.edu
 lib-vm-bitcur10.princeton.edu
 lib-vm-bitcur11.princeton.edu
 lib-vm-bitcur12.princeton.edu
+lib-vm-bitcur13.princeton.edu


### PR DESCRIPTION
We currently have bitcurator VMs numbered 1-13 in VMware. Number 12 is powered off and may be slated for decommissioning, but meanwhile we need to automate number 13. 

This PR adds the number 13 VM to inventory so we can update it. Related to https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/294. 