### PR TITLE
Added condition for pkg to install if not in package_facts

### DIFF
--- a/group_vars/xdr/vars.yml
+++ b/group_vars/xdr/vars.yml
@@ -1,5 +1,4 @@
 ---
-brownfield_xdr_version: "102720205"
 cortex_install: "cortex-8.9.0.136780"
-greenfield_xdr_version: "11062025"
+xdr_version: "11062025"
 xdr_distribution_server: "https://distributions.traps.paloaltonetworks.com/"

--- a/playbooks/utils/security_theater.yml
+++ b/playbooks/utils/security_theater.yml
@@ -21,33 +21,9 @@
     ansible.builtin.package_facts:
 
   tasks:
-  - name: check for the falcon log file
-    ansible.builtin.stat:
-      path: "/var/log/falcon-sensor.log"
-      # path: "/var/log/falcon-libbpf.log"
-    register: falcon_configured
-
-  - name: set to greenfield if falcon log is absent
-    ansible.builtin.set_fact:
-      install_type: greenfield
-      xdr_version: "{{ greenfield_xdr_version }}"
-    when:
-      - not falcon_configured.stat.exists
-    # when:
-    #   - "'falcon-sensor' not in ansible_facts.services"
-
-  - name: set to brownfield if falcon log is present
-    ansible.builtin.set_fact:
-      install_type: brownfield
-      xdr_version: "{{ brownfield_xdr_version }}"
-    when:
-      - falcon_configured.stat.exists
-    # when:
-    #   - "'falcon-sensor' not in ansible_facts.services"
-
   - name: Download the XDR deb file (Ubuntu)
     ansible.builtin.unarchive:
-      src: "https://pulmirror.princeton.edu/mirror/palo/{{ install_type }}/Linux-{{ xdr_version }}_deb.tar.gz"
+      src: "https://pulmirror.princeton.edu/mirror/palo/Linux-{{ xdr_version }}_deb.tar.gz"
       dest: /opt/
       creates: /opt/{{ cortex_install }}.deb
       remote_src: true
@@ -57,7 +33,7 @@
 
   - name: Download the XDR rpm file (RedHat)
     ansible.builtin.unarchive:
-      src: "https://pulmirror.princeton.edu/mirror/palo/{{ install_type }}/Linux-{{ xdr_version }}_rpm.tar.gz"
+      src: "https://pulmirror.princeton.edu/mirror/palo/Linux-{{ xdr_version }}_rpm.tar.gz"
       dest: /opt/
       creates: /opt/{{ cortex_install }}.rpm
       remote_src: true
@@ -101,6 +77,7 @@
       deb: "/opt/{{ cortex_install }}.deb"
     when:
       - ansible_os_family == "Debian"
+      - "'cortex-agent' not in ansible_facts.packages"
 
   # yum module equiv of sudo yum -y install for rocky
   - name: install XDR agent (RedHat)


### PR DESCRIPTION
Removed falcon check, and the need for a green and brown installation. 
Also added a condition to install only when the cortex-agent is not in the package facts.
The behavior was not present in rocky version vms so did not add the condition for it. 

Ran from branch on multiple hosts with and without the cortex-agent installed.