### PR TITLE
[denyhost] Block Alibaba US (which is located in Singapore)

### DIFF
--- a/roles/denyhost/vars/main.yml
+++ b/roles/denyhost/vars/main.yml
@@ -451,10 +451,11 @@ banned_ranges:
     ip_range:
       - 14.160.0.0/11
       - 14.224.0.0/11
+      - 113.160.0.0/11
+      - 123.16.0.0/12
   - name: Alibaba US (Singapore)
     ip_range:
       - 43.119.0.0/18
-
 
 # Below is an example of banning Francis
 # - name: Francis test | Description (see ticket 12345)


### PR DESCRIPTION
They are making a lot of calls to bibdata availability service, which is causing us to use 8x as many Alma API calls as usual.

We ran the playbook with this today.