### PR TITLE
[EZProxy] remove PPPL IP ranges from config

### DIFF
--- a/roles/ezproxy/templates/princeton_allow.txt.j2
+++ b/roles/ezproxy/templates/princeton_allow.txt.j2
@@ -4,7 +4,5 @@ Group Default
 IncludeIP 0.0.0.0 - 255.255.255.255
 ExcludeIP 128.112.0.0 - 128.112.255.255
 ExcludeIP 140.180.0.0 - 140.180.255.255
-ExcludeIP 198.35.0.0 - 198.35.15.255
-ExcludeIP 198.125.224.0 - 198.125.239.255
 ### Permitted for Anywhere Access Support - Autologin is not otherwise used
 AutoLoginIP 35.153.163.236


### PR DESCRIPTION
related to #6946 

removed exclude lines for PPPL IP ranges that begin with 198

tested on ezproxy-test without issues