### PR TITLE
[nginxplus] Catalog prod: use production traefik bot wall

### DIFF
--- a/roles/nginxplus/files/conf/http/catalog-prod.conf
+++ b/roles/nginxplus/files/conf/http/catalog-prod.conf
@@ -21,7 +21,7 @@ upstream catalog-prod {
     # server service.consul service=testchallenge.traefik-wall-testing resolve max_fails=0;
     # highchallenge challenges everyone. Comment above and uncomment
     # this when you're being swarmed by bots.
-    server service.consul service=highchallenge.traefik-wall-staging resolve max_fails=0;
+    server service.consul service=highchallenge.traefik-wall-production resolve max_fails=0;
     # If Traefik crashes, fall down to the box directly.
     server catalog1.princeton.edu max_fails=0 resolve backup;
     server catalog2.princeton.edu max_fails=0 resolve backup;


### PR DESCRIPTION
We were previously using the staging bot wall (I think I remember @christinach and @kayiwa mentioning something about this).

It apparently stopped working on Wednesday -- we observed in both datadog and Cloudflare's analytics that challenges dropped drastically.  As of today, trying to go to catalog.princeton.edu/challenge gave me a 'Something went wrong'.  And we had a pretty dramatic crawler event this morning that was not blocked by the bot wall.

I ran this change today on both LBs.  And now catalog.princeton.edu/challenge works for me!