### PR TITLE
Remove past CDH staff and contractors

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -103,13 +103,10 @@ cdh_github_keys:
   - https://github.com/aaronmdunn.keys
   - https://github.com/blms.keys # Ben Silverman, external consultant
   - https://github.com/cmroughan.keys # CDH post-doc, co-PI on HTR2HPC project
-  - https://github.com/haydngreatnews.keys # Haydn Greatnews, contractor (Springload)
   - https://github.com/jerielizabeth.keys
   - https://github.com/laurejt.keys
   - https://github.com/mabdellatif88.keys
-  - https://github.com/mnaydan.keys
   - https://github.com/rlskoeser.keys
-  - https://github.com/sarahframe.keys # Sarah Frame, contractor (Springload)
   - https://github.com/WHaverals.keys
   - https://github.com/tanhaow.keys
 analyze_catalog_github_keys:


### PR DESCRIPTION
This PR updates the list of CDH user github keys to remove people who no longer need access.
- Mary Naydan moved to a different unit at Princeton
- Hadyn and Sarah no longer work for Springload