### PR TITLE
[nginx] update Veridian sites redirects

### DIFF
--- a/roles/nginxplus/files/conf/http/veridian-sites.conf
+++ b/roles/nginxplus/files/conf/http/veridian-sites.conf
@@ -17,12 +17,6 @@ upstream veridian14 {
 
 server {
     listen 80;
-    server_name diglib4.princeton.edu;
-    rewrite ^/(.*)$ https://historicperiodicals.princeton.edu/$1 permanent;
-}
-
-server {
-    listen 80;
     server_name historicperiodicals.princeton.edu;
 
     location / {
@@ -49,7 +43,7 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-        return 301 https://bluemountain.princeton.edu;
+        rewrite ^/(.*)$ https://bluemountain.veridiansoftware.com/$1 permanent;
     }
 
     include /etc/nginx/conf.d/templates/errors.conf;


### PR DESCRIPTION
related to #7034 

- remove redirect for diglib4
- add redirect to historicperiodicals.princeton.edu for new Veridian hosted bluemountain site until CNAME is created in 3 months 