### PR TITLE
[Traefik Wall] Give more ram to traefik

### DIFF
--- a/nomad/traefik-wall/deploy/production.hcl
+++ b/nomad/traefik-wall/deploy/production.hcl
@@ -120,7 +120,7 @@ job "traefik-wall-production" {
 
       resources {
         cpu    = 1000
-        memory = 512
+        memory = 1024
       }
     }
   }


### PR DESCRIPTION
I was seeing failing requests to `digital-collections` and @kevinreiss just reported folks were seeing failed challenges. Nomad was showing maxed ram usage for this instance.