### PR TITLE
[unbreak main] drop remote_tmp and /tmp from molecule

### DIFF
--- a/roles/ad_join/molecule/default/molecule.yml
+++ b/roles/ad_join/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/apache2/molecule/default/molecule.yml
+++ b/roles/apache2/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/approvals/molecule/default/molecule.yml
+++ b/roles/approvals/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/bibdata/molecule/default/molecule.yml
+++ b/roles/bibdata/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/bibdata_sqs_poller/molecule/default/molecule.yml
+++ b/roles/bibdata_sqs_poller/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/bind9/molecule/default/molecule.yml
+++ b/roles/bind9/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/blacklight_app/molecule/default/molecule.yml
+++ b/roles/blacklight_app/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/cantaloupe/molecule/default/molecule.yml
+++ b/roles/cantaloupe/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/capistrano/molecule/default/molecule.yml
+++ b/roles/capistrano/molecule/default/molecule.yml
@@ -22,7 +22,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -33,9 +32,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/clamav/molecule/default/molecule.yml
+++ b/roles/clamav/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/composer/molecule/default/molecule.yml
+++ b/roles/composer/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/datadog/molecule/default/molecule.yml
+++ b/roles/datadog/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/deploy_user/molecule/default/molecule.yml
+++ b/roles/deploy_user/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/dss/molecule/default/molecule.yml
+++ b/roles/dss/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/example/molecule/default/molecule.yml
+++ b/roles/example/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/extra_path/molecule/default/molecule.yml
+++ b/roles/extra_path/molecule/default/molecule.yml
@@ -22,7 +22,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -33,9 +32,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/ezproxy/molecule/default/molecule.yml
+++ b/roles/ezproxy/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/ffmpeg_s/molecule/default/molecule.yml
+++ b/roles/ffmpeg_s/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/figgy/molecule/default/molecule.yml
+++ b/roles/figgy/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/figgy_filewatcher_worker/molecule/default/molecule.yml
+++ b/roles/figgy_filewatcher_worker/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/figgy_pubsub_worker/molecule/default/molecule.yml
+++ b/roles/figgy_pubsub_worker/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/freetds/molecule/default/molecule.yml
+++ b/roles/freetds/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/gitlab/molecule/default/molecule.yml
+++ b/roles/gitlab/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -83,6 +83,7 @@
   ansible.builtin.apt:
     name: gitlab-ce
     state: present
+    update_cache: true
     force_apt_get: true
   environment:
     DEBIAN_FRONTEND: noninteractive

--- a/roles/golang/molecule/default/molecule.yml
+++ b/roles/golang/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/himmelblau_entra_id/molecule/default/molecule.yml
+++ b/roles/himmelblau_entra_id/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/hr_share/molecule/default/molecule.yml
+++ b/roles/hr_share/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/iiif/molecule/default/molecule.yml
+++ b/roles/iiif/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/imagemagick/molecule/default/molecule.yml
+++ b/roles/imagemagick/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/lae/molecule/default/molecule.yml
+++ b/roles/lae/molecule/default/molecule.yml
@@ -22,7 +22,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -33,9 +32,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/lib_jobs/molecule/default/molecule.yml
+++ b/roles/lib_jobs/molecule/default/molecule.yml
@@ -22,7 +22,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -33,9 +32,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/lib_sftp/molecule/default/molecule.yml
+++ b/roles/lib_sftp/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/libstatic/molecule/default/molecule.yml
+++ b/roles/libstatic/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/lockers_and_study_spaces/molecule/default/molecule.yml
+++ b/roles/lockers_and_study_spaces/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/mailcatcher/molecule/default/molecule.yml
+++ b/roles/mailcatcher/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/mediainfo/molecule/default/molecule.yml
+++ b/roles/mediainfo/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/memcached/molecule/default/molecule.yml
+++ b/roles/memcached/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/mysql/molecule/default/molecule.yml
+++ b/roles/mysql/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/nfsserver/molecule/default/molecule.yml
+++ b/roles/nfsserver/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/nginx/molecule/default/molecule.yml
+++ b/roles/nginx/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/nginxplus/molecule/default/molecule.yml
+++ b/roles/nginxplus/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/nodejs/molecule/default/molecule.yml
+++ b/roles/nodejs/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/obsd_httpd/molecule/default/molecule.yml
+++ b/roles/obsd_httpd/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/openjdk/molecule/default/molecule.yml
+++ b/roles/openjdk/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/orangelight/molecule/default/molecule.yml
+++ b/roles/orangelight/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/otel_collector/molecule/default/molecule.yml
+++ b/roles/otel_collector/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/pas/molecule/default/molecule.yml
+++ b/roles/pas/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/passenger/molecule/default/molecule.yml
+++ b/roles/passenger/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/php/molecule/default/molecule.yml
+++ b/roles/php/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/postfix/molecule/default/molecule.yml
+++ b/roles/postfix/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/postgresql/molecule/default/molecule.yml
+++ b/roles/postgresql/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/pul_nomad/molecule/default/molecule.yml
+++ b/roles/pul_nomad/molecule/default/molecule.yml
@@ -34,7 +34,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
@@ -61,7 +60,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
@@ -85,7 +83,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
@@ -109,7 +106,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/roles/pulfalight/molecule/default/molecule.yml
+++ b/roles/pulfalight/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/pulmap/molecule/default/molecule.yml
+++ b/roles/pulmap/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/redis/molecule/default/molecule.yml
+++ b/roles/redis/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/repec/molecule/default/molecule.yml
+++ b/roles/repec/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/resque_worker/molecule/default/molecule.yml
+++ b/roles/resque_worker/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/ruby_app/molecule/default/molecule.yml
+++ b/roles/ruby_app/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/ruby_s/molecule/default/molecule.yml
+++ b/roles/ruby_s/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/rust/molecule/default/molecule.yml
+++ b/roles/rust/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/samba/molecule/default/molecule.yml
+++ b/roles/samba/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/shared_data/molecule/default/molecule.yml
+++ b/roles/shared_data/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/sneakers_worker/molecule/default/molecule.yml
+++ b/roles/sneakers_worker/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/solr9cloud/molecule/default/molecule.yml
+++ b/roles/solr9cloud/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/solrcloud/molecule/default/molecule.yml
+++ b/roles/solrcloud/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/studio_proc/molecule/default/molecule.yml
+++ b/roles/studio_proc/molecule/default/molecule.yml
@@ -22,7 +22,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -33,9 +32,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/subversion/molecule/default/molecule.yml
+++ b/roles/subversion/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/timezone/molecule/default/molecule.yml
+++ b/roles/timezone/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/tippecanoe/molecule/default/molecule.yml
+++ b/roles/tippecanoe/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/tomcat9/molecule/default/molecule.yml
+++ b/roles/tomcat9/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/towerdeploy/molecule/default/molecule.yml
+++ b/roles/towerdeploy/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/ufw_firewall/molecule/default/molecule.yml
+++ b/roles/ufw_firewall/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/vips/molecule/default/molecule.yml
+++ b/roles/vips/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/xrdp/molecule/default/molecule.yml
+++ b/roles/xrdp/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/zfs/molecule/default/molecule.yml
+++ b/roles/zfs/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/zookeeper/molecule/default/molecule.yml
+++ b/roles/zookeeper/molecule/default/molecule.yml
@@ -26,7 +26,6 @@ platforms:
     tmpfs:
       - /run
       - /run/lock
-      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -37,9 +36,6 @@ provisioner:
   playbooks:
     create: create.yml
     destroy: destroy.yml
-  config_options:
-    defaults:
-      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible


### PR DESCRIPTION
ansible-core 2.19 surfaces a tmpdir race in the Docker connection plugin when remote_tmp points at /tmp and /tmp is also mounted as tmpfs. Gathering Facts fails with "dd: failed to open ... No such file or directory" because systemd-tmpfiles and Ansible's mkdir race on container boot, leaving the ansible-tmp-* subdirectory missing when dd runs.

Removing the remote_tmp override lets Ansible fall back to /root/.ansible/tmp, which the image already provisions at mode 777 on the overlay FS. Dropping /tmp from the tmpfs list keeps /run and /run/lock as tmpfs (systemd still needs those) while letting /tmp live on the overlay FS where it is not touched by systemd on boot.

no behavioral change for the roles themselves and only affects the molecule (currently failing)

ref: https://github.com/pulibrary/vm-builds/pull/59