### PR TITLE
[pdc_discovery] remove no longer needed UFW firewall rule

### DIFF
--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -21,12 +21,6 @@
     - role: ruby_app
     - role: otel_collector
   tasks:
-    - name: Allow HTTP from libnet
-      community.general.ufw:
-        rule: allow
-        port: "80"
-        proto: tcp
-        src: "172.20.80.0/22"
 
 # This is a temporary workaround. We should re-write the nodejs role to support yarn 4, 
 # but in the meantime we need to set it manually here.


### PR DESCRIPTION
This has now been baked into the machine image and isn't needed here.

I ran this playbook against pdc-discovery staging and re-deployed afterwards and everything worked. 

Closes #7046 