### PR TITLE
[nginx] Refactor nginx role to support FreeBSD

### DIFF
--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -6,33 +6,66 @@ Installs upstream version of nginx
 Requirements
 ------------
 
-Ubuntu Linux
+* Ubuntu Linux
+* FreeBSD
 
 Role Variables
 --------------
 
-* `nginx_config_file` (default: `/etc/nginx/conf.d/default.conf`)
-   * The directory where NGINX configuration files are stored.
+* `nginx_package_name` (default: `nginx`)
+  * The name of the nginx package to install
+
+* `nginx_service_name` (default: `nginx`)
+  * The name of the nginx service
+
+* `nginx_user` (default: `www` for FreeBSD, `nginx` for Ubuntu)
+  * The user that nginx runs as
+
+* `nginx_group` (default: `www` for FreeBSD, `nginx` for Ubuntu)
+  * The group that nginx runs as
+
+* `nginx_config_file` (default: `/usr/local/etc/nginx/nginx.conf` for FreeBSD, `/etc/nginx/nginx.conf` for Ubuntu)
+  * The main nginx configuration file path
+
+* `nginx_conf_dir` (default: `/usr/local/etc/nginx` for FreeBSD, `/etc/nginx` for Ubuntu)
+  * The directory where NGINX configuration files are stored
+
+* `nginx_mime_types_file` (default: `/usr/local/etc/nginx/mime.types` for FreeBSD, `/etc/nginx/mime.types` for Ubuntu)
+  * The path to the mime.types file
+
+* `nginx_pid_file` (default: `/var/run/nginx.pid` for FreeBSD, `/run/nginx.pid` for Ubuntu)
+  * The path to the nginx PID file
+
+* `nginx_error_log` (default: `/var/log/nginx/error.log`)
+  * The path to the nginx error log file
+
+* `nginx_access_log` (default: `/var/log/nginx/access.log`)
+  * The path to the nginx access log file
+
+* `nginx_manage_config` (default: `true`)
+  * Whether to manage the nginx configuration file
+
+* `nginx_enable_service` (default: `true`)
+  * Whether to enable the nginx service to start at boot
+
+* `nginx_start_service` (default: `true`)
+  * Whether to start the nginx service
+
+* `running_on_server` (default: `true`)
+  * Set to `false` when running in test containers to skip service management
 
 Dependencies
 ------------
 
+* `community.general` collection (required for FreeBSD `pkgng` and `sysrc` modules)
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
-
-License
--------
-
-BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+```yaml
+- hosts: servers
+  roles:
+    - role: nginx
+      nginx_config_file: /etc/nginx/nginx.conf
+      nginx_enable_service: true
+```

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,3 +1,44 @@
 ---
 # defaults file for roles/nginx
-nginx_config_file: default.conf
+nginx_package_name: nginx
+nginx_service_name: nginx
+
+nginx_user: "{{ 'www' if ansible_os_family == 'FreeBSD' else 'nginx' }}"
+nginx_group: "{{ 'www' if ansible_os_family == 'FreeBSD' else 'nginx' }}"
+
+nginx_config_file: >-
+  {{
+    '/usr/local/etc/nginx/nginx.conf'
+    if ansible_os_family == 'FreeBSD'
+    else '/etc/nginx/nginx.conf'
+  }}
+
+nginx_conf_dir: >-
+  {{
+    '/usr/local/etc/nginx'
+    if ansible_os_family == 'FreeBSD'
+    else '/etc/nginx'
+  }}
+
+nginx_mime_types_file: >-
+  {{
+    '/usr/local/etc/nginx/mime.types'
+    if ansible_os_family == 'FreeBSD'
+    else '/etc/nginx/mime.types'
+  }}
+
+nginx_pid_file: >-
+  {{
+    '/var/run/nginx.pid'
+    if ansible_os_family == 'FreeBSD'
+    else '/run/nginx.pid'
+  }}
+
+nginx_error_log: /var/log/nginx/error.log
+nginx_access_log: /var/log/nginx/access.log
+
+nginx_manage_config: true
+nginx_enable_service: true
+nginx_start_service: true
+
+running_on_server: true

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -1,8 +1,6 @@
 ---
-# handlers file for roles/nginx
 - name: Restart Nginx
-  ansible.builtin.systemd:
-    name: nginx
+  ansible.builtin.service:
+    name: "{{ nginx_service_name }}"
     state: restarted
-    daemon_reload: true
   when: running_on_server

--- a/roles/nginx/meta/main.yml
+++ b/roles/nginx/meta/main.yml
@@ -13,4 +13,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - jammy
+    - name: FreeBSD
+      versions:
+        - all
 dependencies: []

--- a/roles/nginx/tasks/config.yml
+++ b/roles/nginx/tasks/config.yml
@@ -1,0 +1,22 @@
+---
+- name: Nginx | Ensure log directory exists
+  ansible.builtin.file:
+    path: /var/log/nginx
+    state: directory
+    owner: root
+    group: "{{ 'wheel' if ansible_os_family == 'FreeBSD' else 'root' }}"
+    mode: "0755"
+  when: running_on_server
+
+- name: Nginx | Deploy nginx configuration
+  ansible.builtin.template:
+    src: nginx.conf.j2
+    dest: "{{ nginx_config_file }}"
+    owner: root
+    group: "{{ 'wheel' if ansible_os_family == 'FreeBSD' else 'root' }}"
+    mode: "0644"
+    validate: "nginx -t -c %s"
+  notify: Restart Nginx
+  when:
+    - running_on_server
+    - nginx_manage_config

--- a/roles/nginx/tasks/freebsd.yml
+++ b/roles/nginx/tasks/freebsd.yml
@@ -1,0 +1,11 @@
+---
+- name: Nginx | Install nginx on FreeBSD
+  community.general.pkgng:
+    name: "{{ nginx_package_name }}"
+    state: present
+
+- name: Nginx | Enable nginx in rc.conf
+  community.general.sysrc:
+    name: nginx_enable
+    value: "YES"
+  when: nginx_enable_service

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,54 +1,15 @@
 ---
 # tasks file for roles/nginx
-- name: Nginx | Install prerequisites
-  ansible.builtin.apt:
-    name: "{{ item }}"
-    state: present
-  loop:
-    - curl
-    - gnupg2
-    - ca-certificates
-    - lsb-release
-    - ubuntu-keyring
+- name: Nginx | Include Ubuntu tasks
+  ansible.builtin.include_tasks: ubuntu.yml
+  when: ansible_distribution == "Ubuntu"
 
-- name: Nginx | import signing key
-  ansible.builtin.apt_key:
-    state: present
-    url: https://nginx.org/keys/nginx_signing.key
+- name: Nginx | Include FreeBSD tasks
+  ansible.builtin.include_tasks: freebsd.yml
+  when: ansible_os_family == "FreeBSD"
 
-- name: Nginx - add repository
-  ansible.builtin.apt_repository:
-    repo: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
-    state: present
-    filename: nginx
-    update_cache: false
+- name: Nginx | Include config tasks
+  ansible.builtin.include_tasks: config.yml
 
-- name: Nginx | Update apt cache after adding repository
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 0
-  register: repo_cache_update
-  retries: 3
-  delay: 5
-  until: repo_cache_update is succeeded
-
-- name: Nginx | Install Nginx
-  ansible.builtin.apt:
-    name: nginx
-    state: present
-
-- name: Nginx | copy configuration
-  ansible.builtin.template:
-    src: default.conf.j2
-    dest: "{{ nginx_config_file }}"
-    mode: "0755"
-  notify:
-    - Restart Nginx
-  when: running_on_server
-
-- name: Nginx | Ensure Nginx is running
-  ansible.builtin.service:
-    name: nginx
-    state: started
-    enabled: true
-  when: running_on_server
+- name: Nginx | Include service tasks
+  ansible.builtin.include_tasks: service.yml

--- a/roles/nginx/tasks/service.yml
+++ b/roles/nginx/tasks/service.yml
@@ -1,0 +1,7 @@
+---
+- name: Nginx | Ensure nginx is enabled and running
+  ansible.builtin.service:
+    name: "{{ nginx_service_name }}"
+    enabled: "{{ nginx_enable_service }}"
+    state: "{{ 'started' if nginx_start_service else 'stopped' }}"
+  when: running_on_server

--- a/roles/nginx/tasks/ubuntu.yml
+++ b/roles/nginx/tasks/ubuntu.yml
@@ -1,0 +1,38 @@
+---
+- name: Nginx | Install prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - gnupg2
+      - ca-certificates
+      - lsb-release
+      - ubuntu-keyring
+    state: present
+    update_cache: true
+    cache_valid_time: 600
+
+- name: Nginx | Import nginx.org signing key
+  ansible.builtin.apt_key:
+    state: present
+    url: https://nginx.org/keys/nginx_signing.key
+
+- name: Nginx | Add nginx.org repository
+  ansible.builtin.apt_repository:
+    repo: "deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx"
+    state: present
+    filename: nginx
+    update_cache: false
+
+- name: Nginx | Update apt cache after adding repository
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 0
+  register: nginx_repo_cache_update
+  retries: 3
+  delay: 5
+  until: nginx_repo_cache_update is succeeded
+
+- name: Nginx | Install nginx
+  ansible.builtin.apt:
+    name: "{{ nginx_package_name }}"
+    state: present

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -1,0 +1,28 @@
+{{ ansible_managed | comment }}
+
+user {{ nginx_user }};
+worker_processes auto;
+
+error_log {{ nginx_error_log }} notice;
+pid {{ nginx_pid_file }};
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include {{ nginx_mime_types_file }};
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log {{ nginx_access_log }} main;
+
+    sendfile on;
+
+    keepalive_timeout 65;
+
+    include {{ nginx_conf_dir }}/conf.d/*.conf;
+}


### PR DESCRIPTION
The role was previously Ubuntu-only, relying on apt, nginx.org repositories, and systemd, which prevented reuse on FreeBSD hosts. We are migrating our Google cloud loadbalancers to FreeBSD and managing them via ansible. 

This change introduces OS-specific task files for Ubuntu and FreeBSD, using pkg for installation and rc.d service management on FreeBSD. Configuration paths, user/group, and PID locations are now derived from OS-aware defaults. The handler has been updated to use the generic service module for portability.

Molecule remains Ubuntu-only; FreeBSD support is validated via syntax/lint and real host testing. No change in behavior for existing Ubuntu deployments.