### PR TITLE
[denyhost] re-enable Azure IP ranges

### DIFF
--- a/roles/denyhost/vars/main.yml
+++ b/roles/denyhost/vars/main.yml
@@ -426,13 +426,14 @@ banned_ranges:
       - 213.180.203.0/24
       - 95.108.213.0/24
       - 5.255.231.0/24
-  - name: Azure aggressive crawler
-    ip_range:
-      - 52.145.0.0/16
-      - 52.146.0.0/15
-      - 52.148.0.0/14
-      - 52.152.0.0/13
-      - 52.160.0.0/11
+  # - name: Azure aggressive crawler
+    # re-enabled 4-27-26 as it was blocking New Yorker Archives
+  #   ip_range:
+  #     - 52.145.0.0/16
+  #     - 52.146.0.0/15
+  #     - 52.148.0.0/14
+  #     - 52.152.0.0/13
+  #     - 52.160.0.0/11
   - name: VIETTEL-CAMBODIA crawler
     ip_range:
       - 175.0.0.0/8


### PR DESCRIPTION
Re-enabled Azure IP ranges since they were blocking New Yorker Archives for IAS users

Related to SNow [TASK0427497](https://princeton.service-now.com/now/nav/ui/classic/params/target/sc_task.do%3Fsys_id%3D2af8890dc3a04750f123b143e4013160)
