### PR TITLE
[Figgy] Update tigerdata mount target

### DIFF
--- a/group_vars/figgy/production.yml
+++ b/group_vars/figgy/production.yml
@@ -1,5 +1,5 @@
 ---
-tigerdata_nfs_src: 'test.rc.princeton.edu:/figgy'
+tigerdata_nfs_src: 'tigerdata-nfs.princeton.edu:/figgy'
 tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp,actimeo=0,lookupcache=none'
 deploy_ssh_users:
   - name: tpendragon

--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -1,5 +1,5 @@
 ---
-tigerdata_nfs_src: 'test.rc.princeton.edu:/figgy'
+tigerdata_nfs_src: 'tigerdata-nfs.princeton.edu:/figgy'
 tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp,actimeo=0,lookupcache=none'
 figgy_db_name: 'figgy_staging'
 figgy_db_user: '{{vault_figgy_staging_db_user}}'

--- a/playbooks/utils/tigerdata_nfs_mount.yml
+++ b/playbooks/utils/tigerdata_nfs_mount.yml
@@ -6,7 +6,7 @@
 # 'nfs_opts'
 # values are available in Tower; or pass '-e' at the command line
 # For example:
-#  -e nfs_share=test.rc.princeton.edu:/figgy \
+#  -e nfs_share=tigerdata-nfs.princeton.edu:/figgy \
 #  -e mount_point=/mnt/tigerdata \
 #  -e nfs_opts="nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp"
 #


### PR DESCRIPTION
closes #7054

Deploy runbook, staging:
```
ansible figgy_staging -a "umount -l /mnt/tigerdata" --become
ansible-playbook playbooks/figgy_staging.yml --tags=mounts
```

Deploy runbook, prod:
first a group
```
ansible figgy_production_group_a -a "umount -l /mnt/tigerdata" --become
ansible-playbook playbooks/figgy_production.yml --tags=mounts --limit figgy_production_group_a
```
you can check one of the boxes (a group is odd numbered boxes) with `df -ht nfs`
then do b group
```
ansible figgy_production_group_b -a "umount -l /mnt/tigerdata" --become
ansible-playbook playbooks/figgy_production.yml --tags=mounts --limit figgy_production_group_b
```
