### PR TITLE
Openresty loadb prod

### DIFF
--- a/group_vars/gcploadbalancer/production.yml
+++ b/group_vars/gcploadbalancer/production.yml
@@ -24,7 +24,7 @@ openresty_altcha_bypass_networks:
 
 openresty_real_ip_enable: true
 openresty_real_ip_from:
-  - 35.245.45.3/32           # GCP LB SNAT
+  - 34.85.237.83/32
   - 130.41.0.0/16            # GlobalProtect ranges
   - 134.238.0.0/16
   - 137.83.0.0/16

--- a/group_vars/gcploadbalancer/production.yml
+++ b/group_vars/gcploadbalancer/production.yml
@@ -1,0 +1,59 @@
+---
+lego_email: lsupport@princeton.edu
+openresty_altcha_enable: true
+openresty_altcha_bypass_networks:
+  - 10.249.64.0/18           # Princeton Wired Private-1
+  - 10.249.0.0/18            # Princeton Wired Private-2
+  - 128.112.0.0/16           # Princeton Wired
+  - 172.20.80.0/22           # PU Subnet LibNetPvt
+  - 172.20.95.0/24           # GlobalProtect internal
+  - 172.20.192.0/19          # GlobalProtect internal
+  - 128.112.200.0/21         # PU LibNet extension
+  - 137.108.70.0/24          # PU CORE Team
+  - 140.180.0.0/16           # PU Eduroam
+  - 128.112.64.96/27         # SonicWALL SRA
+  - 128.112.64.224/27        # SonicWALL SRA
+  - 128.112.65.0/24          # SonicWALL SRA
+  - 128.112.66.0/23          # SonicWALL SRA
+  - 128.112.68.0/22          # SonicWALL SRA
+  # specific service IPs that should bypass:
+  - 172.20.80.110/32         # figgy-web-staging2
+  - 172.20.80.67/32          # bibdata-worker-staging1
+  - 128.112.203.105/32       # bibdata-worker-prod1
+  - 128.112.203.109/32       # bibdata-worker-prod2
+
+openresty_real_ip_enable: true
+openresty_real_ip_from:
+  - 35.245.45.3/32           # GCP LB SNAT
+  - 130.41.0.0/16            # GlobalProtect ranges
+  - 134.238.0.0/16
+  - 137.83.0.0/16
+  - 165.1.0.0/16
+  - 208.127.0.0/16
+  - 140.180.242.46/32
+
+
+lego_certificates:
+  - primary: dataspace.princeton.edu
+    domains: [dataspace.princeton.edu]
+  - primary: oar.princeton.edu
+    domains: [oar.princeton.edu]
+
+openresty_vhosts:
+  - name: dataspace.princeton.edu
+    upstream: { name: dataspace, server: 10.244.0.2:81 }
+    ssl_cert: dataspace.princeton.edu.crt
+    ssl_key:  dataspace.princeton.edu.key
+    access_log: dataspace.access.log
+    client_max_body_size: 100M
+    altcha: true
+    altcha_bypass_internal: true
+
+  - name: oar.princeton.edu
+    upstream: { name: oar, server: 10.244.0.3:81 }
+    ssl_cert: oar.princeton.edu.crt
+    ssl_key:  oar.princeton.edu.key
+    access_log: oar.access.log
+    client_max_body_size: 100M
+    altcha: true
+    altcha_bypass_internal: true

--- a/group_vars/gcploadbalancer/staging.yml
+++ b/group_vars/gcploadbalancer/staging.yml
@@ -2,6 +2,11 @@
 lego_email: "lsupport@princeton.edu"
 openresty_altcha_enable: true
 
+openresty_real_ip_enable: true
+openresty_real_ip_from:
+  - 34.170.204.218/32
+  - 130.41.0.0/16            # GlobalProtect ranges
+
 lego_certificates:
   - primary: dataspace-staging.princeton.edu
     domains: [dataspace-staging.princeton.edu]

--- a/inventory/by_cloud/google_cloud.ini
+++ b/inventory/by_cloud/google_cloud.ini
@@ -20,13 +20,16 @@ gcp-oar-staging1 ansible_host=10.132.0.4
 
 [gcploadbalancer_dev]
 # inventory name is dev.pucloud.io; GCP VM name is dev-adc to be deleted once prod goes in
-dev.pulcloud.io
+dev.pulcloud.io ansible_ssh_common_args=''
 [gcploadbalancer_staging]
 # inventory name is staging.pucloud.io; GCP VM name is staging-adc
 staging.pulcloud.io ansible_ssh_common_args=''
 [gcploadbalancer_production]
 # inventory name is prod.pucloud.io; GCP VM name is gcdc-prod-adc
 prod.pulcloud.io
+
+[gcploadbalancer_staging:vars]
+ansible_python_interpreter=/usr/local/bin/python
 
 
 [pulcheck_gcp]

--- a/inventory/by_cloud/google_cloud.ini
+++ b/inventory/by_cloud/google_cloud.ini
@@ -26,7 +26,7 @@ dev.pulcloud.io ansible_ssh_common_args=''
 staging.pulcloud.io ansible_ssh_common_args=''
 [gcploadbalancer_production]
 # inventory name is prod.pucloud.io; GCP VM name is gcdc-prod-adc
-prod.pulcloud.io
+prod.pulcloud.io ansible_ssh_common_args=''
 
 [gcploadbalancer_staging:vars]
 ansible_python_interpreter=/usr/local/bin/python

--- a/playbooks/gcp_loadbalancer.yml
+++ b/playbooks/gcp_loadbalancer.yml
@@ -8,8 +8,12 @@
     - ../group_vars/gcploadbalancer/vault.yml
   roles:
     - lego        # bootstrap self-signed placeholders + cron
+    - globalprotect_updater
     - openresty   # render nginx.conf, start service (uses placeholders)
   post_tasks:
+    - name: First-time GP IP resolve (populate include before openresty serves real traffic)
+      ansible.builtin.command: "{{ gp_updater_binary }}"
+      changed_when: false
     - name: Trigger initial cert issuance
       ansible.builtin.command: /usr/local/sbin/lego-renew.sh
       changed_when: false

--- a/roles/globalprotect_updater/README.md
+++ b/roles/globalprotect_updater/README.md
@@ -1,0 +1,74 @@
+# GlobalProtect Updater
+
+Installs, compiles, and schedules a Rust utility to resolve GlobalProtect gateway domains into IP ranges for [Nginx/OpenResty](../openresty) trust lists.
+
+## Description
+
+The `globalprotect_updater` role performs the following actions:
+
+1. **Installs the Rust toolchain** (via `pkgng` for FreeBSD).
+
+2. **Compiles a custom Rust utility** from source code provided in the role.
+
+3. **Deploys the binary** to a standard system path.
+
+4. **Configures a Cron job** to run the updater periodically.
+
+5. **Manages log files** and directory structures for the tool.
+
+The utility itself resolves multiple regional GlobalProtect domains, identifies their /24 network blocks, and generates an Nginx configuration file containing `set_real_ip_from` directives. It includes safety checks, such as backing up existing configs and running `nginx -t` before reloading.
+
+## Requirements
+
+- **OS:** FreeBSD (configured in `meta/main.yml`).
+
+- **Ansible:** 2.14 or higher.
+
+- **Permissions:** Must be run as a user with `root` privileges to install packages and manage system binaries.
+
+## Role Variables
+
+The following variables are defined in `defaults/main.yml`:
+
+| **Variable**               | **Default Value**                      | **Description**                                               |
+| -------------------------- | -------------------------------------- | ------------------------------------------------------------- |
+| `gp_updater_install_dir`   | `/opt/globalprotect-updater`           | Directory where source code is stored and compiled.           |
+| `gp_updater_binary`        | `/usr/local/bin/globalprotect-updater` | Target path for the compiled binary.                          |
+| `gp_updater_log`           | `/var/log/globalprotect-updater.log`   | Path for the execution logs.                                  |
+| `gp_updater_cron`          | `minute: "*/15", hour: "*"`            | How often the updater runs.                                   |
+| `gp_updater_static_ips`    | *(List of 3 IPs)*                      | A list of static CIDRs to always include in the Nginx config. |
+| `gp_updater_nginx_include` | `/usr/local/etc/openresty/conf.d/...`  | Path where the generated Nginx config is written.             |
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+Tight coupling with [OpenResty](../openresty)
+
+```yaml
+- hosts: load_balancers
+  roles:
+    - role: lego
+    - role: globalprotect_updater
+    - role: openresty
+      vars:
+        gp_updater_cron:
+          minute: "0"
+          hour: "*/2"
+```
+
+## Internal Tool Details
+
+The Rust source code (located in `files/main.rs`) handles the heavy lifting:
+
+- **Domain Discovery:** It iterates through a list of global regions (e.g., `us-east-g`, `canada-east`) combined with a domain pattern.
+
+- **CIDR Generation:** It creates /32 or /128 entries for specific resolutions and /24 blocks for IPv4 ranges to ensure narrow but reliable trust scoping.
+
+- **Atomicity:** It tests the Nginx configuration before reloading. If the generated config is invalid, it restores a backup.
+
+## License
+
+MIT

--- a/roles/globalprotect_updater/defaults/main.yml
+++ b/roles/globalprotect_updater/defaults/main.yml
@@ -1,0 +1,18 @@
+#SPDX-License-Identifier: MIT-0
+---
+# defaults file for roles/globalprotect_updater
+gp_updater_install_dir: /opt/globalprotect-updater
+gp_updater_binary: /usr/local/bin/globalprotect-updater
+gp_updater_config_path: /usr/local/etc/globalprotect-updater.toml
+gp_updater_log: /var/log/globalprotect-updater.log
+
+gp_updater_nginx_include: /usr/local/etc/openresty/conf.d/globalprotect_ips.conf
+gp_updater_cache_path: /var/cache/globalprotect_ips.json
+gp_updater_static_ips:
+  - 137.83.217.148/32   # Clientless VPN Portal
+  - 35.245.45.3/32      # GCP LB SNAT
+  - 140.180.242.46/32   # Campus SNAT
+
+gp_updater_cron:
+  minute: "*/15"
+  hour: "*"

--- a/roles/globalprotect_updater/files/Cargo.toml
+++ b/roles/globalprotect_updater/files/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "globalprotect-ip-updater"
+version = "0.2.0"
+edition = "2021"
+
+[dependencies]
+chrono = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/roles/globalprotect_updater/files/main.rs
+++ b/roles/globalprotect_updater/files/main.rs
@@ -1,0 +1,320 @@
+use std::collections::HashSet;
+use std::fs;
+use std::net::{IpAddr, ToSocketAddrs};
+use std::path::Path;
+use std::process::Command;
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the script
+#[derive(Debug, Deserialize, Serialize)]
+struct Config {
+    /// Path to the nginx include file to generate
+    nginx_include_path: String,
+    /// Path to cache resolved IPs (for comparison)
+    cache_file_path: String,
+    /// Whether to reload nginx after updating
+    auto_reload_nginx: bool,
+    /// Additional static IPs to always include
+    static_ips: Vec<String>,
+    /// Domain pattern for GlobalProtect gateways
+    domain_pattern: String,
+    /// Path to the openresty/nginx binary used for config testing
+    nginx_binary: String,
+    /// Path to the live nginx config file (passed to nginx -t -c)
+    nginx_config_path: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            nginx_include_path:
+                "/usr/local/etc/openresty/conf.d/globalprotect_ips.conf".to_string(),
+            cache_file_path: "/var/cache/globalprotect_ips.json".to_string(),
+            auto_reload_nginx: true,
+            static_ips: vec![
+                "137.83.217.148/32".to_string(), // Clientless VPN Portal
+                "35.245.45.3/32".to_string(),    // LB SNAT
+                "140.180.242.46/32".to_string(), // Campus SNAT
+            ],
+            domain_pattern: "princeto.gpogn2y5gg2j.gw.gpcloudservice.com".to_string(),
+            nginx_binary: "/usr/local/nginx/sbin/nginx".to_string(),
+            nginx_config_path: "/usr/local/etc/openresty/nginx.conf".to_string(),
+        }
+    }
+}
+
+/// Cached IP data
+#[derive(Debug, Deserialize, Serialize, Default)]
+struct IpCache {
+    ips: HashSet<String>,
+    last_updated: String,
+}
+
+/// List of GlobalProtect gateway regions
+fn get_gateway_regions() -> Vec<&'static str> {
+    vec![
+        // North America
+        "us-west-g",
+        "us-southeast-g",
+        "mexico-central",
+        "us-central-g",
+        "canada-east",
+        "costa-rica",
+        "us-northeast",
+        "canada-west",
+        "us-east-g",
+        "us-south",
+        "us-northwest-g",
+        "us-southwest-g",
+    ]
+}
+
+/// Resolve a domain name to its IP addresses
+fn resolve_domain(domain: &str) -> Vec<IpAddr> {
+    let mut ips = Vec::new();
+
+    // Append :443 because ToSocketAddrs requires a port
+    let addr_with_port = format!("{}:443", domain);
+
+    match addr_with_port.to_socket_addrs() {
+        Ok(addrs) => {
+            for addr in addrs {
+                ips.push(addr.ip());
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to resolve {}: {}", domain, e);
+        }
+    }
+
+    ips
+}
+
+/// Convert IP to CIDR notation with /32 for IPv4 and /128 for IPv6
+fn ip_to_cidr(ip: &IpAddr) -> String {
+    match ip {
+        IpAddr::V4(ipv4) => format!("{}/32", ipv4),
+        IpAddr::V6(ipv6) => format!("{}/128", ipv6),
+    }
+}
+
+/// Get a /24 network block for a v4 IP. /24 instead of /16 keeps the
+/// trust list narrowly scoped — a single resolution doesn't pull a
+/// whole provider's /16 into set_real_ip_from.
+fn get_network_block(ip: &IpAddr) -> Option<String> {
+    match ip {
+        IpAddr::V4(ipv4) => {
+            let octets = ipv4.octets();
+            Some(format!("{}.{}.{}.0/24", octets[0], octets[1], octets[2]))
+        }
+        IpAddr::V6(_) => None,
+    }
+}
+
+/// Resolve all GlobalProtect gateway domains
+fn resolve_all_gateways(config: &Config) -> HashSet<String> {
+    let mut all_ips = HashSet::new();
+    let mut network_blocks = HashSet::new();
+
+    // Add static IPs
+    for ip in &config.static_ips {
+        all_ips.insert(ip.clone());
+    }
+
+    println!("Resolving GlobalProtect gateway domains...");
+
+    for region in get_gateway_regions() {
+        let domain = format!("{}-{}", region, config.domain_pattern);
+        print!("  Resolving {}... ", domain);
+
+        let ips = resolve_domain(&domain);
+
+        if ips.is_empty() {
+            println!("No IPs found");
+        } else {
+            println!("Found {} IPs", ips.len());
+            for ip in ips {
+                all_ips.insert(ip_to_cidr(&ip));
+                if let Some(block) = get_network_block(&ip) {
+                    network_blocks.insert(block);
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    println!("\nDetected network blocks:");
+    for block in &network_blocks {
+        println!("  {}", block);
+        all_ips.insert(block.clone());
+    }
+    all_ips
+}
+
+/// Generate nginx configuration content
+fn generate_nginx_config(ips: &HashSet<String>) -> String {
+    let mut config = String::new();
+    config.push_str("# GlobalProtect Gateway IPs - Auto-generated\n");
+    config.push_str(&format!(
+        "# Generated at: {}\n",
+        Local::now().format("%Y-%m-%d %H:%M:%S")
+    ));
+    config.push_str("# This file is automatically generated. Do not edit manually.\n\n");
+
+    let mut sorted_ips: Vec<_> = ips.iter().collect();
+    sorted_ips.sort();
+    for ip in sorted_ips {
+        config.push_str(&format!("set_real_ip_from    {};\n", ip));
+    }
+    config
+}
+
+/// Load cached IPs from file
+fn load_cache(path: &str) -> IpCache {
+    if Path::new(path).exists() {
+        match fs::read_to_string(path) {
+            Ok(content) => match serde_json::from_str(&content) {
+                Ok(cache) => return cache,
+                Err(e) => eprintln!("Failed to parse cache: {}", e),
+            },
+            Err(e) => eprintln!("Failed to read cache: {}", e),
+        }
+    }
+    IpCache::default()
+}
+
+/// Save IPs to cache file
+fn save_cache(
+    path: &str,
+    ips: &HashSet<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cache = IpCache {
+        ips: ips.clone(),
+        last_updated: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+    };
+    let json = serde_json::to_string_pretty(&cache)?;
+    fs::write(path, json)?;
+    Ok(())
+}
+
+/// Test nginx configuration using the configured binary + config path.
+/// On FreeBSD with openresty pkg, the default `nginx -t` uses the
+/// compiled-in prefix path (/usr/local/nginx/conf/nginx.conf), which is
+/// not the file we actually run with. Pass -c explicitly.
+fn test_nginx_config(config: &Config) -> bool {
+    match Command::new(&config.nginx_binary)
+        .args(["-t", "-c", &config.nginx_config_path])
+        .output()
+    {
+        Ok(output) => {
+            if !output.status.success() {
+                eprintln!(
+                    "nginx -t failed:\nstdout: {}\nstderr: {}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr),
+                );
+            }
+            output.status.success()
+        }
+        Err(e) => {
+            eprintln!("Failed to test nginx config: {}", e);
+            false
+        }
+    }
+}
+
+/// Reload nginx, trying FreeBSD `service` first, then OpenBSD `rcctl`,
+/// then a direct `nginx -s reload`.
+fn reload_nginx() -> bool {
+    let commands = vec![
+        ("service", vec!["openresty", "reload"]),
+        ("rcctl", vec!["reload", "nginx"]),
+        ("nginx", vec!["-s", "reload"]),
+    ];
+    for (cmd, args) in commands {
+        match Command::new(cmd).args(&args).output() {
+            Ok(output) => {
+                if output.status.success() {
+                    println!(
+                        "Successfully reloaded nginx using: {} {}",
+                        cmd,
+                        args.join(" ")
+                    );
+                    return true;
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+    eprintln!("Failed to reload nginx - please reload manually");
+    false
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::default();
+
+    let cache = load_cache(&config.cache_file_path);
+    let current_ips = resolve_all_gateways(&config);
+
+    println!("\nTotal unique IPs/ranges: {}", current_ips.len());
+
+    if cache.ips == current_ips {
+        println!(
+            "No changes detected since last update ({})",
+            cache.last_updated
+        );
+        return Ok(());
+    }
+
+    let nginx_config = generate_nginx_config(&current_ips);
+
+    // Backup existing config before overwriting
+    if Path::new(&config.nginx_include_path).exists() {
+        let backup_path = format!("{}.backup", config.nginx_include_path);
+        fs::copy(&config.nginx_include_path, &backup_path)?;
+        println!("Backed up existing config to: {}", backup_path);
+    }
+
+    fs::write(&config.nginx_include_path, nginx_config)?;
+    println!("Written nginx config to: {}", config.nginx_include_path);
+
+    save_cache(&config.cache_file_path, &current_ips)?;
+
+    // Verify nginx accepts the new include before reloading
+    if !test_nginx_config(&config) {
+        eprintln!("Nginx configuration test failed! Restoring backup...");
+        let backup_path = format!("{}.backup", config.nginx_include_path);
+        if Path::new(&backup_path).exists() {
+            fs::copy(&backup_path, &config.nginx_include_path)?;
+        }
+        return Err("Nginx configuration test failed".into());
+    }
+
+    if config.auto_reload_nginx {
+        println!("Reloading nginx...");
+        reload_nginx();
+    } else {
+        println!("Skipping nginx reload (auto_reload_nginx = false)");
+        println!("Please reload nginx manually: service openresty reload");
+    }
+
+    let added: HashSet<_> = current_ips.difference(&cache.ips).collect();
+    let removed: HashSet<_> = cache.ips.difference(&current_ips).collect();
+
+    if !added.is_empty() {
+        println!("\nNew IPs added:");
+        for ip in added {
+            println!("  + {}", ip);
+        }
+    }
+
+    if !removed.is_empty() {
+        println!("\nIPs removed:");
+        for ip in removed {
+            println!("  - {}", ip);
+        }
+    }
+
+    Ok(())
+}

--- a/roles/globalprotect_updater/files/main.rs
+++ b/roles/globalprotect_updater/files/main.rs
@@ -28,18 +28,23 @@ struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            nginx_include_path:
-                "/usr/local/etc/openresty/conf.d/globalprotect_ips.conf".to_string(),
-            cache_file_path: "/var/cache/globalprotect_ips.json".to_string(),
+            nginx_include_path: std::env::var("GP_NGINX_INCLUDE")
+                .unwrap_or_else(|_| {
+                    "/usr/local/etc/nginx/conf.d/globalprotect_ips.conf".to_string()
+                }),
+            cache_file_path: std::env::var("GP_CACHE_PATH")
+                .unwrap_or_else(|_| "/var/db/globalprotect_ips.json".to_string()),
             auto_reload_nginx: true,
             static_ips: vec![
-                "137.83.217.148/32".to_string(), // Clientless VPN Portal
-                "35.245.45.3/32".to_string(),    // LB SNAT
-                "140.180.242.46/32".to_string(), // Campus SNAT
+                "137.83.217.148/32".to_string(),
+                "35.85.237.83/32".to_string(),
+                "140.180.242.46/32".to_string(),
             ],
             domain_pattern: "princeto.gpogn2y5gg2j.gw.gpcloudservice.com".to_string(),
-            nginx_binary: "/usr/local/nginx/sbin/nginx".to_string(),
-            nginx_config_path: "/usr/local/etc/openresty/nginx.conf".to_string(),
+            nginx_binary: std::env::var("GP_NGINX_BINARY")
+                .unwrap_or_else(|_| "/usr/local/sbin/nginx".to_string()),
+            nginx_config_path: std::env::var("GP_NGINX_CONFIG")
+                .unwrap_or_else(|_| "/usr/local/etc/nginx/nginx.conf".to_string()),
         }
     }
 }

--- a/roles/globalprotect_updater/handlers/main.yml
+++ b/roles/globalprotect_updater/handlers/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for roles/globalprotect_updater

--- a/roles/globalprotect_updater/meta/main.yml
+++ b/roles/globalprotect_updater/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: Global Protect Update
+  company: Princeton University Library
+  description: GlobalProtect gateway IP resolver for nginx set_real_ip_from
+  author: pulibrary
+
+  license: MIT
+
+  min_ansible_version: 2.14
+
+  platforms:
+    - name: FreeBSD
+      versions:
+        - ["15"]
+dependencies: []
+  # uncomment the line below and remove the `[]` above in your role
+  # - role: "<role I depend on>"

--- a/roles/globalprotect_updater/tasks/main.yml
+++ b/roles/globalprotect_updater/tasks/main.yml
@@ -14,6 +14,14 @@
     group: wheel
     mode: "0755"
 
+- name: Gp_updater | ensure src dir exists
+  ansible.builtin.file:
+    path: "{{ gp_updater_install_dir }}/src"
+    state: directory
+    owner: root
+    group: wheel
+    mode: "0755"
+
 - name: Gp_updater | copy source
   ansible.builtin.copy:
     src: "{{ item.src }}"

--- a/roles/globalprotect_updater/tasks/main.yml
+++ b/roles/globalprotect_updater/tasks/main.yml
@@ -58,6 +58,14 @@
     mode: "0755"
   when: gp_updater_source.changed
 
+- name: gp_updater | ensure cache parent dir exists
+  ansible.builtin.file:
+    path: /var/db
+    state: directory
+    owner: root
+    group: wheel
+    mode: "0755"
+
 - name: Gp_updater | install cron job
   ansible.builtin.cron:
     name: globalprotect ip updater

--- a/roles/globalprotect_updater/tasks/main.yml
+++ b/roles/globalprotect_updater/tasks/main.yml
@@ -1,0 +1,69 @@
+#SPDX-License-Identifier: MIT-0
+---
+# tasks file for roles/globalprotect_updater
+- name: Gp_updater | install rust toolchain
+  ansible.builtin.pkgng:
+    name: rust
+    state: present
+
+- name: Gp_updater | ensure build dir exists
+  ansible.builtin.file:
+    path: "{{ gp_updater_install_dir }}"
+    state: directory
+    owner: root
+    group: wheel
+    mode: "0755"
+
+- name: Gp_updater | copy source
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ gp_updater_install_dir }}/{{ item.dest }}"
+    owner: root
+    group: wheel
+    mode: "0644"
+  loop:
+    - { src: Cargo.toml, dest: Cargo.toml }
+    - { src: main.rs, dest: src/main.rs }
+  register: gp_updater_source
+
+- name: Gp_updater | ensure src dir exists
+  ansible.builtin.file:
+    path: "{{ gp_updater_install_dir }}/src"
+    state: directory
+
+- name: Gp_updater | build release binary
+  ansible.builtin.command:
+    cmd: cargo build --release
+    chdir: "{{ gp_updater_install_dir }}"
+    creates: "{{ gp_updater_install_dir }}/target/release/globalprotect-ip-updater"
+  when: gp_updater_source.changed
+  environment:
+    CARGO_HOME: "{{ gp_updater_install_dir }}/.cargo"
+
+- name: Gp_updater | install binary
+  ansible.builtin.copy:
+    src: "{{ gp_updater_install_dir }}/target/release/globalprotect-ip-updater"
+    dest: "{{ gp_updater_binary }}"
+    remote_src: true
+    owner: root
+    group: wheel
+    mode: "0755"
+  when: gp_updater_source.changed
+
+- name: Gp_updater | install cron job
+  ansible.builtin.cron:
+    name: globalprotect ip updater
+    user: root
+    minute: "{{ gp_updater_cron.minute }}"
+    hour: "{{ gp_updater_cron.hour }}"
+    job: "{{ gp_updater_binary }} >> {{ gp_updater_log }} 2>&1"
+
+- name: Gp_updater | ensure log exists
+  ansible.builtin.file:
+    path: "{{ gp_updater_log }}"
+    state: touch
+    owner: root
+    group: wheel
+    mode: "0640"
+    modification_time: preserve
+    access_time: preserve

--- a/roles/globalprotect_updater/tests/inventory
+++ b/roles/globalprotect_updater/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+localhost
+

--- a/roles/globalprotect_updater/tests/test.yml
+++ b/roles/globalprotect_updater/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT-0
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/globalprotect_updater

--- a/roles/globalprotect_updater/vars/main.yml
+++ b/roles/globalprotect_updater/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# vars file for roles/globalprotect_updater

--- a/roles/lego/defaults/main.yml
+++ b/roles/lego/defaults/main.yml
@@ -13,7 +13,7 @@ lego_acme_server: ""
 
 # Renewal
 lego_renew_days: 30
-lego_renew_hook: "service openresty reload"
+lego_renew_hook: "service nginx reload"
 lego_renew_log: /var/log/lego-renew.log
 lego_renew_cron:
   minute: "17"

--- a/roles/openresty/defaults/main.yml
+++ b/roles/openresty/defaults/main.yml
@@ -1,17 +1,18 @@
 #SPDX-License-Identifier: MIT-0
 ---
 # defaults file for roles/openresty
-openresty_package: openresty
+openresty_package: nginx-full
+openresty_service: nginx
 openresty_node_package: node
 
-openresty_etc_dir: /usr/local/etc/openresty
-openresty_log_dir: /var/log/openresty
+openresty_etc_dir: /usr/local/etc/nginx
+openresty_log_dir: /var/log/nginx
 openresty_ssl_cert_dir: /var/db/lego/certificates
 openresty_ssl_key_dir:  /var/db/lego/certificates
 openresty_acme_webroot: /usr/local/www/acme
-openresty_pid_path: /var/run/openresty.pid
-openresty_sbin: /usr/local/nginx/sbin/nginx
-openresty_mime_types: /usr/local/nginx/conf/mime.types
+openresty_pid_path: /var/run/nginx.pid
+openresty_sbin: /usr/local/bin/nginx
+openresty_mime_types: /usr/local/etc/nginx/mime.types
 
 # Top-level nginx
 openresty_user: www

--- a/roles/openresty/defaults/main.yml
+++ b/roles/openresty/defaults/main.yml
@@ -36,6 +36,9 @@ openresty_ssl_protocols: "TLSv1.2 TLSv1.3"
 openresty_ssl_ciphers: >-
   ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
 
+openresty_real_ip_enable: false
+openresty_real_ip_from: []
+
 # IP allowlist used by vhosts that set restrict: true
 openresty_altcha_bypass_networks: "{{ openresty_restrict_networks }}"
 openresty_restrict_networks:

--- a/roles/openresty/handlers/main.yml
+++ b/roles/openresty/handlers/main.yml
@@ -9,5 +9,5 @@
 
 - name: reload openresty
   ansible.builtin.service:
-    name: openresty
+    name: "{{ openresty_service }}"
     state: reloaded

--- a/roles/openresty/meta/main.yml
+++ b/roles/openresty/meta/main.yml
@@ -10,9 +10,9 @@ galaxy_info:
   min_ansible_version: 2.2
 
   platforms:
-    - name: Ubuntu
+    - name: FreeBSD
       versions:
-        - jammy
+        - 15
 dependencies: []
   # uncomment the line below and remove the `[]` above in your role
   # - role: "<role I depend on>"

--- a/roles/openresty/tasks/main.yml
+++ b/roles/openresty/tasks/main.yml
@@ -70,24 +70,16 @@
     mode: "0644"
   notify: reload openresty
 
-- name: Openresty | install rc.d service script
-  ansible.builtin.template:
-    src: openresty.rc.j2
-    dest: /usr/local/etc/rc.d/openresty
-    owner: root
-    group: wheel
-    mode: "0755"
-
-- name: Openresty | enable openresty service
+- name: Openresty | enable nginx service in rc.conf
   ansible.builtin.lineinfile:
     path: /etc/rc.conf
-    regexp: '^openresty_enable='
-    line: 'openresty_enable="YES"'
+    regexp: '^nginx_enable='
+    line: 'nginx_enable="YES"'
     create: true
     mode: "0644"
 
-- name: Openresty | start openresty
+- name: Openresty | start nginx
   ansible.builtin.service:
-    name: openresty
+    name: "{{ openresty_service }}"
     state: started
     enabled: true

--- a/roles/openresty/tasks/main.yml
+++ b/roles/openresty/tasks/main.yml
@@ -21,6 +21,16 @@
     group: wheel
     mode: "0755"
 
+- name: Openresty | ensure globalprotect_ips.conf exists
+  ansible.builtin.copy:
+    dest: "{{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf"
+    content: "# placeholder; populated by globalprotect-updater\n"
+    force: false
+    owner: root
+    group: wheel
+    mode: "0644"
+  when: openresty_real_ip_enable | default(false)
+
 - name: Openresty | ensure ACME webroot exists
   ansible.builtin.file:
     path: "{{ openresty_acme_webroot }}"

--- a/roles/openresty/templates/nginx.conf.j2
+++ b/roles/openresty/templates/nginx.conf.j2
@@ -23,6 +23,12 @@ http {
     proxy_headers_hash_max_size    {{ openresty_proxy_headers_hash_max_size }};
     proxy_headers_hash_bucket_size {{ openresty_proxy_headers_hash_bucket_size }};
 
+{% if openresty_real_ip_enable | default(false) %}
+real_ip_header      X-Forwarded-For;
+real_ip_recursive   on;
+include {{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf;
+{% endif %}
+
 {% if openresty_logger_json_enable %}
     log_format logger-json escape=json '{"source": "nginx","message":"nginx log captured","time": $time_iso8601, "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status, "user_agent": "$http_user_agent", "resp_time": $request_time, "upstream_addr": "$upstream_addr"}';
 {% endif %}


### PR DESCRIPTION
Add infrastructure for prod migration where openresty sits behind GCP
HTTP(S) Load Balancer plus GlobalProtect VPN gateways. Without real-IP
unmasking, every request appears to come from the load balancer's IP,
breaking IP-based bypass logic and access logging.