### PR TITLE
Include ansible_alerts_channel for incommon playbooks

### DIFF
--- a/playbooks/utils/incommon_certbot.yml
+++ b/playbooks/utils/incommon_certbot.yml
@@ -9,6 +9,7 @@
   become: true
   vars_files:
     - ../group_vars/all/vault.yml
+    - ../group_vars/all/vars.yml
 
   pre_tasks:
   - name: stop playbook if you didn't use --limit

--- a/playbooks/utils/incommon_certbot_multi.yml
+++ b/playbooks/utils/incommon_certbot_multi.yml
@@ -9,6 +9,7 @@
   become: true
   vars_files:
     - ../group_vars/all/vault.yml
+    - ../group_vars/all/vars.yml
 
   pre_tasks:
   - name: stop playbook if you didn't use --limit

--- a/playbooks/utils/incommon_certbot_revoke.yml
+++ b/playbooks/utils/incommon_certbot_revoke.yml
@@ -11,6 +11,7 @@
   become: true
   vars_files:
     - ../group_vars/all/vault.yml
+    - ../group_vars/all/vars.yml
 
   pre_tasks:
   - name: stop playbook if you didn't use --limit
@@ -46,5 +47,4 @@
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"
         msg: "Ansible ran `{{ ansible_play_name }}` on {{ inventory_hostname }}"
-        channel: ansible-alerts
-        # channel: "{{ slack_alerts_channel }}"
+        channel: "{{ slack_alerts_channel }}"


### PR DESCRIPTION
Closes #6964.

Loads `group_vars/all/vars.yml` to pick up the ansible alerts channel definition for use in the post-task of announcing that the playbook ran. 