### PR TITLE
[Analytics/Nomad] Improve container security

### DIFF
--- a/nomad/analytics/deploy/production.hcl
+++ b/nomad/analytics/deploy/production.hcl
@@ -46,6 +46,9 @@ job "analytics-production" {
       config {
         image        = "ghcr.io/umami-software/umami:3.1.0"
         ports = ["http"]
+        # Maps root to a random permissionless user on the host, prevents someone breaking out of container from having any permissions on the host.
+        # REQUIRES size=65536, otherwise it doesn't do the mapping and silently fails.
+        userns = "auto:size=65536"
       }
 
       template {

--- a/nomad/analytics/deploy/staging.hcl
+++ b/nomad/analytics/deploy/staging.hcl
@@ -46,6 +46,9 @@ job "analytics-staging" {
       config {
         image        = "ghcr.io/umami-software/umami:3.1.0"
         ports = ["http"]
+        # Maps root to a random permissionless user on the host, prevents someone breaking out of container from having any permissions on the host.
+        # REQUIRES size=65536, otherwise it doesn't do the mapping and silently fails.
+        userns = "auto:size=65536"
       }
 
       template {

--- a/roles/pul_nomad/handlers/main.yml
+++ b/roles/pul_nomad/handlers/main.yml
@@ -21,3 +21,8 @@
   ansible.builtin.service:
     name: dnsmasq
     state: restarted
+- name: migrate podman
+  become: true
+  throttle: 1
+  # Sleep for 30 seconds to give nomad a bit to recover.
+  ansible.builtin.shell: podman system migrate ; sleep 30

--- a/roles/pul_nomad/tasks/nomad/podman.yml
+++ b/roles/pul_nomad/tasks/nomad/podman.yml
@@ -6,6 +6,22 @@
   when:
     - "ansible_os_family == 'RedHat'"
   block:
+    - name: 'pul_nomad | nomad | podman | add subuid'
+      ansible.builtin.lineinfile:
+        path: /etc/subuid
+        regexp: '^containers:'
+        line: 'containers:1000000:10000000'
+        state: present
+      notify: migrate podman
+
+    - name: 'pul_nomad | nomad | podman | add subgid'
+      ansible.builtin.lineinfile:
+        path: /etc/subgid
+        regexp: '^containers:'
+        line: 'containers:1000000:10000000'
+        state: present
+      notify: migrate podman
+
     - name: 'pul_nomad | nomad | podman | Install Podman'
       ansible.builtin.dnf:
         name: podman


### PR DESCRIPTION
Since this is a third party container I wanted to beef up the security.

This PR sets `userns=auto`, which makes the host system run the container in a different set of user IDs. Basically, the container sees UID "1001", but the host system is running it as UID "10001001." If someone somehow manages to break out of the container (very hard, and other security would keep them out, but still), they'll end up on the host system as a user with no profile, no access to any files, and no way to connect to anything.

For example, when running "ps" on `dpul-collections-staging1` we see this:

```bash
[pulsys@dpul-collections-staging1 ~]$ sudo ps aux | grep pnpm
1001001   126846  0.0  0.5 756708 94540 ?        Ssl  23:29   0:00 node /usr/local/bin/pnpm start-docker
1001001   126927  0.0  0.4 722184 67336 ?        Sl   23:29   0:00 node /app/node_modules/.bin/../.pnpm/npm-run-all@4.1.5/node_modules/npm-run-all/bin/npm-run-all/index.js check-db update-tracker start-server
1001001   127084  0.0  0.5 757480 94968 ?        Sl   23:29   0:00 node /usr/local/lib/node_modules/pnpm/bin/pnpm.cjs run start-server
```

before this that process would have run as root.

[Podman documentation on userns](https://docs.podman.io/en/stable/markdown/podman-run.1.html#userns-mode)

I think this is significantly more secure than our non-container apps, even.