### PR TITLE
[Analytics] Further improve security, disable filesystem write

### DIFF
--- a/nomad/analytics/deploy/staging.hcl
+++ b/nomad/analytics/deploy/staging.hcl
@@ -59,6 +59,11 @@ job "analytics-staging" {
         security_opt = [
           "no-new-privileges"
         ]
+        # Give some tmpfs space for temp/pid files if necessary.
+        tmpfs = [
+          "/tmp",
+          "/var/run"
+        ]
       }
 
       template {

--- a/nomad/analytics/deploy/staging.hcl
+++ b/nomad/analytics/deploy/staging.hcl
@@ -49,6 +49,8 @@ job "analytics-staging" {
         # Maps root to a random permissionless user on the host, prevents someone breaking out of container from having any permissions on the host.
         # REQUIRES size=65536, otherwise it doesn't do the mapping and silently fails.
         userns = "auto:size=65536"
+        # Don't allow writing anything to the file system.
+        readonly_rootfs = true
       }
 
       template {

--- a/nomad/analytics/deploy/staging.hcl
+++ b/nomad/analytics/deploy/staging.hcl
@@ -43,6 +43,9 @@ job "analytics-staging" {
     task "app" {
       driver = "podman"
 
+      # This is set in the Dockerfile, but set it explicitly in case they change that.
+      user = "1001:1001"
+
       config {
         image        = "ghcr.io/umami-software/umami:3.1.0"
         ports = ["http"]
@@ -51,6 +54,11 @@ job "analytics-staging" {
         userns = "auto:size=65536"
         # Don't allow writing anything to the file system.
         readonly_rootfs = true
+        # We don't need any CAP privileges - don't allow any privilege escalation.
+        cap_drop = ["ALL"]
+        security_opt = [
+          "no-new-privileges"
+        ]
       }
 
       template {


### PR DESCRIPTION
I think this application only takes in requests and forwards to postgres. If so, it doesn't need to write to its file system.

This is a bigger change than #7071, but it's deployed now to staging and I'd like to let it cook for a bit.

When connecting to the container, now you get this:

/app $ touch bla
touch: bla: Read-only file system
/app $


This also applies a number of recommendations from https://dev.to/teguh_coding/docker-security-hardening-10-practices-that-will-protect-your-containers-in-production-4ahe to prevent privilege escalation from within the container.