### PR TITLE
Supports pagination for GitLab issues API

### DIFF
--- a/playbooks/utils/gitlab-api-RW.yml
+++ b/playbooks/utils/gitlab-api-RW.yml
@@ -1,15 +1,17 @@
 ---
-    - name: get all pages of issues from team handbook
+    # this tasks file is included in the gitlab_api.yml playbook
+    # it handles pagination for results from the GitLab issues API
+    - name: get a page of issues from team handbook
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=10&page={{ item }}&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page={{ issues_per_page }}&page={{ item }}&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
-      register: page_of_issues
+      register: current_page
 
     - name: write selected output to CSV for team handbook
       ansible.builtin.lineinfile:
-        dest: /opt/gitlab_issues/team_handbook_issues1.csv
+        dest: /opt/gitlab_issues/team_handbook_issues.csv
         line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
         insertafter: EOF
         state: present
-      loop: "{{ page_of_issues | community.general.json_query('json[*]') }}"
+      loop: "{{ current_page | community.general.json_query('json[*]') }}"

--- a/playbooks/utils/gitlab-api-RW.yml
+++ b/playbooks/utils/gitlab-api-RW.yml
@@ -11,7 +11,9 @@
     - name: write selected output to CSV for team handbook
       ansible.builtin.lineinfile:
         dest: /opt/gitlab_issues/team_handbook_issues.csv
-        line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
+        line: GitLab,"{{ GLissue.title }}",{{ GLissue.iid }},{{ GLissue.state }},{{ GLissue.assignee.name | default('') }},{{ GLissue.created_at }},{{ GLissue.labels | default('') }},{{ GLissue.web_url }}
         insertafter: EOF
         state: present
       loop: "{{ current_page | community.general.json_query('json[*]') }}"
+      loop_control:
+        loop_var: GLissue

--- a/playbooks/utils/gitlab-api-RW.yml
+++ b/playbooks/utils/gitlab-api-RW.yml
@@ -1,0 +1,15 @@
+---
+    - name: get all pages of issues from team handbook
+      ansible.builtin.uri:
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=10&page={{ item }}&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        method: GET
+        # 'scope=all' pulls issues created by all users
+      register: page_of_issues
+
+    - name: write selected output to CSV for team handbook
+      ansible.builtin.lineinfile:
+        dest: /opt/gitlab_issues/team_handbook_issues1.csv
+        line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
+        insertafter: EOF
+        state: present
+      loop: "{{ page_of_issues | community.general.json_query('json[*]') }}"

--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -1,14 +1,17 @@
 ---
 - name: get issues from GitLab
   hosts: localhost
+  vars:
+    issues_per_page: 25
   vars_files:
     - ../../group_vars/gitlab/vault.yml
   tasks:
     - name: call issue API for team handbook
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=10&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page={{ issues_per_page }}&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
+        # return values include the total number of pages
       register: team_handbook_issues
 
     - name: set number of pages
@@ -23,62 +26,57 @@
         insertbefore: BOF
         state: present
 
-# the with_sequence thing works, but we need to put the next 2 tasks
-# into an included tasks file
-# then run the loop on the include (or import, whichever it is)
-# then this should work
-# also, set the items per page as a var so we don't have a future mismatch
     - name: iterate over API results
       ansible.builtin.include_tasks: gitlab-api-RW.yml
       with_sequence: start=1 end="{{ pages }}"
 
-    # - name: Send e-mail with CSV attached
-    #   community.general.mail:
-    #   # TODO: fill in TLS and other
-    #     host: lib-ponyexpr-prod.princeton.edu
-    #     port: 25
-    #     subject: Team Handbook Issue report
-    #     body: Issues from the ops-team-handbook repo
-    #     from: ac2754@princeton.edu
-    #     to: "{{ vault_team_handbook_airtable_email }}"
-    #     # cc: ops@princeton.edu # do we have something like this?
-    #     attach:
-    #       - /opt/gitlab_issues/team_handbook_issues.csv
+    - name: Send e-mail with CSV attached
+      community.general.mail:
+      # TODO: fill in TLS and other
+        host: lib-ponyexpr-prod.princeton.edu
+        port: 25
+        subject: Team Handbook Issue report
+        body: Issues from the ops-team-handbook repo
+        from: ac2754@princeton.edu
+        to: "{{ vault_team_handbook_airtable_email }}"
+        # cc: ops@princeton.edu # do we have something like this?
+        attach:
+          - /opt/gitlab_issues/team_handbook_issues.csv
 
-    # - name: call issue API for ReCAP LAS
-    #   ansible.builtin.uri:
-    #     url: "https://gitlab.lib.princeton.edu/api/v4/projects/12/issues?per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
-    #     method: GET
-    #     # 'scope=all' pulls issues created by all users
-    #   register: recap_las_issues
+    - name: call issue API for ReCAP LAS
+      ansible.builtin.uri:
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/12/issues?per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        method: GET
+        # 'scope=all' pulls issues created by all users
+      register: recap_las_issues
 
-    # - name: write CSV headers for ReCAP LAS
-    #   ansible.builtin.lineinfile:
-    #     create: true
-    #     dest: /opt/gitlab_issues/recap_las_issues.csv
-    #     line: Source,Title,Issue ID,State,Assignee,Created At (UTC),Labels,URL
-    #     insertbefore: BOF
-    #     state: present
+    - name: write CSV headers for ReCAP LAS
+      ansible.builtin.lineinfile:
+        create: true
+        dest: /opt/gitlab_issues/recap_las_issues.csv
+        line: Source,Title,Issue ID,State,Assignee,Created At (UTC),Labels,URL
+        insertbefore: BOF
+        state: present
 
-    # - name: write selected output to CSV for ReCAP LAS
-    #   ansible.builtin.lineinfile:
-    #     dest: /opt/gitlab_issues/recap_las_issues.csv
-    #     line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
-    #     insertafter: EOF
-    #     state: present
-    #   loop: "{{ recap_las_issues | community.general.json_query('json[*]') }}"
-    #   # we assume every issue will have a title, an issue ID, a state, a created_at timestamp, and a URL
-    #   # we allow null values for assignee and labels
+    - name: write selected output to CSV for ReCAP LAS
+      ansible.builtin.lineinfile:
+        dest: /opt/gitlab_issues/recap_las_issues.csv
+        line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
+        insertafter: EOF
+        state: present
+      loop: "{{ recap_las_issues | community.general.json_query('json[*]') }}"
+      # we assume every issue will have a title, an issue ID, a state, a created_at timestamp, and a URL
+      # we allow null values for assignee and labels
 
-    # - name: Send e-mail with CSV attached
-    #   community.general.mail:
-    #   # TODO: fill in TLS and other
-    #     host: lib-ponyexpr-prod.princeton.edu
-    #     port: 25
-    #     subject: ReCAP LAS Issue report
-    #     body: Issues from the ops-team-handbook repo
-    #     from: ac2754@princeton.edu
-    #     to: "{{ vault_recap_las_airtable_email }}"
-    #     # cc: ops@princeton.edu # do we have something like this?
-    #     attach:
-    #       - /opt/gitlab_issues/recap_las_issues.csv
+    - name: Send e-mail with CSV attached
+      community.general.mail:
+      # TODO: fill in TLS and other
+        host: lib-ponyexpr-prod.princeton.edu
+        port: 25
+        subject: ReCAP LAS Issue report
+        body: Issues from the ops-team-handbook repo
+        from: ac2754@princeton.edu
+        to: "{{ vault_recap_las_airtable_email }}"
+        # cc: ops@princeton.edu # do we have something like this?
+        attach:
+          - /opt/gitlab_issues/recap_las_issues.csv

--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -28,26 +28,9 @@
 # then run the loop on the include (or import, whichever it is)
 # then this should work
 # also, set the items per page as a var so we don't have a future mismatch
+    - name: iterate over API results
+      ansible.builtin.include_tasks: gitlab-api-RW.yml
       with_sequence: start=1 end="{{ pages }}"
-
-    - name: get all pages of issues from team handbook
-      ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=10&page={{ item }}&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
-        method: GET
-        # 'scope=all' pulls issues created by all users
-      register: page_of_issues
-
-    # - name: Combine all page results
-    #   ansible.builtin.set_fact:
-    #     all_issues: "{{ team_handbook_issues.results | map(attribute='json') | map(attribute='data') | flatten | list }}"
-
-    - name: write selected output to CSV for team handbook
-      ansible.builtin.lineinfile:
-        dest: /opt/gitlab_issues/team_handbook_issues1.csv
-        line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
-        insertafter: EOF
-        state: present
-      loop: "{{ page_of_issues | community.general.json_query('json[*]') }}"
 
     # - name: Send e-mail with CSV attached
     #   community.general.mail:

--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -6,10 +6,21 @@
   tasks:
     - name: call issue API for team handbook
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?page={{ item }}&per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
       register: team_handbook_issues
+      loop: "{{ range(1, 6) | list }}"
+      until: team_handbook_issues.json.data | length == 0
+      retries: 5
+
+    - name: Combine all page results
+      ansible.builtin.set_fact:
+        all_issues: "{{ team_handbook_issues.results | map(attribute='json') | map(attribute='data') | flatten | list }}"
+
+    - name: view all page results
+      ansible.builtin.debug:
+        var: all_issues
 
     - name: write CSV headers for team handbook
       ansible.builtin.lineinfile:
@@ -25,7 +36,7 @@
         line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
         insertafter: EOF
         state: present
-      loop: "{{ team_handbook_issues | community.general.json_query('json[*]') }}"
+      loop: "{{ all_issues | community.general.json_query('json[*]') }}"
       # we assume every issue will have a title, an issue ID, a state, a created_at timestamp, and a URL
       # we allow null values for assignee and labels
 

--- a/playbooks/utils/gitlab_api.yml
+++ b/playbooks/utils/gitlab_api.yml
@@ -6,21 +6,14 @@
   tasks:
     - name: call issue API for team handbook
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?page={{ item }}&per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=10&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
       register: team_handbook_issues
-      loop: "{{ range(1, 6) | list }}"
-      until: team_handbook_issues.json.data | length == 0
-      retries: 5
 
-    - name: Combine all page results
+    - name: set number of pages
       ansible.builtin.set_fact:
-        all_issues: "{{ team_handbook_issues.results | map(attribute='json') | map(attribute='data') | flatten | list }}"
-
-    - name: view all page results
-      ansible.builtin.debug:
-        var: all_issues
+        pages: "{{ team_handbook_issues.x_total_pages }}"
 
     - name: write CSV headers for team handbook
       ansible.builtin.lineinfile:
@@ -30,63 +23,79 @@
         insertbefore: BOF
         state: present
 
-    - name: write selected output to CSV for team handbook
-      ansible.builtin.lineinfile:
-        dest: /opt/gitlab_issues/team_handbook_issues.csv
-        line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
-        insertafter: EOF
-        state: present
-      loop: "{{ all_issues | community.general.json_query('json[*]') }}"
-      # we assume every issue will have a title, an issue ID, a state, a created_at timestamp, and a URL
-      # we allow null values for assignee and labels
+# the with_sequence thing works, but we need to put the next 2 tasks
+# into an included tasks file
+# then run the loop on the include (or import, whichever it is)
+# then this should work
+# also, set the items per page as a var so we don't have a future mismatch
+      with_sequence: start=1 end="{{ pages }}"
 
-    - name: Send e-mail with CSV attached
-      community.general.mail:
-      # TODO: fill in TLS and other
-        host: lib-ponyexpr-prod.princeton.edu
-        port: 25
-        subject: Team Handbook Issue report
-        body: Issues from the ops-team-handbook repo
-        from: ac2754@princeton.edu
-        to: "{{ vault_team_handbook_airtable_email }}"
-        # cc: ops@princeton.edu # do we have something like this?
-        attach:
-          - /opt/gitlab_issues/team_handbook_issues.csv
-
-    - name: call issue API for ReCAP LAS
+    - name: get all pages of issues from team handbook
       ansible.builtin.uri:
-        url: "https://gitlab.lib.princeton.edu/api/v4/projects/12/issues?per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+        url: "https://gitlab.lib.princeton.edu/api/v4/projects/5/issues?per_page=10&page={{ item }}&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
         method: GET
         # 'scope=all' pulls issues created by all users
-      register: recap_las_issues
+      register: page_of_issues
 
-    - name: write CSV headers for ReCAP LAS
-      ansible.builtin.lineinfile:
-        create: true
-        dest: /opt/gitlab_issues/recap_las_issues.csv
-        line: Source,Title,Issue ID,State,Assignee,Created At (UTC),Labels,URL
-        insertbefore: BOF
-        state: present
+    # - name: Combine all page results
+    #   ansible.builtin.set_fact:
+    #     all_issues: "{{ team_handbook_issues.results | map(attribute='json') | map(attribute='data') | flatten | list }}"
 
-    - name: write selected output to CSV for ReCAP LAS
+    - name: write selected output to CSV for team handbook
       ansible.builtin.lineinfile:
-        dest: /opt/gitlab_issues/recap_las_issues.csv
+        dest: /opt/gitlab_issues/team_handbook_issues1.csv
         line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
         insertafter: EOF
         state: present
-      loop: "{{ recap_las_issues | community.general.json_query('json[*]') }}"
-      # we assume every issue will have a title, an issue ID, a state, a created_at timestamp, and a URL
-      # we allow null values for assignee and labels
+      loop: "{{ page_of_issues | community.general.json_query('json[*]') }}"
 
-    - name: Send e-mail with CSV attached
-      community.general.mail:
-      # TODO: fill in TLS and other
-        host: lib-ponyexpr-prod.princeton.edu
-        port: 25
-        subject: ReCAP LAS Issue report
-        body: Issues from the ops-team-handbook repo
-        from: ac2754@princeton.edu
-        to: "{{ vault_recap_las_airtable_email }}"
-        # cc: ops@princeton.edu # do we have something like this?
-        attach:
-          - /opt/gitlab_issues/recap_las_issues.csv
+    # - name: Send e-mail with CSV attached
+    #   community.general.mail:
+    #   # TODO: fill in TLS and other
+    #     host: lib-ponyexpr-prod.princeton.edu
+    #     port: 25
+    #     subject: Team Handbook Issue report
+    #     body: Issues from the ops-team-handbook repo
+    #     from: ac2754@princeton.edu
+    #     to: "{{ vault_team_handbook_airtable_email }}"
+    #     # cc: ops@princeton.edu # do we have something like this?
+    #     attach:
+    #       - /opt/gitlab_issues/team_handbook_issues.csv
+
+    # - name: call issue API for ReCAP LAS
+    #   ansible.builtin.uri:
+    #     url: "https://gitlab.lib.princeton.edu/api/v4/projects/12/issues?per_page=100&state=opened&access_token={{ vault_gitlab_issue_access_token }}"
+    #     method: GET
+    #     # 'scope=all' pulls issues created by all users
+    #   register: recap_las_issues
+
+    # - name: write CSV headers for ReCAP LAS
+    #   ansible.builtin.lineinfile:
+    #     create: true
+    #     dest: /opt/gitlab_issues/recap_las_issues.csv
+    #     line: Source,Title,Issue ID,State,Assignee,Created At (UTC),Labels,URL
+    #     insertbefore: BOF
+    #     state: present
+
+    # - name: write selected output to CSV for ReCAP LAS
+    #   ansible.builtin.lineinfile:
+    #     dest: /opt/gitlab_issues/recap_las_issues.csv
+    #     line: GitLab,"{{ item.title }}",{{ item.iid }},{{ item.state }},{{ item.assignee.name | default('') }},{{ item.created_at }},{{ item.labels | default('') }},{{ item.web_url }}
+    #     insertafter: EOF
+    #     state: present
+    #   loop: "{{ recap_las_issues | community.general.json_query('json[*]') }}"
+    #   # we assume every issue will have a title, an issue ID, a state, a created_at timestamp, and a URL
+    #   # we allow null values for assignee and labels
+
+    # - name: Send e-mail with CSV attached
+    #   community.general.mail:
+    #   # TODO: fill in TLS and other
+    #     host: lib-ponyexpr-prod.princeton.edu
+    #     port: 25
+    #     subject: ReCAP LAS Issue report
+    #     body: Issues from the ops-team-handbook repo
+    #     from: ac2754@princeton.edu
+    #     to: "{{ vault_recap_las_airtable_email }}"
+    #     # cc: ops@princeton.edu # do we have something like this?
+    #     attach:
+    #       - /opt/gitlab_issues/recap_las_issues.csv


### PR DESCRIPTION
Closes #7050.

The GitLab API sets the maximum number of issues per page to 100. We now have over 100 open issues, so we need to support pagination to get all open issues exported into Airtable.

This PR:
- queries the API for the total number of pages
- uses that number in a loop for an included tasks file
- iterates over the number of pages, requesting data via the API and writing it to CSV for each page
- sets a variable for the number of issues per page