### PR TITLE
[dataspace] bypass verification

### DIFF
--- a/group_vars/gcploadbalancer/production.yml
+++ b/group_vars/gcploadbalancer/production.yml
@@ -21,6 +21,7 @@ openresty_altcha_bypass_networks:
   - 172.20.80.67/32          # bibdata-worker-staging1
   - 128.112.203.105/32       # bibdata-worker-prod1
   - 128.112.203.109/32       # bibdata-worker-prod2
+  - 128.112.201.63/32        # check mk prod
 
 openresty_real_ip_enable: true
 openresty_real_ip_from:


### PR DESCRIPTION
checkmk is reporting that dataspace is down because it gets a 401.

```sh
http -F dataspace.princeton.edu                                                               ✘ 255  1h 54m 43s  impure 10:30:26
HTTP/1.1 401 Unauthorized
Connection: keep-alive
Content-Length: 1363
Content-Type: text/html
Date: Thu, 30 Apr 2026 14:41:19 GMT
Server: nginx/1.28.3

<!doctype html>
<html>
<head>
    <title>Verification required</title>
    <script type="module" src="https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js"></script>
  </head>
```

Adding it to the allowed networks that don't need to verify that they are human

closes #7075 