### PR TITLE
[openssh] add entraid login role

### DIFF
--- a/playbooks/entraid_join.yml
+++ b/playbooks/entraid_join.yml
@@ -1,0 +1,7 @@
+---
+- name: enable ssh via entraid
+  hosts: sandbox-{{ runtime_env | default('ad') }}.lib.princeton.edu
+  remote_user: pulsys
+  become: true
+  roles:
+    - role: entraid_join

--- a/roles/entraid_join/README.md
+++ b/roles/entraid_join/README.md
@@ -1,0 +1,169 @@
+# entraid_join
+
+Configure headless Microsoft Entra ID login on Ubuntu and Rocky Linux using Himmelblau.
+
+This role is intended for SSH/PAM/NSS login without a GUI.
+
+## Supported platforms
+
+- Ubuntu 22.04 by default
+- Rocky Linux 9 by default
+
+Override repository release variables for other supported releases.
+
+## What this role does
+
+- Installs Himmelblau packages
+- Configures `/etc/himmelblau/himmelblau.conf`
+- Enables `himmelblaud`
+- Configures NSS for `passwd` and `group` lookup through Himmelblau
+- Configures PAM for headless MFA
+- Configures SSH for PAM and keyboard-interactive authentication
+- Comments out `AllowUsers` during the pilot because OpenSSH `AllowUsers` does not work cleanly with Entra UPN-style usernames
+- Creates `/etc/krb5.conf.d`
+
+## Example
+
+```yaml
+- hosts: entraid_test
+  become: true
+  roles:
+    - role: entraid_join
+      vars:
+        entraid_join_domain: princeton.edu
+        entraid_join_debug: true
+  ```
+
+### SSH test
+
+Use the explicit login name form:
+
+```sh
+ssh -l 'netid@princeton.edu' sandbox-host.lib.princeton.edu
+```
+
+For Microsoft Authenticator number matching:
+
+- Enter the Entra password.
+- Open Authenticator.
+- Enter the displayed number.
+- Approve the sign-in.
+- Then press Enter in the SSH session.
+
+#### Post-login checks
+
+```sh
+whoami
+id
+groups
+pwd
+echo "$HOME"
+ls -ld "$HOME"
+```
+
+From an existing local session:
+
+```sh
+getent passwd fkayiwa
+getent passwd '<fkayiwa@princeton.edu>'
+id fkayiwa
+id netid@princeton.edu
+```
+
+### Important notes
+
+Do not use OpenSSH `AllowUsers` for Entra/Himmelblau UPN users.
+
+Use `pam_allow_groups` in `himmelblau.conf` after the pilot is working.
+
+Example:
+
+```yaml
+entraid_join_pam_allow_groups:
+
+- "00000000-1111-2222-3333-444444444444"
+```
+
+Use Entra group object IDs for production access control.
+
+---
+
+## Example playbook
+
+```yaml
+---
+- name: Configure headless Entra ID login
+  hosts: entraid_linux
+  become: true
+
+  roles:
+    - role: entraid_join
+      vars:
+        entraid_join_domain: princeton.edu
+        entraid_join_debug: true
+        entraid_join_disable_allowusers: true
+```
+
+### Validation commands
+
+Run these after the role completes.
+
+#### Ubuntu
+
+```sh
+sudo sshd -T | egrep 'usepam|kbdinteractiveauthentication|passwordauthentication|allowusers'
+grep -R "pam_himmelblau" /etc/pam.d
+grep -E '^(passwd|group):' /etc/nsswitch.conf
+sudo aad-tool status
+```
+
+Expected SSH output:
+
+```text
+usepam yes
+passwordauthentication yes
+kbdinteractiveauthentication yes
+```
+
+No `allowusers` output during the pilot.
+
+#### Rocky
+
+```sh
+sudo sshd -T | egrep 'usepam|kbdinteractiveauthentication|passwordauthentication|allowusers|challengeresponseauthentication'
+grep -R "pam_himmelblau" /etc/pam.d/system-auth /etc/pam.d/password-auth /etc/pam.d/sshd
+grep -E '^(passwd|group):' /etc/nsswitch.conf
+sudo aad-tool status
+```
+
+Expected SSH output:
+
+```text
+usepam yes
+passwordauthentication yes
+kbdinteractiveauthentication yes
+```
+
+No `allowusers` output during the pilot.
+
+#### Test SSH
+
+```sh
+ssh -l 'netid@princeton.edu' sandbox-host.lib.princeton.edu
+```
+
+For production, the next step is to set:
+
+```yaml
+entraid_join_pam_allow_groups:
+  - "<entra-group-object-id>"
+```
+
+and turn off debug:
+
+```yaml
+entraid_join_debug: false
+```
+
+```text
+```

--- a/roles/entraid_join/defaults/main.yml
+++ b/roles/entraid_join/defaults/main.yml
@@ -1,0 +1,71 @@
+#SPDX-License-Identifier: MIT-0
+---
+# defaults file for roles/entraid_join
+# Domain allowed for Himmelblau/Entra ID authentication.
+entraid_join_domain: princeton.edu
+
+# Himmelblau package repositories.
+entraid_join_himmelblau_channel: stable/latest
+
+# Ubuntu repo target. Override for ubuntu24.04 when needed.
+# https://himmelblau-idm.org/downloads/index.html
+entraid_join_ubuntu_repo_release: ubuntu22.04
+
+# Rocky repo target. Override for rocky8/rocky10 when needed.
+entraid_join_rocky_repo_release: rocky9
+
+# Himmelblau config.
+entraid_join_enable_hello: false
+entraid_join_shell: /bin/bash
+entraid_join_home_prefix: /home/
+entraid_join_home_attr: CN
+entraid_join_home_alias: CN
+entraid_join_use_etc_skel: true
+entraid_join_debug: false
+
+# Optional Entra group object IDs or UPNs allowed to authenticate.
+# Keep empty for initial pilot, then restrict later.
+entraid_join_pam_allow_groups: []
+
+# SSH pilot behavior.
+# This role disables AllowUsers by commenting out active AllowUsers lines,
+# because OpenSSH AllowUsers does not work well with Entra UPN-style logins.
+entraid_join_disable_allowusers: true
+
+# Manage SSH settings required for headless MFA.
+entraid_join_configure_sshd: true
+entraid_join_password_authentication: true
+entraid_join_kbd_interactive_authentication: true
+
+# Manage PAM auth lines for headless MFA.
+entraid_join_configure_pam: true
+
+# Manage NSS passwd/group resolution.
+entraid_join_configure_nsswitch: true
+
+# Create /etc/krb5.conf.d to avoid Himmelblau task warnings.
+entraid_join_create_krb5_conf_d: true
+
+# Packages.
+entraid_join_ubuntu_packages:
+  - curl
+  - ca-certificates
+  - gnupg
+  - software-properties-common
+  - himmelblau
+  - pam-himmelblau
+  - nss-himmelblau
+  - himmelblau-sso
+
+entraid_join_rocky_packages:
+  - dnf-plugins-core
+  - ca-certificates
+  - himmelblau
+  - pam-himmelblau
+  - nss-himmelblau
+  - himmelblau-sshd-config
+  - himmelblau-selinux
+
+# Service names.
+entraid_join_himmelblau_service: himmelblaud
+entraid_join_himmelblau_tasks_service: himmelblaud-tasks

--- a/roles/entraid_join/handlers/main.yml
+++ b/roles/entraid_join/handlers/main.yml
@@ -1,0 +1,25 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for roles/entraid_join
+- name: restart himmelblaud
+  ansible.builtin.service:
+    name: "{{ entraid_join_himmelblau_service }}"
+    state: restarted
+
+- name: restart himmelblaud-tasks
+  ansible.builtin.service:
+    name: "{{ entraid_join_himmelblau_tasks_service }}"
+    state: restarted
+  failed_when: false
+
+- name: restart ssh ubuntu
+  ansible.builtin.service:
+    name: ssh
+    state: restarted
+  when: ansible_os_family == "Debian"
+
+- name: restart ssh rocky
+  ansible.builtin.service:
+    name: sshd
+    state: restarted
+  when: ansible_os_family == "RedHat"

--- a/roles/entraid_join/meta/main.yml
+++ b/roles/entraid_join/meta/main.yml
@@ -1,0 +1,35 @@
+#SPDX-License-Identifier: MIT-0
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/entraid_join/tasks/main.yml
+++ b/roles/entraid_join/tasks/main.yml
@@ -1,0 +1,58 @@
+#SPDX-License-Identifier: MIT-0
+---
+# tasks file for roles/entraid_join
+- name: Entraid_join | Install and configure Himmelblau packages on Ubuntu
+  ansible.builtin.include_tasks: ubuntu.yml
+  when: ansible_os_family == "Debian"
+
+- name: Entraid_join | Install and configure Himmelblau packages on Rocky
+  ansible.builtin.include_tasks: rocky.yml
+  when: ansible_os_family == "RedHat"
+
+- name: Entraid_join | Ensure krb5 include directory exists
+  ansible.builtin.file:
+    path: /etc/krb5.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: entraid_join_create_krb5_conf_d | bool
+  notify:
+    - restart himmelblaud
+    - restart himmelblaud-tasks
+
+- name: Entraid_join | Configure Himmelblau
+  ansible.builtin.template:
+    src: himmelblau.conf.j2
+    dest: /etc/himmelblau/himmelblau.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - restart himmelblaud
+    - restart himmelblaud-tasks
+
+- name: Entraid_join | Configure NSS
+  ansible.builtin.include_tasks: nss.yml
+  when: entraid_join_configure_nsswitch | bool
+
+- name: Entraid_join | Configure PAM
+  ansible.builtin.include_tasks: pam.yml
+  when: entraid_join_configure_pam | bool
+
+- name: Entraid_join | Configure SSH
+  ansible.builtin.include_tasks: ssh.yml
+  when: entraid_join_configure_sshd | bool
+
+- name: Entraid_join | Enable and start himmelblaud
+  ansible.builtin.service:
+    name: "{{ entraid_join_himmelblau_service }}"
+    enabled: true
+    state: started
+
+- name: Entraid_join | Enable and start himmelblaud-tasks if present
+  ansible.builtin.service:
+    name: "{{ entraid_join_himmelblau_tasks_service }}"
+    enabled: true
+    state: started
+  failed_when: false

--- a/roles/entraid_join/tasks/nss.yml
+++ b/roles/entraid_join/tasks/nss.yml
@@ -1,0 +1,18 @@
+---
+- name: Entraid_join | Ensure passwd uses himmelblau NSS
+  ansible.builtin.lineinfile:
+    path: /etc/nsswitch.conf
+    regexp: '^passwd:'
+    line: 'passwd:     files himmelblau systemd'
+    backup: true
+  notify:
+    - restart himmelblaud
+
+- name: Entraid_join | Ensure group uses himmelblau NSS
+  ansible.builtin.lineinfile:
+    path: /etc/nsswitch.conf
+    regexp: '^group:'
+    line: 'group:      files himmelblau systemd'
+    backup: true
+  notify:
+    - restart himmelblaud

--- a/roles/entraid_join/tasks/pam.yml
+++ b/roles/entraid_join/tasks/pam.yml
@@ -1,0 +1,41 @@
+---
+- name: Entraid_join | Configure Ubuntu common-auth for Himmelblau MFA
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/common-auth
+    regexp: '^auth\s+.*pam_himmelblau\.so.*'
+    line: 'auth     [success=2 default=ignore]    pam_himmelblau.so ignore_unknown_user mfa_poll_prompt no_hello_pin'
+    backup: true
+    firstmatch: true
+  when: ansible_os_family == "Debian"
+  notify:
+    - restart himmelblaud
+
+- name: Entraid_join | Remove duplicate Ubuntu sufficient pam_himmelblau auth line
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/common-auth
+    regexp: '^auth\s+sufficient\s+pam_himmelblau\.so\s+ignore_unknown_user\s+mfa_poll_prompt\s+no_hello_pin'
+    state: absent
+    backup: true
+  when: ansible_os_family == "Debian"
+  notify:
+    - restart himmelblaud
+
+- name: Entraid_join | Configure Rocky system-auth for Himmelblau MFA
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/system-auth
+    regexp: '^auth\s+sufficient\s+pam_himmelblau\.so.*'
+    line: 'auth     sufficient      pam_himmelblau.so ignore_unknown_user mfa_poll_prompt no_hello_pin'
+    backup: true
+  when: ansible_os_family == "RedHat"
+  notify:
+    - restart himmelblaud
+
+- name: Entraid_join | Configure Rocky password-auth for Himmelblau MFA
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/password-auth
+    regexp: '^auth\s+sufficient\s+pam_himmelblau\.so.*'
+    line: 'auth     sufficient      pam_himmelblau.so ignore_unknown_user mfa_poll_prompt no_hello_pin'
+    backup: true
+  when: ansible_os_family == "RedHat"
+  notify:
+    - restart himmelblaud

--- a/roles/entraid_join/tasks/rocky.yml
+++ b/roles/entraid_join/tasks/rocky.yml
@@ -1,0 +1,31 @@
+---
+- name: Entraid_join | Install Rocky prerequisites
+  ansible.builtin.dnf:
+    name:
+      - dnf-plugins-core
+      - ca-certificates
+    state: present
+
+- name: Entraid_join | Import Himmelblau RPM signing key
+  ansible.builtin.rpm_key:
+    key: https://packages.himmelblau-idm.org/himmelblau.asc
+    state: present
+
+- name: Entraid_join | Configure Himmelblau dnf repository
+  ansible.builtin.yum_repository:
+    name: himmelblau
+    description: Himmelblau packages
+    baseurl: "https://packages.himmelblau-idm.org/{{ entraid_join_himmelblau_channel }}/rpm/{{ entraid_join_rocky_repo_release }}"
+    enabled: true
+    gpgcheck: true
+    gpgkey: https://packages.himmelblau-idm.org/himmelblau.asc
+    state: present
+
+- name: Entraid_join | Refresh dnf metadata
+  ansible.builtin.dnf:
+    update_cache: true
+
+- name: Entraid_join | Install Himmelblau packages on Rocky
+  ansible.builtin.dnf:
+    name: "{{ entraid_join_rocky_packages }}"
+    state: present

--- a/roles/entraid_join/tasks/ssh.yml
+++ b/roles/entraid_join/tasks/ssh.yml
@@ -1,0 +1,53 @@
+---
+- name: Entraid_join | Configure SSH for headless Himmelblau login
+  ansible.builtin.template:
+    src: sshd_himmelblau.conf.j2
+    dest: /etc/ssh/sshd_config.d/99-himmelblau-headless-pilot.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - restart ssh ubuntu
+    - restart ssh rocky
+
+# Rocky/RHEL can ship an earlier ChallengeResponseAuthentication no.
+# OpenSSH first-value behavior means a later yes may not override it.
+- name: Entraid_join | Comment out RedHat ChallengeResponseAuthentication no
+  ansible.builtin.replace:
+    path: /etc/ssh/sshd_config.d/50-redhat.conf
+    regexp: '^(ChallengeResponseAuthentication\s+no)$'
+    replace: '# \1'
+    backup: true
+  when:
+    - ansible_os_family == "RedHat"
+    - entraid_join_kbd_interactive_authentication | bool
+  notify:
+    - restart ssh rocky
+
+- name: Entraid_join | Find sshd config files
+  ansible.builtin.find:
+    paths:
+      - /etc/ssh
+      - /etc/ssh/sshd_config.d
+    patterns:
+      - sshd_config
+      - "*.conf"
+    file_type: file
+  register: entraid_join_sshd_config_files
+  when: entraid_join_disable_allowusers | bool
+
+- name: Entraid_join | Comment out active AllowUsers lines for Himmelblau pilot
+  ansible.builtin.replace:
+    path: "{{ item.path }}"
+    regexp: '^(AllowUsers\s+.*)$'
+    replace: '# \1'
+    backup: true
+  loop: "{{ entraid_join_sshd_config_files.files }}"
+  when: entraid_join_disable_allowusers | bool
+  notify:
+    - restart ssh ubuntu
+    - restart ssh rocky
+
+- name: Entraid_join | Validate sshd configuration
+  ansible.builtin.command: sshd -t
+  changed_when: false

--- a/roles/entraid_join/tasks/ubuntu.yml
+++ b/roles/entraid_join/tasks/ubuntu.yml
@@ -1,0 +1,32 @@
+---
+- name: Entraid_join | Install Ubuntu prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - gnupg
+      - software-properties-common
+    state: present
+    update_cache: true
+
+- name: Entraid_join | Install Himmelblau apt signing key
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -fsSL https://packages.himmelblau-idm.org/himmelblau.asc \
+      | gpg --dearmor -o /etc/apt/trusted.gpg.d/himmelblau.gpg
+  args:
+    executable: /bin/bash
+    creates: /etc/apt/trusted.gpg.d/himmelblau.gpg
+
+- name: Entraid_join | Configure Himmelblau apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64] https://packages.himmelblau-idm.org/{{ entraid_join_himmelblau_channel }}/deb/{{ entraid_join_ubuntu_repo_release }}/ ./"
+    filename: himmelblau
+    state: present
+    update_cache: true
+
+- name: Entraid_join | Install Himmelblau packages on Ubuntu
+  ansible.builtin.apt:
+    name: "{{ entraid_join_ubuntu_packages }}"
+    state: present
+    update_cache: true

--- a/roles/entraid_join/templates/himmelblau.conf.j2
+++ b/roles/entraid_join/templates/himmelblau.conf.j2
@@ -1,0 +1,14 @@
+# Managed by Ansible: entraid_join
+
+[global]
+domain = {{ entraid_join_domain }}
+enable_hello = {{ entraid_join_enable_hello | string | lower }}
+shell = {{ entraid_join_shell }}
+home_prefix = {{ entraid_join_home_prefix }}
+home_attr = {{ entraid_join_home_attr }}
+home_alias = {{ entraid_join_home_alias }}
+use_etc_skel = {{ entraid_join_use_etc_skel | string | lower }}
+debug = {{ entraid_join_debug | string | lower }}
+{% if entraid_join_pam_allow_groups | length > 0 %}
+pam_allow_groups = {{ entraid_join_pam_allow_groups | join(',') }}
+{% endif %}

--- a/roles/entraid_join/templates/sshd_himmelblau.conf.j2
+++ b/roles/entraid_join/templates/sshd_himmelblau.conf.j2
@@ -1,0 +1,6 @@
+# Managed by Ansible: entraid_join
+# Headless Himmelblau / Microsoft Entra ID SSH login.
+
+UsePAM yes
+PasswordAuthentication {{ 'yes' if entraid_join_password_authentication else 'no' }}
+KbdInteractiveAuthentication {{ 'yes' if entraid_join_kbd_interactive_authentication else 'no' }}

--- a/roles/entraid_join/tests/inventory
+++ b/roles/entraid_join/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+localhost
+

--- a/roles/entraid_join/tests/test.yml
+++ b/roles/entraid_join/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT-0
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/entraid_join

--- a/roles/entraid_join/vars/main.yml
+++ b/roles/entraid_join/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# vars file for roles/entraid_join


### PR DESCRIPTION
Create an entraid_join role for headless Microsoft Entra ID authentication on Ubuntu and Rocky Linux using Himmelblau. The role installs the appropriate Himmelblau packages and repositories, configures PAM/NSS, enables keyboard-interactive SSH authentication, and writes the Himmelblau configuration for the Princeton Entra domain.

This is needed so Linux users can log in over SSH with their Entra credentials without requiring a GUI workflow or Microsoft Entra Domain Services. The role also handles Rocky-specific SSH behavior by disabling the Red Hat ChallengeResponseAuthentication override, and it comments out OpenSSH AllowUsers entries during the pilot because they block UPN-style Himmelblau logins.

Side effects: SSH password and keyboard-interactive authentication are enabled for the pilot, and existing AllowUsers restrictions are commented out so Entra access should be restricted through Himmelblau/PAM group controls instead.

ref: #7025