### PR TITLE
[common] make mirrors.yml idempotent (#7090)

### DIFF
--- a/roles/common/tasks/mirrors.yml
+++ b/roles/common/tasks/mirrors.yml
@@ -32,7 +32,6 @@
   loop:
     - /etc/apt/sources.list.d/00-princeton.list
     - /etc/apt/sources.list.d/pul_postgresql.list
-    - /etc/apt/sources.list.d/pul_redis.list
     - /etc/apt/sources.list.d/pul_yarn.list
   when:
     - ansible_os_family == "Debian"
@@ -182,7 +181,7 @@
 - name: Common | Update apt cache
   ansible.builtin.apt:
     update_cache: true
-    cache_valid_time: 0
+    cache_valid_time: 3600
   when:
     - ansible_os_family == "Debian"
   register: apt_cache_update

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -101,3 +101,4 @@
     name: ["yarn"]
     state: present
   when: use_yarn
+

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -35,12 +35,22 @@
     state: file
   when: ansible_os_family == "Debian"
 
-- name: PostgreSQL | add postgresql repository for latest ubuntu
+- name: PostgreSQL | Remove legacy/conflicting repository files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list
+    - /etc/apt/sources.list.d/pul_postgresql.list
+  become: true
+  when: ansible_os_family == "Debian"
+
+- name: PostgreSQL | Add PostgreSQL APT repository
   ansible.builtin.apt_repository:
     repo: "{{ postgres_apt_repository }}"
     state: present
-    filename: pul_postgresql
-    update_cache: false
+    filename: postgresql
+    update_cache: true
   when: ansible_os_family == "Debian"
 
 - name: PostgreSQL | add postgres:13 appstream
@@ -50,40 +60,6 @@
   when:
     - running_on_server
     - ansible_os_family == "RedHat"
-
-- name: PostgreSQL | add postgresql repository for latest ubuntu
-  ansible.builtin.apt_repository:
-    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main'
-    state: present
-    update_cache: false
-  when:
-    - ansible_os_family == "Debian"
-
-- name: PostgreSQL | Clean apt cache
-  ansible.builtin.command: apt-get clean
-  changed_when: false
-
-- name: PostgreSQL | Update apt cache after adding repository
-  ansible.builtin.command: apt-get update
-  register: cache_update
-  retries: 3
-  delay: 5
-  until: cache_update.rc == 0
-  changed_when: false
-  failed_when: false
-
-- name: PostgreSQL | Display cache update errors
-  ansible.builtin.debug:
-    msg: |
-      Return code: {{ cache_update.rc }}
-      STDOUT: {{ cache_update.stdout }}
-      STDERR: {{ cache_update.stderr }}
-  when: cache_update.rc != 0
-
-- name: PostgreSQL | Fail if cache update failed
-  ansible.builtin.fail:
-    msg: "apt-get update failed. See debug output above."
-  when: cache_update.rc != 0
 
 - name: PostgreSQL | install postgresql server packages (Ubuntu)
   ansible.builtin.apt:
@@ -318,3 +294,4 @@
   ansible.builtin.include_tasks: create_read_only_user.yml
   when: application_dbuser_ro_name is defined
   tags: grant_ro_privs
+

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Redis | Download Redis GPG key (ASCII)
   ansible.builtin.get_url:
     url: "{{ redis_apt_key_url }}"
-    dest: "/tmp/redis.gpg.key"
+    dest: /tmp/redis.gpg.key
     mode: '0644'
 
 - name: Redis | De-armor Redis GPG key to binary keyring
@@ -20,44 +20,18 @@
     state: file
   become: true
 
-- name: Redis | Remove legacy repository file if it exists
+- name: Redis | Remove legacy repository file (pre-rename)
   ansible.builtin.file:
-    path: /etc/apt/sources.list.d/redis.list
+    path: /etc/apt/sources.list.d/pul_redis.list
     state: absent
   become: true
 
-- name: Redis | Add Redis Labs repository (Modern)
+- name: Redis | Add Redis Labs repository
   ansible.builtin.apt_repository:
     repo: "{{ redis_apt_repository }}"
     state: present
-    filename: pul_redis
-    update_cache: false
-
-- name: Redis | Clean apt cache before update
-  ansible.builtin.command: apt-get clean
-  changed_when: false
-
-- name: Redis | Update apt cache after adding Redis repository
-  ansible.builtin.command: apt-get update
-  register: redis_cache_update
-  retries: 3
-  delay: 5
-  until: redis_cache_update.rc == 0
-  changed_when: false
-  failed_when: false
-
-- name: Redis | Display cache update output for debugging
-  ansible.builtin.debug:
-    msg: |
-      apt-get update return code: {{ redis_cache_update.rc }}
-      STDOUT: {{ redis_cache_update.stdout }}
-      STDERR: {{ redis_cache_update.stderr }}
-  when: redis_cache_update.rc != 0
-
-- name: Redis | Fail if cache update didn't succeed
-  ansible.builtin.fail:
-    msg: "Failed to update apt cache after adding Redis repository. See debug output above."
-  when: redis_cache_update.rc != 0
+    filename: redis
+    update_cache: true
 
 - name: Redis | install redis packages
   ansible.builtin.apt:
@@ -66,32 +40,30 @@
 
 - name: Redis | configure redis
   ansible.builtin.template:
-    src: "redis.conf.j2"
-    dest: "/etc/redis/redis.conf"
-    owner: "redis"
-    group: "redis"
-    mode: "0644"
-  changed_when: false
+    src: redis.conf.j2
+    dest: /etc/redis/redis.conf
+    owner: redis
+    group: redis
+    mode: '0644'
   notify:
     - restart redis
 
 - name: Redis | ulimit value for redis
   ansible.builtin.template:
-    src: "redis_ulimit.conf.j2"
-    dest: "/etc/security/limits.d/redis.conf"
-    force: true
-    mode: "0644"
+    src: redis_ulimit.conf.j2
+    dest: /etc/security/limits.d/redis.conf
+    mode: '0644'
 
 - name: Redis | Set vm.overcommit
   ansible.posix.sysctl:
-    name: "vm.overcommit_memory"
+    name: vm.overcommit_memory
     value: 1
-    sysctl_file: "/etc/sysctl.d/30-redis.conf"
-  when: redis__overcommit_memory_enable|bool
+    sysctl_file: /etc/sysctl.d/30-redis.conf
+  when: redis__overcommit_memory_enable | bool
 
 - name: Redis | ensure Redis Server service enabled
   ansible.builtin.service:
-    name: "redis-server"
+    name: redis-server
     state: started
     enabled: true
   when: running_on_server


### PR DESCRIPTION
* [common] make mirrors.yml idempotent

- Use fixed path for sources.list backup (was timestamped, always changed)
- Remove timestamp comment from 99-ubuntu-archive.list content
- Bump cache_valid_time from 0 to 3600
- Remove duplicate mirrors.yml include from tasks/main.yml

i7085: redis - rename pul_redis filename and simplify cache flow

- Rename apt_repository filename from pul_redis to redis to avoid collision with common role's legacy-PUL-prefixed file scrubbing
- Replace manual apt-get clean/update block with apt_repository's built-in update_cache: true (idempotent, surfaces real errors)
- Add legacy-cleanup task to migrate hosts with old filenames
- Remove changed_when: false from redis.conf template task so config changes properly notify the restart handler

* [common/postgresql] fix idempotence

  - Remove the duplicate apt_repository task that was writing an unsigned source line for apt.postgresql.org. With strict apt behavior on jammy, having both a signed entry (from postgres_apt_repository) and an unsigned entry for the same repo caused 'Conflicting values set for option Signed-By' and refused to update.
  - Rename apt_repository filename from pul_postgresql to postgresql for the same reason as redis above.
  - Add a cleanup task that removes both legacy filenames: pul_postgresql.list and apt_postgresql_org_pub_repos_apt.list (the auto-named file the deleted duplicate task was writing).
  - Replace the manual apt-get clean / apt-get update / debug / fail block with apt_repository's built-in update_cache: true, same rationale as redis.