### PR TITLE
[DPUL-C] Improve prometheus metrics

### DIFF
--- a/nomad/grafana/deploy/staging.hcl
+++ b/nomad/grafana/deploy/staging.hcl
@@ -197,7 +197,7 @@ scrape_configs:
       regex: '(.*)metrics(.*)'
       action: keep
     - source_labels: ['__meta_consul_service']
-      target_label: instance
+      target_label: exported_job
     - source_labels: ['__meta_consul_service']
       regex: '.*(staging|production).*'
       replacement: '$${1}'


### PR DESCRIPTION
We use these to keep track of some DPUL-C metrics right now. Overriding instance was making all the requests/second graphs break.