### PR TITLE
[openresty] Allow good bots

### DIFF
--- a/group_vars/gcploadbalancer/production.yml
+++ b/group_vars/gcploadbalancer/production.yml
@@ -24,6 +24,23 @@ openresty_altcha_bypass_networks:
   - 128.112.201.63/32        # check mk prod
 
 openresty_real_ip_enable: true
+openresty_altcha_bypass_user_agents:
+  - "Googlebot"
+  - "Googlebot-Image"
+  - "Googlebot-News"
+  - "Googlebot-Video"
+  - "AdsBot-Google"
+  - "AdsBot-Google-Mobile"
+  - "APIs-Google"
+  - "Mediapartners-Google"
+  - "FeedFetcher-Google"
+  - "Google-InspectionTool"
+  - "Storebot-Google"
+  - "GoogleOther"
+  - "bingbot"
+  # Internet Archive, scholarly preservation
+  - "ia_archiver"
+  - "archive.org_bot"
 openresty_real_ip_from:
   - 34.85.237.83/32
   - 130.41.0.0/16            # GlobalProtect ranges

--- a/roles/openresty/templates/nginx.conf.j2
+++ b/roles/openresty/templates/nginx.conf.j2
@@ -41,6 +41,13 @@ include {{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf;
         {{ cidr }} 1;
 {% endfor %}
     }
+    # Maps of trusted user agents that bypass
+    map $http_user_agent $altcha_bypass_ua {
+        default 0;
+{% for ua_pattern in openresty_altcha_bypass_user_agents | default([]) %}
+        "~*{{ ua_pattern }}" 1;
+{% endfor %}
+    }
 {% endif %}
 
 {% for vhost in openresty_vhosts %}
@@ -166,13 +173,17 @@ include {{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf;
         location / {
 {% if vhost.altcha | default(false) %}
 {% if vhost.altcha_bypass_internal | default(false) %}
-            if ($altcha_bypass = 0) {
+            # Bypass if trusted IP OR trusted UA
+            if ($altcha_bypass-$altcha_bypass_ua = "0-0") {
                 error_page 418 = @altcha_gate;
                 return 418;
             }
 {% else %}
-            error_page 418 = @altcha_gate;
-            return 418;
+            # Bypass only if trusted UA
+            if ($altcha_bypass_ua = "0") {
+                error_page 418 = @altcha_gate;
+                return 418;
+            }
 {% endif %}
 {% endif %}
 

--- a/roles/openresty/templates/nginx.conf.j2
+++ b/roles/openresty/templates/nginx.conf.j2
@@ -30,7 +30,7 @@ include {{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf;
 {% endif %}
 
 {% if openresty_logger_json_enable %}
-    log_format logger-json escape=json '{"source": "nginx","message":"nginx log captured","time": $time_iso8601, "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status, "user_agent": "$http_user_agent", "resp_time": $request_time, "upstream_addr": "$upstream_addr"}';
+    log_format logger-json escape=json '{"source": "nginx","message":"nginx log captured","time": $time_iso8601, "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status, "user_agent": "$http_user_agent", "resp_time": $request_time, "upstream_addr": "$upstream_addr", "altcha_bypass": "$altcha_bypass", "altcha_bypass_ua": "$altcha_bypass_ua", "altcha_needs_gate": "$altcha_needs_gate"}';
 {% endif %}
 
 {% if openresty_altcha_enable %}
@@ -41,12 +41,20 @@ include {{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf;
         {{ cidr }} 1;
 {% endfor %}
     }
-    # Maps of trusted user agents that bypass
+
+    # Map of trusted user agents that bypass altcha on opted-in vhosts
     map $http_user_agent $altcha_bypass_ua {
         default 0;
 {% for ua_pattern in openresty_altcha_bypass_user_agents | default([]) %}
         "~*{{ ua_pattern }}" 1;
 {% endfor %}
+    }
+
+    # Require the altcha gate only when neither IP nor user-agent is trusted.
+    # This avoids fragile inline variable concatenation in nginx `if`.
+    map "$altcha_bypass:$altcha_bypass_ua" $altcha_needs_gate {
+        default 0;
+        "0:0" 1;
     }
 {% endif %}
 
@@ -173,14 +181,14 @@ include {{ openresty_etc_dir }}/conf.d/globalprotect_ips.conf;
         location / {
 {% if vhost.altcha | default(false) %}
 {% if vhost.altcha_bypass_internal | default(false) %}
-            # Bypass if trusted IP OR trusted UA
-            if ($altcha_bypass-$altcha_bypass_ua = "0-0") {
+            # Bypass ALTCHA if trusted IP OR trusted user-agent
+            if ($altcha_needs_gate = 1) {
                 error_page 418 = @altcha_gate;
                 return 418;
             }
 {% else %}
-            # Bypass only if trusted UA
-            if ($altcha_bypass_ua = "0") {
+            # Bypass ALTCHA only if trusted user-agent
+            if ($altcha_bypass_ua = 0) {
                 error_page 418 = @altcha_gate;
                 return 418;
             }


### PR DESCRIPTION
Add an explicit nginx map that combines the ALTCHA IP bypass and
user-agent bypass values into a single altcha_needs_gate variable. This
avoids relying on fragile inline variable concatenation inside an nginx
if statement, which nginx parsed as an invalid variable name.

The OpenResty template now gates requests only when neither the client IP
nor the user-agent is trusted. This allows configured crawler user agents
such as Googlebot to reach Dataspace and OAR without receiving the ALTCHA
verification page, while preserving the challenge for untrusted traffic.

Also include ALTCHA bypass values in JSON access logs so future
troubleshooting can confirm whether a request was allowed by IP,
user-agent, or sent through the challenge flow.