### PR TITLE
[Figgy] Temporarily prevent non-download requests going to figgy 3/4.

### DIFF
--- a/roles/nginxplus/files/conf/http/figgy-prod.conf
+++ b/roles/nginxplus/files/conf/http/figgy-prod.conf
@@ -12,8 +12,10 @@ upstream figgy {
     # If Traefik crashes, fall down to the box directly.
     server figgy-web-prod1.princeton.edu resolve max_fails=0 backup;
     server figgy-web-prod2.princeton.edu resolve max_fails=0 backup;
-    server figgy-web-prod3.princeton.edu resolve max_fails=0 backup;
-    server figgy-web-prod4.princeton.edu resolve max_fails=0 backup;
+    # Temporarily disabling web traffic to 3/4, as downloads sometimes takes
+    # those down when mediaflux suffers.
+    #server figgy-web-prod3.princeton.edu resolve max_fails=0 backup;
+    #server figgy-web-prod4.princeton.edu resolve max_fails=0 backup;
     sticky learn
           create=$upstream_cookie_figgycookie
           lookup=$cookie_figgycookie


### PR DESCRIPTION
Download requests are backing up 3/4 because the mediaflux node they're
connected to is slow right now. We don't want to do this forever, but
this should allow our staff to work again for now.

Part of pulibrary/figgy#7150