### PR TITLE
[libstatic] remove old cicognara references and named_sites vars

### DIFF
--- a/group_vars/libstatic/production.yml
+++ b/group_vars/libstatic/production.yml
@@ -1,11 +1,4 @@
 ---
-named_sites:
-    - server_name: "cicognara.org"
-      site_name: "cicognara.org"
-      doc_root: '/var/local/cicognara/apps/cicognara-static/_site'
-      repo_root: "/var/local/cicognara"
-      git_repo: 'https://github.com/pulibrary/digital-cicognara-library'
-      version: 'main'
 lib_static_site:
     site_name: 'static-prod1.lib'
     server_name: 'static-prod.lib'

--- a/group_vars/libstatic/staging.yml
+++ b/group_vars/libstatic/staging.yml
@@ -1,7 +1,6 @@
 ---
 # defaults file for roles/libstatic
 running_on_server: true
-named_sites:
 lib_static_site:
   site_name: 'static-staging1'
   server_name: 'static-staging1.lib'

--- a/roles/libstatic/tasks/main.yml
+++ b/roles/libstatic/tasks/main.yml
@@ -13,14 +13,6 @@
   tags:
     - install_keys
 
-- name: debug named_sites
-  ansible.builtin.debug: 
-    var: named_sites
-
-- name: debug sites
-  ansible.builtin.debug: 
-    var: sites
-
 - name: Libstatic | Grant permissions for deploy user
   ansible.builtin.file:
     path: "{{ item.repo_root }}"
@@ -74,17 +66,6 @@
   tags:
     - install_sites
 
-# - name: Libstatic | Add all the named sites
-#   ansible.builtin.template:
-#     src: "apache-named-sites.conf.j2"
-#     dest: "/etc/apache2/sites-available/{{ item.server_name }}.conf"
-#     mode: "0644"
-#   notify: restart apache
-#   become: true
-#   with_items: '{{ named_sites }}'
-#   tags:
-#     - install_sites
-
 - name: Libstatic | Add aliases and directories for the libstatic site
   ansible.builtin.template:
     src: "apache-static-sites.conf.j2"
@@ -94,15 +75,6 @@
   become: true
   tags:
     - install_sites
-
-# - name: Libstatic | enable apache2 sites
-#   ansible.builtin.command: 'a2ensite {{ item.site_name }}'
-#   become: true
-#   with_items: '{{ named_sites }}'
-#   register: apache2_enabled
-#   changed_when: '"Enabling site" in apache2_enabled.stdout'
-#   tags:
-#     - install_sites
 
 - name: Libstatic | enable apache2 static site
   ansible.builtin.command: 'a2ensite 000-{{ item.site_name }}'

--- a/roles/libstatic/tasks/main.yml
+++ b/roles/libstatic/tasks/main.yml
@@ -13,6 +13,14 @@
   tags:
     - install_keys
 
+- name: debug named_sites
+  ansible.builtin.debug: 
+    var: named_sites
+
+- name: debug sites
+  ansible.builtin.debug: 
+    var: sites
+
 - name: Libstatic | Grant permissions for deploy user
   ansible.builtin.file:
     path: "{{ item.repo_root }}"
@@ -22,7 +30,7 @@
     follow: false
     recurse: true
     mode: "0755"
-  with_items: '{{ named_sites + sites }}'
+  with_items: '{{ sites }}'
   changed_when: false
   tags:
     - install_sites
@@ -30,7 +38,7 @@
 - name: Libstatic | Make repos safe
   ansible.builtin.command: git config --global --add safe.directory '{{ item.repo_root }}'
   become: true
-  with_items: '{{ named_sites + sites }}'
+  with_items: '{{ sites }}'
   changed_when: false
   tags:
     - install_sites
@@ -47,7 +55,7 @@
     ssh_opts: '{{ item.ssh_opts | default(omit) }}'
   become: true
   notify: restart apache
-  with_items: '{{ named_sites + sites }}'
+  with_items: '{{ sites }}'
   changed_when: false
   tags:
     - install_sites
@@ -61,21 +69,21 @@
     follow: false
     recurse: true
     mode: "0775"
-  with_items: '{{ named_sites + sites }}'
+  with_items: '{{ sites }}'
   changed_when: false
   tags:
     - install_sites
 
-- name: Libstatic | Add all the named sites
-  ansible.builtin.template:
-    src: "apache-named-sites.conf.j2"
-    dest: "/etc/apache2/sites-available/{{ item.server_name }}.conf"
-    mode: "0644"
-  notify: restart apache
-  become: true
-  with_items: '{{ named_sites }}'
-  tags:
-    - install_sites
+# - name: Libstatic | Add all the named sites
+#   ansible.builtin.template:
+#     src: "apache-named-sites.conf.j2"
+#     dest: "/etc/apache2/sites-available/{{ item.server_name }}.conf"
+#     mode: "0644"
+#   notify: restart apache
+#   become: true
+#   with_items: '{{ named_sites }}'
+#   tags:
+#     - install_sites
 
 - name: Libstatic | Add aliases and directories for the libstatic site
   ansible.builtin.template:
@@ -87,14 +95,14 @@
   tags:
     - install_sites
 
-- name: Libstatic | enable apache2 sites
-  ansible.builtin.command: 'a2ensite {{ item.site_name }}'
-  become: true
-  with_items: '{{ named_sites }}'
-  register: apache2_enabled
-  changed_when: '"Enabling site" in apache2_enabled.stdout'
-  tags:
-    - install_sites
+# - name: Libstatic | enable apache2 sites
+#   ansible.builtin.command: 'a2ensite {{ item.site_name }}'
+#   become: true
+#   with_items: '{{ named_sites }}'
+#   register: apache2_enabled
+#   changed_when: '"Enabling site" in apache2_enabled.stdout'
+#   tags:
+#     - install_sites
 
 - name: Libstatic | enable apache2 static site
   ansible.builtin.command: 'a2ensite 000-{{ item.site_name }}'


### PR DESCRIPTION
- removes old cicognara references in group_vars for libstatic prod since that site is now hosted on Nomad

- removes references to the named_sites vars, since these no longer exist

related to #7106 