### PR TITLE
[DPUL-C] Update log-shipping to use Alloy instead of Promtail

### DIFF
--- a/nomad/grafana/deploy/log-shipping.hcl
+++ b/nomad/grafana/deploy/log-shipping.hcl
@@ -5,19 +5,15 @@ variable "branch_or_sha" {
 job "log-shipping" {
   datacenters = ["dc1"]
   type = "system"
-  node_pool   = "staging"
-  update {
-    max_parallel      = 1
-    min_healthy_time  = "10s"
-    healthy_deadline  = "3m"
-    progress_deadline = "10m"
-    auto_revert       = false
-  }
+  node_pool   = "all"
+  priority = 60
   group "log-shipping" {
     count = 1
+        consul {}
+
     network {
-      port "promtail-healthcheck" {
-        to = 3000
+      dns {
+        servers = ["10.88.0.1", "128.112.129.209", "8.8.8.8", "8.8.4.4"]
       }
     }
     restart {
@@ -57,83 +53,70 @@ job "log-shipping" {
         memory = 512
       }
     }
-    task "promtail" {
+    task "alloy" {
       driver = "podman"
       config {
-        image = "docker.io/grafana/promtail:2.2.1"
+        image = "docker.io/grafana/alloy:latest"
         args = [
-          "-config.file",
-          "local/config.yaml",
-          "-print-config-stderr",
+          "run",
+          "local/config.alloy",
         ]
-        ports = ["promtail-healthcheck"]
       }
       template {
-        data = <<EOH
-server:
-  http_listen_port: 3000
-  grpc_listen_port: 0
+        data        = <<EOH
+          logging {
+              level = "debug"
+              format = "logfmt"
+          }
+          local.file_match "logs" {
+              path_targets = [{
+                  __address__ = "localhost",
+                  __path__    = "{{ env "NOMAD_ALLOC_DIR" }}//nomad-logs.log",
+                  job         = "nomad",
+              }]
+          }
 
-positions:
-  filename: {{ env "NOMAD_ALLOC_DIR" }}/positions.yaml
+          loki.process "logs" {
+            forward_to = [loki.write.destination.receiver]
+            stage.json {
+              expressions = {
+                  alloc_id     = "alloc_id",
+                  data         = "data",
+                  job_name     = "job_name",
+                  message      = "message",
+                  node_name    = "node_name",
+                  service_name = "service_name",
+                  task_name    = "task_name",
+                }
+              }
+              stage.labels {
+                  values = {
+                      job_name     = null,
+                      alloc_id     = null,
+                      node_name    = null,
+                      service_name = null,
+                      task_name = null,
+                  }
+                }
+              }
+              loki.source.file "logs" {
+                  targets               = local.file_match.logs.targets
+                  forward_to            = [loki.process.logs.receiver]
+                  legacy_positions_file = "local/positions.yaml"
+              }
 
-client:
-  url: http://{{ range service "loki" }}{{ .Address }}:{{ .Port }}{{ end }}/loki/api/v1/push
-scrape_configs:
-- job_name: local
-  static_configs:
-  - targets:
-      - localhost
-    labels:
-      job: nomad
-      __path__: "{{ env "NOMAD_ALLOC_DIR" }}/nomad-logs.log"
-  pipeline_stages:
-    # extract the fields from the JSON logs
-    - json:
-        expressions:
-          alloc_id: alloc_id
-          job_name: job_name
-          job_meta: job_meta
-          node_name: node_name
-          service_name: service_name
-          service_tags: service_tags
-          task_meta: task_meta
-          task_name: task_name
-          message: message
-          data: data
-    # the following fields are used as labels and are indexed:
-    - labels:
-        job_name:
-        task_name:
-        service_name:
-        node_name:
-        service_tags:
-    # use a regex to extract a field called time from within message( which is for non-JSON formatted logs,
-    # so the assumption is that they're in the logfmt format,
-    # and a field time= is present with a timestamp in, which is the actual timestamp of the log)
-    - regex:
-        expression: ".*time=\\\"(?P<timestamp>\\S*)\\\"[ ]"
-        source: "message"
-    - timestamp:
-        source: timestamp
-        format: RFC3339
-EOH
-        destination = "local/config.yaml"
+              loki.write "destination" {
+                endpoint {
+                    url = "http://loki.service.consul:3100/loki/api/v1/push"
+                }
+              }
+
+              EOH
+        destination = "local/config.alloy"
       }
-      # resource limits are a good idea because you don't want your log collection to consume all resources available
       resources {
-        cpu    = 500
+        cpu    = 100
         memory = 512
-      }
-      service {
-        name = "promtail"
-        port = "promtail-healthcheck"
-        check {
-          type     = "http"
-          path     = "/ready"
-          interval = "10s"
-          timeout  = "2s"
-        }
       }
     }
   }

--- a/nomad/grafana/deploy/loki.hcl
+++ b/nomad/grafana/deploy/loki.hcl
@@ -67,12 +67,13 @@ job "loki" {
       template {
         data = <<EOH
 auth_enabled: false
-
 server:
   http_listen_port: 3100
   grpc_listen_port: 9096
-  log_level: debug
+  log_level: info
   grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 16777216 # 16MB
+  grpc_server_max_send_msg_size: 16777216 # 16MB
 
 common:
   instance_addr: 127.0.0.1
@@ -106,6 +107,8 @@ compactor:
   delete_request_store: filesystem
 limits_config:
   retention_period: 360h
+  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 20
 schema_config:
   configs:
     - from: 2020-10-24
@@ -131,8 +134,8 @@ EOH
         destination = "local/loki/local-config.yaml"
       }
       resources {
-        cpu    = 512
-        memory = 256
+        cpu    = 1024
+        memory = 2048
       }
     }
   }


### PR DESCRIPTION
Promtail's gone, this just modernizes the practice we're doing now and fixes some of the tags so Loki can ingest the prod logs.
Probably to be deprecated as Signoz ships as standard practice.
