### PR TITLE
adds new vms for Tower upgrade to Ansible Platform 2.6

### DIFF
--- a/inventory/all_projects/ansible_tower.ini
+++ b/inventory/all_projects/ansible_tower.ini
@@ -3,3 +3,11 @@ ansible-exec-node1.princeton.edu
 ansible-exec-node2.princeton.edu
 ansible-tower1.princeton.edu
 ansible-tower2.princeton.edu
+[tower_26]
+# upgrading to 2.6 requires new architecture
+ansible26controller1.lib.princeton.edu
+ansible26controller2.lib.princeton.edu
+ansible26database1.lib.princeton.edu
+ansible26exec1.lib.princeton.edu
+ansible26exec2.lib.princeton.edu
+ansible26gateway1.lib.princeton.edu


### PR DESCRIPTION
We are upgrading ansible-tower.princeton.edu to RH Ansible Automation Platform 2.6. The new version requires a more distributed architecture. In addition to 2 controller and 2 exec VMs, we need a dedicated database VM and a gateway VM, all running on RHEL 9.

The plan is to install RHAAP 2.6 and test it on clean VMs. Assuming that works, we will export our existing RHAAP database and try to upgrade it onto 2.6.

This PR adds the new VMs to inventory so we can maintain them during this upgrade and beyond.