### PR TITLE
[solr9cloud] Enable Solr 9 OpenTelemetry tracing

### DIFF
--- a/group_vars/solr9cloud/staging.yml
+++ b/group_vars/solr9cloud/staging.yml
@@ -7,6 +7,19 @@ ruby_version_override: "ruby-3.4.1"
 solr_heap_setting: '20g'
 jardirectory: "/opt/solr/lib"
 jolokia_agent_version: "2.5.1"
+# modularize modules
+solr_modules:
+  - analysis-extras
+  - scripting
+  - langid
+  - opentelemetry
+
+solr_otel_enabled: true
+solr_otel_service_name: solr
+solr_otel_endpoint: "http://127.0.0.1:4317"
+solr_otel_protocol: grpc
+solr_otel_sampler: parentbased_always_on
+solr_otel_propagators: "tracecontext,baggage"
 # more granular option would be:
 # solr_java_memory: '-Xms16g -Xmx20g'
 # solr shards
@@ -58,6 +71,13 @@ otel_default_resource_attributes:
   environment: staging
 
 otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
   filelog/solr-main:
     include:
       - /solr/logs/solr.log
@@ -191,3 +211,12 @@ otel_service_pipelines:
     exporters:
       - loadbalancing
       - debug
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing

--- a/roles/solr9cloud/templates/solr.in.sh.j2
+++ b/roles/solr9cloud/templates/solr.in.sh.j2
@@ -7,6 +7,8 @@ SOLR_HEAP="{{ solr_heap_setting }}"
 SOLR_HEAP="{{ solr_heap }}"
 {% endif %}
 
+{% set solr_enabled_modules = solr_modules | default(['analysis-extras', 'scripting', 'langid']) %}
+
 # GC tune var
 GC_TUNE="{{ solr_gc_tune }}"
 
@@ -29,7 +31,7 @@ ENABLE_REMOTE_JMX_OPTS="true"
 RMI_PORT="1099"
 
 # All system properties on ONE line
-SOLR_OPTS="-Xss256k -Dsolr.solr.home={{ solr_data_dir }} -Dsolr.log.dir={{ solr_log_dir }} -Dsolr.install.symDir={{ solr_installation }} -Dsolr.allowPaths={{ solr_data_dir }},/solr/backups -Dlog4j.configurationFile={{ solr_data_home }}/log4j2.xml -Dsolr.jetty.host=0.0.0.0 -Djetty.home={{ solr_installation }}/server -Dsolr.jetty.threads.idle.timeout=1800000 -Dsolr.cloud.client.stallTime=1800000 -Dlog4j2.formatMsgNoLookups=true -Djava.security.egd=file:/dev/./urandom -Dsolr.modules=analysis-extras,scripting,langid -DzkClientTimeout=${ZK_CLIENT_TIMEOUT} -XX:+AlwaysPreTouch -XX:MaxGCPauseMillis=200 -javaagent:/opt/solr/lib/jolokia-agent-jvm-{{ jolokia_agent_version }}-javaagent.jar=port=8778,host=127.0.0.1"
+SOLR_OPTS="-Xss256k -Dsolr.solr.home={{ solr_data_dir }} -Dsolr.log.dir={{ solr_log_dir }} -Dsolr.install.symDir={{ solr_installation }} -Dsolr.allowPaths={{ solr_data_dir }},/solr/backups -Dlog4j.configurationFile={{ solr_data_home }}/log4j2.xml -Dsolr.jetty.host=0.0.0.0 -Djetty.home={{ solr_installation }}/server -Dsolr.jetty.threads.idle.timeout=1800000 -Dsolr.cloud.client.stallTime=1800000 -Dlog4j2.formatMsgNoLookups=true -Djava.security.egd=file:/dev/./urandom -Dsolr.modules={{ solr_enabled_modules | join(',') }} -DzkClientTimeout=${ZK_CLIENT_TIMEOUT} -XX:+AlwaysPreTouch -XX:MaxGCPauseMillis=200 -javaagent:/opt/solr/lib/jolokia-agent-jvm-{{ jolokia_agent_version }}-javaagent.jar=port=8778,host=127.0.0.1{% if solr_otel_enabled | default(false) %} -Dotel.service.name={{ solr_otel_service_name | default('solr') }} -Dotel.sdk.disabled=false -Dotel.traces.exporter=otlp -Dotel.exporter.otlp.protocol={{ solr_otel_protocol | default('grpc') }} -Dotel.exporter.otlp.endpoint={{ solr_otel_endpoint | default('http://127.0.0.1:4317') }} -Dotel.traces.sampler={{ solr_otel_sampler | default('parentbased_always_on') }}{% if solr_otel_sampler_arg is defined %} -Dotel.traces.sampler.arg={{ solr_otel_sampler_arg }}{% endif %} -Dotel.propagators={{ solr_otel_propagators | default('tracecontext,baggage') }} -Dotel.resource.attributes=service.name={{ solr_otel_service_name | default('solr') }},service.version={{ runtime_env | default('staging') }},environment={{ runtime_env | default('staging') }},host.name={{ inventory_hostname }}{% endif %}"
 
 # SSL (disabled here; enable if needed)
 SOLR_SSL_ENABLED=false


### PR DESCRIPTION
Add OpenTelemetry tracing support for the Solr 9 staging cloud without changing the existing log and metrics collection paths.

This makes the Solr module list configurable and enables the opentelemetry module alongside the existing analysis-extras, scripting, and langid modules. It also adds OTEL JVM properties to the rendered solr.in.sh when tracing is enabled, sending OTLP/gRPC spans to the local collector on 127.0.0.1:4317.

The Solr collector configuration now includes an OTLP receiver and a traces pipeline so Solr can emit spans locally before the collector forwards them to the SigNoz cluster through the existing loadbalancing exporter.