### PR TITLE
[gcploadbalancer] allow google scholar IPs

### DIFF
--- a/group_vars/gcploadbalancer/production.yml
+++ b/group_vars/gcploadbalancer/production.yml
@@ -23,6 +23,10 @@ openresty_altcha_bypass_networks:
   - 128.112.203.109/32       # bibdata-worker-prod2
   - 128.112.201.63/32        # check mk prod
 
+  # Google Scholar crawler ranges
+  - 66.249.64.0/20
+  - 192.178.4.0/22
+
 openresty_real_ip_enable: true
 openresty_altcha_bypass_user_agents:
   - "Googlebot"


### PR DESCRIPTION
Add the Google Scholar crawler CIDR ranges to the OpenResty ALTCHA bypass network list for the production GCP load balancers.

Google Scholar provided these ranges so their crawler can reach Dataspace content without receiving the ALTCHA verification challenge. This keeps the existing trusted user-agent bypass in place, but allows the Scholar crawler by source IP as well, which is less fragile than relying only on user-agent matching.

No behavior changes are expected for untrusted clients because requests outside the configured bypass networks and user-agent list still pass through the ALTCHA gate.