### PR TITLE
[tigerdata] Fix ansible python warning

### DIFF
--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -1,4 +1,6 @@
 ---
+ansible_python_interpreter: /usr/bin/python3
+
 postgresql_is_local: false
 postgres_version: 15
 postgres_admin_password: '{{ vault_postgres_admin_password }}'


### PR DESCRIPTION
Fixes this warning: 

> [WARNING]: Host 'tigerdata-qa2.princeton.edu' is using the discovered Python interpreter at '/usr/bin/python3.10', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.19/reference_appendices/interpreter_discovery.html for more information.