### PR TITLE
Adds SigNoz configuration for LAE, Figgy, and DPUL

### DIFF
--- a/group_vars/dpul/staging.yml
+++ b/group_vars/dpul/staging.yml
@@ -1,4 +1,12 @@
 ---
+beyla_enabled: true
+beyla_service_name: dpul
+beyla_environment: staging
+beyla_otlp_endpoint: "http://127.0.0.1:4318"
+beyla_otlp_protocol: "http/protobuf"
+
+beyla_open_ports:
+  - 80
 postgres_host: "lib-postgres-staging1.princeton.edu"
 postgres_version: 15
 postgres_admin_user: "postgres"
@@ -117,6 +125,12 @@ otel_default_resource_attributes:
   environment: staging
 
 otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
   filelog/nginx-access:
     include: ["/var/log/nginx/access.log*"]
     start_at: end
@@ -133,7 +147,8 @@ otel_receivers:
         value: "dpul_access"
       - type: add
         field: attributes.service_name
-        value: dpul
+        value: dpul_access
+
   filelog/nginx-error:
     include: ["/var/log/nginx/error.log*"]
     start_at: end
@@ -144,25 +159,78 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "dpul"
+
   hostmetrics:
     collection_interval: 30s
-    scrapers: { cpu: {}, disk: {}, filesystem: {}, load: {}, memory: {}, network: {} }
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
 
 otel_processors:
-  batch: { send_batch_max_size: 1024, send_batch_size: 512, timeout: 30s }
+  batch:
+    send_batch_max_size: 1024
+    send_batch_size: 512
+    timeout: 30s
 
 otel_exporters:
-  otlp:
-    endpoint: "http://sandbox-signoz1.lib.princeton.edu:4317"
-    tls: { insecure: true }
-  debug: { verbosity: basic }
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    resolver:
+      static:
+        hostnames:
+          - k8s-staging1.lib.princeton.edu:30374
+          - k8s-staging2.lib.princeton.edu:30374
+          - k8s-staging3.lib.princeton.edu:30374
+
+  debug:
+    verbosity: basic
 
 otel_service_pipelines:
   logs:
-    receivers: ["filelog/nginx-access", "filelog/nginx-error"]
-    processors: ["resource", "batch"]
-    exporters: ["otlp", "debug"]
+    receivers:
+      - filelog/nginx-access
+      - filelog/nginx-error
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
   metrics:
-    receivers: ["hostmetrics"]
-    processors: ["resource", "batch"]
-    exporters: ["otlp", "debug"]
+    receivers:
+      - otlp
+      - hostmetrics
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing

--- a/group_vars/figgy/staging.yml
+++ b/group_vars/figgy/staging.yml
@@ -1,4 +1,12 @@
 ---
+beyla_enabled: true
+beyla_service_name: figgy
+beyla_environment: staging
+beyla_otlp_endpoint: "http://127.0.0.1:4318"
+beyla_otlp_protocol: "http/protobuf"
+
+beyla_open_ports:
+  - 80
 tigerdata_nfs_src: 'tigerdata-nfs.princeton.edu:/figgy'
 tigerdata_nfs_opts: 'nfsvers=3,mountport=2049,port=2049,nolock,proto=tcp,actimeo=0,lookupcache=none'
 figgy_db_name: 'figgy_staging'
@@ -139,6 +147,12 @@ otel_default_resource_attributes:
   environment: staging
 
 otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
   filelog/nginx-access:
     include: ["/var/log/nginx/access.log*"]
     start_at: end
@@ -156,6 +170,7 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: figgy_access
+
   filelog/nginx-error:
     include: ["/var/log/nginx/error.log*"]
     start_at: end
@@ -166,25 +181,78 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "figgy"
+
   hostmetrics:
     collection_interval: 30s
-    scrapers: { cpu: {}, disk: {}, filesystem: {}, load: {}, memory: {}, network: {} }
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
 
 otel_processors:
-  batch: { send_batch_max_size: 1024, send_batch_size: 512, timeout: 30s }
+  batch:
+    send_batch_max_size: 1024
+    send_batch_size: 512
+    timeout: 30s
 
 otel_exporters:
-  otlp:
-    endpoint: "http://sandbox-signoz1.lib.princeton.edu:4317"
-    tls: { insecure: true }
-  debug: { verbosity: basic }
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    resolver:
+      static:
+        hostnames:
+          - k8s-staging1.lib.princeton.edu:30374
+          - k8s-staging2.lib.princeton.edu:30374
+          - k8s-staging3.lib.princeton.edu:30374
+
+  debug:
+    verbosity: basic
 
 otel_service_pipelines:
   logs:
-    receivers: ["filelog/nginx-access", "filelog/nginx-error"]
-    processors: ["resource", "batch"]
-    exporters: ["otlp", "debug"]
+    receivers:
+      - filelog/nginx-access
+      - filelog/nginx-error
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
   metrics:
-    receivers: ["hostmetrics"]
-    processors: ["resource", "batch"]
-    exporters: ["otlp", "debug"]
+    receivers:
+      - otlp
+      - hostmetrics
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing

--- a/group_vars/lae/staging.yml
+++ b/group_vars/lae/staging.yml
@@ -1,4 +1,12 @@
 ---
+beyla_enabled: true
+beyla_service_name: lae
+beyla_environment: staging
+beyla_otlp_endpoint: "http://127.0.0.1:4318"
+beyla_otlp_protocol: "http/protobuf"
+
+beyla_open_ports:
+  - 80
 ruby_version_override: "ruby-3.4.8"
 postgres_host: "lib-postgres-staging1.princeton.edu"
 postgres_version: 15
@@ -86,6 +94,12 @@ otel_default_resource_attributes:
   environment: staging
 
 otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
   filelog/nginx-access:
     include: ["/var/log/nginx/access.log*"]
     start_at: end
@@ -172,6 +186,7 @@ otel_service_pipelines:
 
   metrics:
     receivers:
+      - otlp
       - hostmetrics
     processors:
       - resource
@@ -179,3 +194,12 @@ otel_service_pipelines:
     exporters:
       - loadbalancing
       - debug
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing

--- a/playbooks/dpul.yml
+++ b/playbooks/dpul.yml
@@ -15,6 +15,7 @@
   roles:
     - role: dpul
     - role: otel_collector
+    - role: beyla
     - role: datadog
       when: runtime_env | default('staging') == "production"
     - role: prometheus.prometheus.node_exporter

--- a/playbooks/figgy_staging.yml
+++ b/playbooks/figgy_staging.yml
@@ -31,6 +31,7 @@
     # that.
     - role: prometheus.prometheus.node_exporter
     - role: otel_collector
+    - role: beyla
   post_tasks:
     - name: tell everyone on slack you ran an ansible playbook
       slack:

--- a/playbooks/lae.yml
+++ b/playbooks/lae.yml
@@ -12,6 +12,7 @@
 
   roles:
     - role: otel_collector
+    - role: beyla
     - role: lae
 
   post_tasks:

--- a/roles/beyla/README.md
+++ b/roles/beyla/README.md
@@ -1,10 +1,8 @@
-# Ansible Role: Beyla
+# Beyla
 
 Installs and configures [Grafana Beyla](https://www.google.com/search?q=https://grafana.com/oss/beyla/), an eBPF-based auto-instrumentation tool that captures application observability metrics and traces without requiring code modifications. This role downloads the specified release, configures the service to export telemetry to an OpenTelemetry (OTLP) endpoint, and manages the Beyla systemd service.
 
 ## Requirements
-
-- **Operating System**: Linux (amd64) with systemd.
 
 - **Privileges**: Root access is required, as eBPF needs elevated permissions to attach to application processes and network sockets.
 
@@ -18,7 +16,7 @@ The following variables are defined in `defaults/main.yml` and can be overridden
 
 | **Variable**          | **Default** | **Description**                                                                   |
 | --------------------- | ----------- | --------------------------------------------------------------------------------- |
-| **`beyla_enabled`**   | `false`     | Master toggle for the role. Must be set to `true` to install and configure Beyla. |
+| **`beyla_enabled`**   | `false`     | Main toggle for the role. Must be set to `true` to install and configure Beyla. |
 | **`beyla_version`**   | `"3.15.0"`  | The version of Grafana Beyla to download and install.                             |
 | **`beyla_user`**      | `root`      | System user to run the Beyla systemd service. (Requires eBPF/proc access).        |
 | **`beyla_group`**     | `root`      | System group to run the Beyla systemd service.                                    |
@@ -39,7 +37,7 @@ Beyla needs to know which processes or ports to instrument. You can provide thes
 
 | **Variable**                 | **Default** | **Description**                                                                                            |
 | ---------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| **`beyla_open_ports`**       | `[]`        | List of target local listener ports to instrument (e.g., `[80, 8983, 8080]`).                               |
+| **`beyla_open_ports`**       | `[]`        | List of target local listener ports to instrument (e.g., `[80, 5432, 8983, 8080]`).                               |
 | **`beyla_executable_names`** | `[]`        | List of explicit executable paths to monitor if port discovery is too broad (e.g., `['/usr/sbin/nginx']`). |
 
 ### Paths and Directories

--- a/roles/beyla/README.md
+++ b/roles/beyla/README.md
@@ -1,0 +1,87 @@
+# Ansible Role: Beyla
+
+Installs and configures [Grafana Beyla](https://www.google.com/search?q=https://grafana.com/oss/beyla/), an eBPF-based auto-instrumentation tool that captures application observability metrics and traces without requiring code modifications. This role downloads the specified release, configures the service to export telemetry to an OpenTelemetry (OTLP) endpoint, and manages the Beyla systemd service.
+
+## Requirements
+
+- **Operating System**: Linux (amd64) with systemd.
+
+- **Privileges**: Root access is required, as eBPF needs elevated permissions to attach to application processes and network sockets.
+
+- **Dependencies**: Ensure `tar` is installed on the target machine to unarchive the release.
+
+## Role Variables
+
+The following variables are defined in `defaults/main.yml` and can be overridden to customize the installation and configuration.
+
+### Core Configuration
+
+| **Variable**          | **Default** | **Description**                                                                   |
+| --------------------- | ----------- | --------------------------------------------------------------------------------- |
+| **`beyla_enabled`**   | `false`     | Master toggle for the role. Must be set to `true` to install and configure Beyla. |
+| **`beyla_version`**   | `"3.15.0"`  | The version of Grafana Beyla to download and install.                             |
+| **`beyla_user`**      | `root`      | System user to run the Beyla systemd service. (Requires eBPF/proc access).        |
+| **`beyla_group`**     | `root`      | System group to run the Beyla systemd service.                                    |
+| **`beyla_log_level`** | `info`      | The logging verbosity for the Beyla daemon.                                       |
+
+### Telemetry Export (OTLP)
+
+| **Variable**              | **Default**                                 | **Description**                                                                                    |
+| ------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **`beyla_otlp_endpoint`** | `"http://127.0.0.1:4318"`                   | The OTLP endpoint where traces and metrics will be sent (usually a local OpenTelemetry Collector). |
+| **`beyla_otlp_protocol`** | `"http/protobuf"`                           | The protocol used for OTLP exports.                                                                |
+| **`beyla_service_name`**  | `"{{ inventory_hostname }}"`                | Defines the `service.name` resource attribute.                                                     |
+| **`beyla_environment`**   | `"{{ runtime_env \| default('staging') }}"` | Defines the `deployment.environment` resource attribute.                                           |
+
+### Discovery Selection
+
+Beyla needs to know which processes or ports to instrument. You can provide these via open ports or executable names.
+
+| **Variable**                 | **Default** | **Description**                                                                                            |
+| ---------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
+| **`beyla_open_ports`**       | `[]`        | List of target local listener ports to instrument (e.g., `[80, 8983, 8080]`).                               |
+| **`beyla_executable_names`** | `[]`        | List of explicit executable paths to monitor if port discovery is too broad (e.g., `['/usr/sbin/nginx']`). |
+
+### Paths and Directories
+
+| **Variable**            | **Default**             | **Description**                                    |
+| ----------------------- | ----------------------- | -------------------------------------------------- |
+| **`beyla_install_dir`** | `/opt/beyla`            | Base installation directory.                       |
+| **`beyla_config_dir`**  | `/etc/beyla`            | Directory for Beyla configuration files.           |
+| **`beyla_binary_path`** | `/usr/local/bin/beyla`  | Destination path for the executable binary.        |
+| **`beyla_config_path`** | `/etc/beyla/config.yml` | Destination path for the main configuration file.  |
+| **`beyla_env_path`**    | `/etc/default/beyla`    | Destination path for the systemd environment file. |
+
+## Dependencies
+
+It expects [otel_collector](../otel_collector/) to ship to Signoz
+
+## Example Playbook
+
+Here is an example of how to include and configure this role in your playbook to instrument a local NGINX server exporting to a local OpenTelemetry collector:
+
+```yaml
+- hosts: web_servers
+  become: true
+  vars:
+    beyla_enabled: true
+    beyla_version: "3.15.0"
+    beyla_service_name: "nginx-frontend"
+    beyla_environment: "production"
+    beyla_open_ports:
+      - 80
+      - 443
+    beyla_executable_names:
+      - /usr/sbin/nginx
+
+  roles:
+    - role: beyla
+```
+
+## License
+
+MIT-0 (No Attribution)
+
+## Author Information
+
+Princeton University Library

--- a/roles/beyla/defaults/main.yml
+++ b/roles/beyla/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+beyla_enabled: false
+
+beyla_version: "3.15.0"
+beyla_release_dir: "{{ beyla_install_dir }}/releases/{{ beyla_version }}"
+beyla_archive_path: "/tmp/beyla-linux-amd64-v{{ beyla_version }}.tar.gz"
+
+beyla_download_url: "https://github.com/grafana/beyla/releases/download/v{{ beyla_version }}/beyla-linux-amd64-v{{ beyla_version }}.tar.gz"
+
+beyla_install_dir: /opt/beyla
+beyla_config_dir: /etc/beyla
+beyla_config_path: /etc/beyla/config.yml
+beyla_env_path: /etc/default/beyla
+beyla_binary_path: /usr/local/bin/beyla
+
+# Prefer exporting to the local collector on each app host.
+beyla_otlp_endpoint: "http://127.0.0.1:4318"
+beyla_otlp_protocol: "http/protobuf"
+
+# Set these in group_vars/host_vars.
+beyla_service_name: "{{ inventory_hostname }}"
+beyla_environment: "{{ runtime_env | default('staging') }}"
+
+# Target local listener ports. For NGINX/Apache/Passenger apps,
+# this is commonly 80 or 443.
+beyla_open_ports: []
+
+# Optional executable matching if port-based discovery is too broad.
+# Examples:
+#   - /usr/sbin/nginx
+#   - /usr/sbin/apache2
+beyla_executable_names: []
+
+beyla_log_level: info
+
+# eBPF requires elevated permissions. Run as root for first pass.
+beyla_user: root
+beyla_group: root

--- a/roles/beyla/handlers/main.yml
+++ b/roles/beyla/handlers/main.yml
@@ -1,0 +1,11 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for roles/beyla
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart beyla
+  ansible.builtin.systemd:
+    name: beyla
+    state: restarted

--- a/roles/beyla/meta/main.yml
+++ b/roles/beyla/meta/main.yml
@@ -1,0 +1,35 @@
+#SPDX-License-Identifier: MIT-0
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/beyla/tasks/main.yml
+++ b/roles/beyla/tasks/main.yml
@@ -1,0 +1,88 @@
+#SPDX-License-Identifier: MIT-0
+---
+# tasks file for roles/beyla
+- name: Beyla | Ensure install and config directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ beyla_install_dir }}", mode: "0755" }
+    - { path: "{{ beyla_config_dir }}", mode: "0755" }
+  when: beyla_enabled | bool
+- name: Beyla | Ensure release directory exists
+  ansible.builtin.file:
+    path: "{{ beyla_release_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: beyla_enabled | bool
+
+- name: Beyla | Download amd64 release archive
+  ansible.builtin.get_url:
+    url: "{{ beyla_download_url }}"
+    dest: "{{ beyla_archive_path }}"
+    mode: "0644"
+  when: beyla_enabled | bool
+
+- name: Beyla | Unarchive release
+  ansible.builtin.unarchive:
+    src: "{{ beyla_archive_path }}"
+    dest: "{{ beyla_release_dir }}"
+    remote_src: true
+    creates: "{{ beyla_release_dir }}/beyla"
+  when: beyla_enabled | bool
+
+- name: Beyla | Install binary
+  ansible.builtin.copy:
+    src: "{{ beyla_release_dir }}/beyla"
+    dest: "{{ beyla_binary_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+    remote_src: true
+  notify: Restart beyla
+  when: beyla_enabled | bool
+
+- name: Beyla | Template config
+  ansible.builtin.template:
+    src: config.yml.j2
+    dest: "{{ beyla_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart beyla
+  when: beyla_enabled | bool
+
+- name: Beyla | Template environment file
+  ansible.builtin.template:
+    src: beyla.env.j2
+    dest: "{{ beyla_env_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart beyla
+  when: beyla_enabled | bool
+
+- name: Beyla | Install systemd unit
+  ansible.builtin.template:
+    src: beyla.service.j2
+    dest: /etc/systemd/system/beyla.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Restart beyla
+  when: beyla_enabled | bool
+
+- name: Beyla | Enable and start service
+  ansible.builtin.systemd:
+    name: beyla
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: beyla_enabled | bool

--- a/roles/beyla/templates/beyla.env.j2
+++ b/roles/beyla/templates/beyla.env.j2
@@ -1,0 +1,3 @@
+OTEL_EXPORTER_OTLP_ENDPOINT={{ beyla_otlp_endpoint }}
+OTEL_EXPORTER_OTLP_PROTOCOL={{ beyla_otlp_protocol }}
+BEYLA_LOG_LEVEL={{ beyla_log_level }}

--- a/roles/beyla/templates/beyla.service.j2
+++ b/roles/beyla/templates/beyla.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Grafana Beyla eBPF auto-instrumentation
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ beyla_user }}
+Group={{ beyla_group }}
+EnvironmentFile={{ beyla_env_path }}
+ExecStart={{ beyla_binary_path }} --config {{ beyla_config_path }}
+Restart=on-failure
+RestartSec=5s
+
+# Beyla needs eBPF/proc access. Keep permissive for first pass.
+NoNewPrivileges=false
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/beyla/templates/config.yml.j2
+++ b/roles/beyla/templates/config.yml.j2
@@ -1,0 +1,36 @@
+---
+discovery:
+  services:
+{% if beyla_open_ports | length > 0 %}
+{% for port in beyla_open_ports %}
+    - open_ports: {{ port | int }}
+{% endfor %}
+{% endif %}
+{% if beyla_executable_names | length > 0 %}
+{% for executable in beyla_executable_names %}
+    - exe_path: {{ executable | to_json }}
+{% endfor %}
+{% endif %}
+
+otel_traces_export:
+  endpoint: {{ beyla_otlp_endpoint | to_json }}
+  protocol: {{ beyla_otlp_protocol | to_json }}
+
+otel_metrics_export:
+  endpoint: {{ beyla_otlp_endpoint | to_json }}
+  protocol: {{ beyla_otlp_protocol | to_json }}
+
+routes:
+  unmatched: heuristic
+
+name:
+  resolver:
+    sources:
+      - env
+      - exec
+      - hostname
+
+resource_attributes:
+  service.name: {{ beyla_service_name | to_json }}
+  deployment.environment: {{ beyla_environment | to_json }}
+  host.name: {{ inventory_hostname | to_json }}

--- a/roles/beyla/tests/inventory
+++ b/roles/beyla/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+localhost
+

--- a/roles/beyla/tests/test.yml
+++ b/roles/beyla/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT-0
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/beyla

--- a/roles/beyla/vars/main.yml
+++ b/roles/beyla/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# vars file for roles/beyla

--- a/roles/figgy/meta/main.yml
+++ b/roles/figgy/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
         - 18.04
 dependencies:
   - { role: "redis", tags: "redis" }
-  - { role: "mediainfo", tags: "mediainfo" }
+  #  - { role: "mediainfo", tags: "mediainfo" }
   - role: "vips"
   - role: "tippecanoe"
   - role: "imagemagick"


### PR DESCRIPTION
Testing hosted application with no application level opentelemetry. Adding Grafana Beyla gives us eBPF-based request tracing and RED metrics without changing application code.