### PR TITLE
[otel_collector] install versioned otelcol upgrades

### DIFF
--- a/group_vars/nginxplus/staging.yml
+++ b/group_vars/nginxplus/staging.yml
@@ -2,6 +2,7 @@
 adc_domain: "adc-dev.lib.princeton.edu"
 nginx_http_upload_src: conf/http/dev/*.conf
 nginx_template_upload_src: conf/http/dev/templates/*.conf
+
 # modules to install
 nginx_modules:
   waf: false
@@ -12,6 +13,7 @@ nginx_modules:
   rtmp: true
   otel: true
   xslt: true
+
 # dos: true
 # app_protect logs
 app_protect_dir: "/var/log/app_protect/*.log"
@@ -44,15 +46,15 @@ otel_receivers:
     include_file_path: true
     include_file_name: true
     operators:
-      - type: regex_parser
-        id: parse_nginxplus_access
-        regex: '^(?P<remote_addr>[^\s]+) - (?P<remote_user>[^\s]+) \[(?P<time_local>[^\]]+)\] "(?P<method>\S+) (?P<path>\S+)(?: (?P<protocol>[^"]+))?" (?P<status>\d+) (?P<body_bytes_sent>\d+) "(?P<http_referer>[^"]*)" "(?P<http_user_agent>[^"]*)"(?: "(?P<http_x_forwarded_for>[^"]*)")?.*$'
+      - type: json_parser
+        id: parse_nginxplus_access_json
         parse_from: body
 
       - type: time_parser
-        parse_from: attributes.time_local
+        parse_from: attributes.timestamp
         layout_type: strptime
-        layout: '%d/%b/%Y:%H:%M:%S %z'
+        layout: '%Y-%m-%dT%H:%M:%S%z'
+        on_error: send
 
       - type: severity_parser
         parse_from: attributes.status
@@ -64,6 +66,39 @@ otel_receivers:
             - '^4\d\d$'
           error:
             - '^5\d\d$'
+        on_error: send
+
+      # If ngx_otel_module populated trace_id/span_id directly,
+      # promote them to top-level log fields for trace/log correlation.
+      - type: move
+        from: attributes.trace_id
+        to: trace_id
+        if: 'attributes.trace_id != nil and attributes.trace_id != ""'
+
+      - type: move
+        from: attributes.span_id
+        to: span_id
+        if: 'attributes.span_id != nil and attributes.span_id != ""'
+
+      # If trace_id/span_id were not populated directly but traceparent exists,
+      # extract the W3C traceparent header into attributes.
+      - type: regex_parser
+        id: parse_traceparent
+        parse_from: attributes.traceparent
+        regex: '^(?P<trace_version>[0-9a-f]{2})-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
+        if: '(trace_id == nil or trace_id == "") and attributes.traceparent != nil and attributes.traceparent != ""'
+        on_error: send
+
+      # Promote traceparent-derived IDs if direct ngx_otel IDs were not present.
+      - type: move
+        from: attributes.trace_id
+        to: trace_id
+        if: 'trace_id == nil and attributes.trace_id != nil and attributes.trace_id != ""'
+
+      - type: move
+        from: attributes.span_id
+        to: span_id
+        if: 'span_id == nil and attributes.span_id != nil and attributes.span_id != ""'
 
       - type: add
         field: attributes.log_type

--- a/group_vars/nginxplus/staging.yml
+++ b/group_vars/nginxplus/staging.yml
@@ -52,8 +52,8 @@ otel_receivers:
 
       - type: time_parser
         parse_from: attributes.timestamp
-        layout_type: strptime
-        layout: '%Y-%m-%dT%H:%M:%S%z'
+        layout_type: gotime
+        layout: "2006-01-02T15:04:05Z07:00"
         on_error: send
 
       - type: severity_parser
@@ -68,37 +68,15 @@ otel_receivers:
             - '^5\d\d$'
         on_error: send
 
-      # If ngx_otel_module populated trace_id/span_id directly,
-      # promote them to top-level log fields for trace/log correlation.
-      - type: move
+      - type: copy
         from: attributes.trace_id
-        to: trace_id
+        to: attributes.otel_trace_id
         if: 'attributes.trace_id != nil and attributes.trace_id != ""'
 
-      - type: move
+      - type: copy
         from: attributes.span_id
-        to: span_id
+        to: attributes.otel_span_id
         if: 'attributes.span_id != nil and attributes.span_id != ""'
-
-      # If trace_id/span_id were not populated directly but traceparent exists,
-      # extract the W3C traceparent header into attributes.
-      - type: regex_parser
-        id: parse_traceparent
-        parse_from: attributes.traceparent
-        regex: '^(?P<trace_version>[0-9a-f]{2})-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
-        if: '(trace_id == nil or trace_id == "") and attributes.traceparent != nil and attributes.traceparent != ""'
-        on_error: send
-
-      # Promote traceparent-derived IDs if direct ngx_otel IDs were not present.
-      - type: move
-        from: attributes.trace_id
-        to: trace_id
-        if: 'trace_id == nil and attributes.trace_id != nil and attributes.trace_id != ""'
-
-      - type: move
-        from: attributes.span_id
-        to: span_id
-        if: 'span_id == nil and attributes.span_id != nil and attributes.span_id != ""'
 
       - type: add
         field: attributes.log_type
@@ -124,7 +102,7 @@ otel_receivers:
       - type: time_parser
         parse_from: attributes.time_local
         layout_type: strptime
-        layout: '%Y/%m/%d %H:%M:%S'
+        layout: "%Y/%m/%d %H:%M:%S"
         on_error: send
 
       - type: severity_parser

--- a/roles/nginxplus/templates/etc_nginx.conf.j2
+++ b/roles/nginxplus/templates/etc_nginx.conf.j2
@@ -53,7 +53,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format json_logs escape=json '{'
+        log_format json_logs escape=json '{'
         '"remote_ip": "$remote_addr",'
         '"remote_user": "$remote_user",'
         '"timestamp": "$time_iso8601",'
@@ -64,7 +64,19 @@ http {
         '"body_bytes_sent": "$body_bytes_sent",'
         '"referer": "$http_referer",'
         '"host": "$host",'
-        '"user_agent": "$http_user_agent"'
+        '"user_agent": "$http_user_agent",'
+        '"request_id": "$request_id",'
+        '"traceparent": "$http_traceparent",'
+{% if nginx_modules.otel and nginx_type == "plus" %}
+        '"trace_id": "$otel_trace_id",'
+        '"span_id": "$otel_span_id",'
+        '"parent_span_id": "$otel_parent_id",'
+        '"parent_sampled": "$otel_parent_sampled",'
+{% endif %}
+        '"upstream_addr": "$upstream_addr",'
+        '"upstream_status": "$upstream_status",'
+        '"request_time": "$request_time",'
+        '"upstream_response_time": "$upstream_response_time"'
     '}';
 
     access_log  /var/log/nginx/access.log json_logs;

--- a/roles/otel_collector/defaults/main.yml
+++ b/roles/otel_collector/defaults/main.yml
@@ -1,34 +1,35 @@
 ---
 # defaults file for roles/otel_collector
-# The version of the otelcol-contrib to install
-otel_version: "0.138.0"
 
-# internal (molecule) values
-# place holder if we ever want to modify
+# The version of otelcol-contrib to install.
+otel_version: "0.153.0"
+
+# Install locations.
 otel_install_dir: "/opt/otelcol"
+otel_releases_dir: "{{ otel_install_dir }}/releases"
+otel_release_dir: "{{ otel_releases_dir }}/{{ otel_version }}"
 otel_binary_path: "{{ otel_install_dir }}/otelcol-contrib"
 otel_config_path: "{{ otel_install_dir }}/config.yaml"
+otel_archive_path: "/tmp/otelcol-contrib_{{ otel_version }}_linux_amd64.tar.gz"
 
-# Construct the download URL (hardcoded for amd64)
+# Construct the download URL. PUL targets amd64.
 otel_download_url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{ otel_version }}/otelcol-contrib_{{ otel_version }}_linux_amd64.tar.gz"
 
-# Whether to manage a systemd unit for otelcol-contrib
+# Whether to manage a systemd unit for otelcol-contrib.
 otel_service_name: "otelcol-contrib"
 otel_service_user: "root"
 otel_service_group: "root"
 
-# Validate config after templating (safe no-op if disabled)
+# Validate config after templating.
 otel_validate_config: false
 otel_validate_cmd: "{{ otel_binary_path }} --config {{ otel_config_path }} --dry-run"
 
-# Core config inputs (override in group_vars/project)
-# We keep them empty by default; the template renders valid empty structures.
+# Core config inputs.
 otel_receivers: {}
 otel_processors: {}
 otel_exporters: {}
 otel_service_pipelines: {}
 otel_extensions: []
 
-# default resource attributes to merge into processors.resource
-# they’ll be merged under a processors.resource attributes list.
-otel_default_resource_attributes: {}  # e.g. {'host.name': 'lib-postgres-staging1', 'environment': 'staging'}
+# Default resource attributes to merge into processors.resource.
+otel_default_resource_attributes: {}

--- a/roles/otel_collector/handlers/main.yml
+++ b/roles/otel_collector/handlers/main.yml
@@ -2,8 +2,12 @@
 - name: Systemd daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true
+  when:
+    - running_on_server | default(true) | bool
 
 - name: Restart otelcol
   ansible.builtin.systemd:
     name: "{{ otel_service_name }}"
     state: restarted
+  when:
+    - running_on_server | default(true) | bool

--- a/roles/otel_collector/tasks/main.yml
+++ b/roles/otel_collector/tasks/main.yml
@@ -1,28 +1,49 @@
 ---
 # tasks file for roles/otel_collector
-- name: Otel_collector | Ensure target directory exists
-  ansible.builtin.file:
-    path: "{{ otel_install_dir }}"
-    state: directory
-    mode: '0755'
-    owner: root
-    group: root
 
-- name: Otel_collector | Download and unarchive otelcol-contrib binary
-  ansible.builtin.unarchive:
-    src: "{{ otel_download_url }}"
-    dest: "{{ otel_install_dir }}"
-    remote_src: true
-    mode: '0755'
+- name: Otel_collector | Ensure target directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: "{{ item.mode }}"
     owner: root
     group: root
-    creates: "{{ otel_binary_path }}"
+  loop:
+    - { path: "{{ otel_install_dir }}", mode: "0755" }
+    - { path: "{{ otel_releases_dir }}", mode: "0755" }
+    - { path: "{{ otel_release_dir }}", mode: "0755" }
+
+- name: Otel_collector | Download otelcol-contrib archive
+  ansible.builtin.get_url:
+    url: "{{ otel_download_url }}"
+    dest: "{{ otel_archive_path }}"
+    mode: "0644"
+
+- name: Otel_collector | Unarchive otelcol-contrib release
+  ansible.builtin.unarchive:
+    src: "{{ otel_archive_path }}"
+    dest: "{{ otel_release_dir }}"
+    remote_src: true
+    mode: "0755"
+    owner: root
+    group: root
+    creates: "{{ otel_release_dir }}/otelcol-contrib"
+
+- name: Otel_collector | Install selected otelcol-contrib binary
+  ansible.builtin.copy:
+    src: "{{ otel_release_dir }}/otelcol-contrib"
+    dest: "{{ otel_binary_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+    remote_src: true
+  notify: Restart otelcol
 
 - name: Otel_collector | Deploy config
   ansible.builtin.template:
     src: config.yaml.j2
     dest: "{{ otel_config_path }}"
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
   notify: Restart otelcol
@@ -32,30 +53,48 @@
 - name: Otel_collector | Validate config
   ansible.builtin.command: "{{ otel_validate_cmd }}"
   changed_when: false
-  when: otel_validate_config
+  when:
+    - running_on_server
+    - otel_validate_config
 
 - name: Otel_collector | Install systemd unit
   ansible.builtin.template:
     src: otelcol.service.j2
     dest: "/etc/systemd/system/{{ otel_service_name }}.service"
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
-  notify: Systemd daemon-reload
+  notify:
+    - Systemd daemon-reload
+    - Restart otelcol
   when:
     - running_on_server
 
-- name: Otel_collector | Daemon-reload (if not via handler)
+- name: Otel_collector | Daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true
   changed_when: false
   when:
     - running_on_server
 
-- name: Otel_collector | Ensure service is enabled & running
+- name: Otel_collector | Ensure service is enabled and running
   ansible.builtin.systemd:
     name: "{{ otel_service_name }}"
     state: started
     enabled: true
+  when:
+    - running_on_server
+
+- name: Otel_collector | Check installed version
+  ansible.builtin.command:
+    cmd: "{{ otel_binary_path }} --version"
+  register: otel_installed_version
+  changed_when: false
+  when:
+    - running_on_server
+
+- name: Otel_collector | Show installed version
+  ansible.builtin.debug:
+    var: otel_installed_version.stdout
   when:
     - running_on_server


### PR DESCRIPTION
The otel_collector role did not honor changes to otel_version after the collector had already been installed. The unarchive task used the installed binary path as its creates guard, so Ansible skipped extraction whenever /opt/otelcol/otelcol-contrib already existed.

This changes the collector install flow to use versioned release directories under /opt/otelcol/releases/<version>. The role downloads the configured amd64 release archive, extracts it into the version-specific directory, and then copies that selected binary to /opt/otelcol/otelcol-contrib.

When otel_version changes, Ansible extracts the new release, replaces the active binary when the checksum differs, and restarts otelcol-contrib.