### PR TITLE
[gitlab] Add GitLab telemetry collection

### DIFF
--- a/group_vars/gitlab/staging.yml
+++ b/group_vars/gitlab/staging.yml
@@ -6,3 +6,183 @@ gitlab_trusted_proxies: "'172.20.80.13', '172.20.80.14', '172.20.80.19'"
 gitlab_entra_identifier_id: "{{ vault_gitlab_entra_identifier_staging_id }}"
 gitlab_entra_issuer_id: "{{ vault_gitlab_entra_issuer_staging_id }}"
 gitlab_entra_secret_id: "{{ vault_gitlab_entra_secret_staging_id }}"
+# signoz / otel collector for gitlab
+otel_default_resource_attributes:
+  host.name: "{{ inventory_hostname }}"
+  service.name: gitlab
+  service.version: staging
+  environment: staging
+  deployment.environment: staging
+
+otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
+  prometheus/gitlab:
+    config:
+      scrape_configs:
+        - job_name: gitlab_exporter
+          scrape_interval: 30s
+          static_configs:
+            - targets:
+                - 127.0.0.1:9168
+              labels:
+                service: gitlab
+                component: gitlab_exporter
+
+        - job_name: gitlab_node_exporter
+          scrape_interval: 30s
+          static_configs:
+            - targets:
+                - 127.0.0.1:9100
+              labels:
+                service: gitlab
+                component: node_exporter
+
+        - job_name: gitlab_redis_exporter
+          scrape_interval: 30s
+          static_configs:
+            - targets:
+                - 127.0.0.1:9121
+              labels:
+                service: gitlab
+                component: redis_exporter
+
+        - job_name: gitlab_postgres_exporter
+          scrape_interval: 30s
+          static_configs:
+            - targets:
+                - 127.0.0.1:9187
+              labels:
+                service: gitlab
+                component: postgres_exporter
+
+        - job_name: gitlab_sidekiq
+          scrape_interval: 30s
+          static_configs:
+            - targets:
+                - 127.0.0.1:8082
+              labels:
+                service: gitlab
+                component: sidekiq
+
+        - job_name: gitlab_puma
+          scrape_interval: 30s
+          static_configs:
+            - targets:
+                - 127.0.0.1:8083
+              labels:
+                service: gitlab
+                component: puma
+
+  filelog/gitlab:
+    include:
+      - /var/log/gitlab/gitlab-rails/current
+      - /var/log/gitlab/gitlab-workhorse/current
+      - /var/log/gitlab/nginx/gitlab_access.log
+      - /var/log/gitlab/nginx/gitlab_error.log
+      - /var/log/gitlab/puma/current
+      - /var/log/gitlab/sidekiq/current
+      - /var/log/gitlab/gitaly/current
+      - /var/log/gitlab/postgresql/current
+      - /var/log/gitlab/redis/current
+    exclude:
+      - /var/log/gitlab/**/*.gz
+      - /var/log/gitlab/**/*.s
+      - /var/log/gitlab/**/*.u
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: add
+        field: attributes.service
+        value: gitlab
+
+      - type: regex_parser
+        id: extract_gitlab_component
+        regex: '^/var/log/gitlab/(?P<gitlab_component>[^/]+)/'
+        parse_from: attributes["log.file.path"]
+        parse_to: attributes
+
+      - type: add
+        field: attributes.log_type
+        value: gitlab
+
+otel_processors:
+  batch: {}
+
+  resource/gitlab:
+    attributes:
+      - key: service.name
+        value: gitlab
+        action: upsert
+      - key: service
+        value: gitlab
+        action: upsert
+      - key: deployment.environment
+        value: staging
+        action: upsert
+      - key: environment
+        value: staging
+        action: upsert
+      - key: host.name
+        value: "{{ inventory_hostname }}"
+        action: upsert
+
+otel_exporters:
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    resolver:
+      static:
+        hostnames:
+          - k8s-staging1.lib.princeton.edu:30374
+          - k8s-staging2.lib.princeton.edu:30374
+          - k8s-staging3.lib.princeton.edu:30374
+
+otel_service:
+  pipelines:
+    metrics:
+      receivers:
+        - otlp
+        - prometheus/gitlab
+      processors:
+        - resource/gitlab
+        - batch
+      exporters:
+        - loadbalancing
+
+    logs:
+      receivers:
+        - filelog/gitlab
+      processors:
+        - resource/gitlab
+        - batch
+      exporters:
+        - loadbalancing
+
+    traces:
+      receivers:
+        - otlp
+      processors:
+        - resource/gitlab
+        - batch
+      exporters:
+        - loadbalancing

--- a/group_vars/gitlab/staging.yml
+++ b/group_vars/gitlab/staging.yml
@@ -6,6 +6,7 @@ gitlab_trusted_proxies: "'172.20.80.13', '172.20.80.14', '172.20.80.19'"
 gitlab_entra_identifier_id: "{{ vault_gitlab_entra_identifier_staging_id }}"
 gitlab_entra_issuer_id: "{{ vault_gitlab_entra_issuer_staging_id }}"
 gitlab_entra_secret_id: "{{ vault_gitlab_entra_secret_staging_id }}"
+
 # signoz / otel collector for gitlab
 otel_default_resource_attributes:
   host.name: "{{ inventory_hostname }}"
@@ -79,39 +80,6 @@ otel_receivers:
                 service: gitlab
                 component: puma
 
-  filelog/gitlab:
-    include:
-      - /var/log/gitlab/gitlab-rails/current
-      - /var/log/gitlab/gitlab-workhorse/current
-      - /var/log/gitlab/nginx/gitlab_access.log
-      - /var/log/gitlab/nginx/gitlab_error.log
-      - /var/log/gitlab/puma/current
-      - /var/log/gitlab/sidekiq/current
-      - /var/log/gitlab/gitaly/current
-      - /var/log/gitlab/postgresql/current
-      - /var/log/gitlab/redis/current
-    exclude:
-      - /var/log/gitlab/**/*.gz
-      - /var/log/gitlab/**/*.s
-      - /var/log/gitlab/**/*.u
-    start_at: end
-    include_file_path: true
-    include_file_name: true
-    operators:
-      - type: add
-        field: attributes.service
-        value: gitlab
-
-      - type: regex_parser
-        id: extract_gitlab_component
-        regex: '^/var/log/gitlab/(?P<gitlab_component>[^/]+)/'
-        parse_from: attributes["log.file.path"]
-        parse_to: attributes
-
-      - type: add
-        field: attributes.log_type
-        value: gitlab
-
 otel_processors:
   batch: {}
 
@@ -157,32 +125,22 @@ otel_exporters:
           - k8s-staging2.lib.princeton.edu:30374
           - k8s-staging3.lib.princeton.edu:30374
 
-otel_service:
-  pipelines:
-    metrics:
-      receivers:
-        - otlp
-        - prometheus/gitlab
-      processors:
-        - resource/gitlab
-        - batch
-      exporters:
-        - loadbalancing
+otel_service_pipelines:
+  metrics:
+    receivers:
+      - otlp
+      - prometheus/gitlab
+    processors:
+      - resource/gitlab
+      - batch
+    exporters:
+      - loadbalancing
 
-    logs:
-      receivers:
-        - filelog/gitlab
-      processors:
-        - resource/gitlab
-        - batch
-      exporters:
-        - loadbalancing
-
-    traces:
-      receivers:
-        - otlp
-      processors:
-        - resource/gitlab
-        - batch
-      exporters:
-        - loadbalancing
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource/gitlab
+      - batch
+    exporters:
+      - loadbalancing

--- a/playbooks/Gitlab.yml
+++ b/playbooks/Gitlab.yml
@@ -15,6 +15,7 @@
     - ../group_vars/gitlab/{{ runtime_env | default('staging') }}.yml
     - ../group_vars/gitlab/vault.yml
   roles:
+    - role: otel_collector
     - role: gitlab
 
   post_tasks:

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -1,5 +1,32 @@
 ---
 # tasks file for roles/gitlab
+- name: GitLab | Download repo ASCII key
+  ansible.builtin.get_url:
+    url: https://packages.gitlab.com/gpg.key
+    dest: /usr/share/keyrings/gitlab-ce-archive-keyring.asc
+    mode: "0644"
+  register: gitlab_ascii_key
+
+- name: GitLab | Check for existing dearmored key
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/gitlab-ce-archive-keyring.gpg
+  register: gitlab_gpg_keyring
+
+- name: GitLab | Dearmor key into keyring
+  ansible.builtin.command:
+    cmd: >
+      gpg --dearmor --yes
+      -o /usr/share/keyrings/gitlab-ce-archive-keyring.gpg
+      /usr/share/keyrings/gitlab-ce-archive-keyring.asc
+  when: gitlab_ascii_key.changed or not gitlab_gpg_keyring.stat.exists
+
+- name: GitLab | Add APT repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/gitlab-ce-archive-keyring.gpg] https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu jammy main"
+    filename: gitlab_gitlab-ce
+    state: present
+    update_cache: false
+
 - name: Gitlab | Install required packages
   ansible.builtin.apt:
     name:
@@ -42,42 +69,6 @@
   ansible.builtin.command: /usr/bin/certbot certonly --standalone --non-interactive --agree-tos --email lsupport@princeton.edu --server https://acme.sectigo.com/v2/InCommonRSAOV --eab-kid {{ vault_acme_eab_kid }} --eab-hmac-key {{ vault_acme_eab_hmac_key }} --domain {{ inventory_hostname }} --cert-name {{ inventory_hostname }}
   changed_when: false
   when: running_on_server
-
-- name: GitLab | Remove old ascii key if present
-  ansible.builtin.file:
-    path: /usr/share/keyrings/gitlab-ce.gpg
-    state: absent
-
-- name: GitLab | Download repo ASCII key
-  ansible.builtin.get_url:
-    url: https://packages.gitlab.com/gpg.key
-    dest: /usr/share/keyrings/gitlab-ce-archive-keyring.asc
-    mode: "0644"
-
-- name: GitLab | Dearmor key into keyring
-  ansible.builtin.command:
-    cmd: >
-      gpg --dearmor
-      -o /usr/share/keyrings/gitlab-ce-archive-keyring.gpg
-      /usr/share/keyrings/gitlab-ce-archive-keyring.asc
-  args:
-    creates: /usr/share/keyrings/gitlab-ce-archive-keyring.gpg
-
-- name: GitLab | Add APT repository
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/gitlab-ce-archive-keyring.gpg] https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu jammy main"
-    filename: gitlab_gitlab-ce
-    state: present
-    update_cache: false
-
-- name: Gitlab | Update apt cache after adding repository
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 0
-  register: repo_cache_update
-  retries: 3
-  delay: 5
-  until: repo_cache_update is succeeded
 
 - name: GitLab | install CE package
   ansible.builtin.apt:

--- a/roles/gitlab/templates/gitlab.rb.j2
+++ b/roles/gitlab/templates/gitlab.rb.j2
@@ -27,7 +27,7 @@ gitlab_rails['gitlab_email_enabled'] = true
 gitlab_rails['gitlab_default_theme'] = 2
 gitlab_rails['trusted_proxies'] = [{{ gitlab_trusted_proxies }}]
 gitlab_rails['lfs_enabled'] = true
- gitlab_rails['lfs_storage_path'] = "/var/opt/gitlab/gitlab-rails/shared/lfs-objects"
+gitlab_rails['lfs_storage_path'] = "/var/opt/gitlab/gitlab-rails/shared/lfs-objects"
 gitlab_rails['ldap_enabled'] = false
 gitlab_rails['ldap_servers'] = {
   'main' => {
@@ -69,6 +69,37 @@ gitlab_rails['backup_upload_connection'] = {
 }
 gitlab_rails['backup_upload_remote_directory'] = '{{ gitlab_google_bucket }}'
 gitlab_rails['backup_keep_time'] = 2419200
+################################################################################
+## Telemetry / Prometheus exporters
+################################################################################
+prometheus_monitoring['enable'] = true
+
+## GitLab application exporter
+gitlab_exporter['enable'] = true
+gitlab_exporter['listen_address'] = '127.0.0.1'
+gitlab_exporter['listen_port'] = 9168
+
+## Host metrics
+node_exporter['enable'] = true
+node_exporter['listen_address'] = '127.0.0.1:9100'
+
+## Redis metrics
+redis_exporter['enable'] = true
+redis_exporter['listen_address'] = '127.0.0.1:9121'
+
+## PostgreSQL metrics
+postgres_exporter['enable'] = true
+postgres_exporter['listen_address'] = '127.0.0.1:9187'
+
+## Puma metrics
+puma['exporter_enabled'] = true
+puma['exporter_address'] = '127.0.0.1'
+puma['exporter_port'] = 8083
+
+## Sidekiq metrics
+sidekiq['metrics_enabled'] = true
+sidekiq['listen_address'] = '127.0.0.1'
+sidekiq['listen_port'] = 8082
 
 ## OmniAuth common settings
 {% set _external_url = 'https://' ~ gitlab_loadbalancer_domain_name %}


### PR DESCRIPTION
Configure the OpenTelemetry collector to scrape the local GitLab
Prometheus exporters and ship GitLab component logs to SigNoz.

This gives the GitLab staging host host, PostgreSQL, Redis, Puma,
Sidekiq, and GitLab application metrics without exposing exporter
ports outside the VM. It also adds log collection for the main
Omnibus GitLab services under /var/log/gitlab.

The configuration keeps the existing OTLP receivers in place so
future application traces can be accepted if GitLab or related
services emit them.

related to #6234 