### PR TITLE
[orangelight] disable ufw for catalog prod servers

### DIFF
--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -31,6 +31,14 @@
       when: runtime_env | default('staging') == "production"
 
   post_tasks:
+    - name: Production webservers | Disable ufw
+      ansible.builtin.command: ufw disable
+      when:
+        - runtime_env | default('staging') == "production"
+        - "'orangelight_production_webservers' in group_names"
+      register: ufw_disable_result
+      changed_when: "'Firewall stopped and disabled on system startup' in ufw_disable_result.stdout"
+
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
         token: "{{ vault_pul_slack_token }}"


### PR DESCRIPTION
The catalog production webservers should not manage host firewall state with ufw during the orangelight deployment.

Add a post task to the orangelight playbook that disables ufw only when running against the production runtime environment and only for members of the orangelight_production_webservers group.

This keeps the change scoped to the catalog production web hosts and does not affect staging, QA, or indexer hosts.

Closes #7160 when we can successfully replace one of the catalog webservers and the firewall is disabled