### PR TITLE
[nginxplus] Monitor NGINX Plus upstream availability

### DIFF
--- a/group_vars/nginxplus/production.yml
+++ b/group_vars/nginxplus/production.yml
@@ -20,3 +20,6 @@ sites:
   - domain: pcdm.org
     cert_dst: /etc/nginx/conf.d/ssl/certs/pcdm_org_chained.pem
     key_dst: /etc/nginx/conf.d/ssl/private/pcdm_org_priv.key
+
+nginxplus_otel_enabled: false
+nginxplus_otel_stub_status_port: 18080

--- a/roles/nginxplus/defaults/main.yml
+++ b/roles/nginxplus/defaults/main.yml
@@ -86,6 +86,8 @@ nginx_modules:
   otel: false
   xslt: false
 
+nginxplus_otel_enabled: false
+nginxplus_otel_stub_status_port: 18080
 # Install NGINX Amplify.
 # Use your NGINX Amplify API key.
 # Requires access to either the NGINX stub status or the NGINX Plus REST API.

--- a/roles/nginxplus/files/check_nginx_plus_upstreams.py
+++ b/roles/nginxplus/files/check_nginx_plus_upstreams.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 import json
 import sys
 import urllib.error
@@ -26,6 +25,24 @@ def fetch_upstreams():
         return json.loads(response.read().decode("utf-8"))
 
 
+def tally(peers):
+    """Return (total, up, bad, other) counts for a group of peers."""
+    total = len(peers)
+    up = sum(1 for peer in peers if peer.get("state") in GOOD_STATES)
+    bad = sum(1 for peer in peers if peer.get("state") in BAD_STATES)
+    other = total - up - bad
+    return total, up, bad, other
+
+
+def problem_details(peers):
+    """Comma-joined 'name=state' for peers that are bad or in an unexpected state."""
+    return ", ".join(
+        f'{peer.get("name", peer.get("server", "unknown"))}={peer.get("state", "unknown")}'
+        for peer in peers
+        if peer.get("state") in BAD_STATES or peer.get("state") not in GOOD_STATES
+    )
+
+
 def main():
     try:
         upstreams = fetch_upstreams()
@@ -43,46 +60,78 @@ def main():
     total_upstreams = 0
     critical_upstreams = 0
     warning_upstreams = 0
+    backup_serving_upstreams = 0
 
     for upstream_name, upstream in sorted(upstreams.items()):
         peers = upstream.get("peers", [])
         primary_peers = [peer for peer in peers if not peer.get("backup", False)]
+        backup_peers = [peer for peer in peers if peer.get("backup", False)]
 
-        total = len(primary_peers)
-        up = sum(1 for peer in primary_peers if peer.get("state") in GOOD_STATES)
-        bad = sum(1 for peer in primary_peers if peer.get("state") in BAD_STATES)
-        other = total - up - bad
+        p_total, p_up, p_bad, p_other = tally(primary_peers)
+        b_total, b_up, b_bad, b_other = tally(backup_peers)
 
-        bad_peer_details = [
-            f'{peer.get("name", peer.get("server", "unknown"))}={peer.get("state", "unknown")}'
-            for peer in primary_peers
-            if peer.get("state") in BAD_STATES or peer.get("state") not in GOOD_STATES
-        ]
+        bad_primary = problem_details(primary_peers)
+        bad_backup = problem_details(backup_peers)
 
-        metrics = f"upstream_primary_peers={total}|upstream_peers_up={up}|upstream_peers_bad={bad}"
+        metrics = (
+            f"upstream_primary_peers={p_total}|"
+            f"upstream_peers_up={p_up}|"
+            f"upstream_peers_bad={p_bad}|"
+            f"upstream_backup_peers={b_total}|"
+            f"upstream_backup_peers_up={b_up}|"
+            f"upstream_backup_peers_bad={b_bad}"
+        )
 
         service_name = f"NGINX Plus upstream {upstream_name}"
 
-        if total == 0:
+        if p_total == 0 and b_total == 0:
             warning_upstreams += 1
-            emit(1, service_name, metrics, "No primary upstream peers found")
-        elif up == 0:
-            critical_upstreams += 1
-            detail = ", ".join(bad_peer_details) or "no usable primary peers"
-            emit(2, service_name, metrics, f"All primary upstream peers are unavailable: {detail}")
-        elif bad > 0 or other > 0:
+            emit(1, service_name, metrics, "No upstream peers found")
+
+        elif p_up > 0:
+            # At least one primary is usable.
+            if p_bad > 0 or p_other > 0:
+                warning_upstreams += 1
+                emit(
+                    1,
+                    service_name,
+                    metrics,
+                    f"{p_up}/{p_total} primary peers usable; problem peers: {bad_primary}",
+                )
+            else:
+                emit(0, service_name, metrics, f"{p_up}/{p_total} primary peers usable")
+
+        elif b_up > 0:
+            # No usable primaries, but backups are up and serving traffic.
+            # Degraded, not down: warn instead of crit.
+            backup_serving_upstreams += 1
             warning_upstreams += 1
-            detail = ", ".join(bad_peer_details)
-            emit(1, service_name, metrics, f"{up}/{total} primary peers usable; problem peers: {detail}")
+            primary_detail = bad_primary or "no usable primary peers"
+            emit(
+                1,
+                service_name,
+                metrics,
+                f"All primaries unavailable; serving from {b_up}/{b_total} "
+                f"backup peers (primaries: {primary_detail})",
+            )
+
         else:
-            emit(0, service_name, metrics, f"{up}/{total} primary peers usable")
+            # No usable primaries and no usable backups: genuinely down.
+            critical_upstreams += 1
+            primary_detail = bad_primary or "no primary peers"
+            if b_total == 0:
+                detail = f"primaries: {primary_detail}; no backup peers defined"
+            else:
+                detail = f"primaries: {primary_detail}; backups: {bad_backup or 'none usable'}"
+            emit(2, service_name, metrics, f"No usable peers ({detail})")
 
         total_upstreams += 1
 
     summary_metrics = (
         f"upstreams={total_upstreams}|"
         f"critical_upstreams={critical_upstreams}|"
-        f"warning_upstreams={warning_upstreams}"
+        f"warning_upstreams={warning_upstreams}|"
+        f"backup_serving_upstreams={backup_serving_upstreams}"
     )
 
     if critical_upstreams:
@@ -90,14 +139,16 @@ def main():
             2,
             "NGINX Plus upstream summary",
             summary_metrics,
-            f"{critical_upstreams} upstreams have no usable primary peers; {warning_upstreams} degraded",
+            f"{critical_upstreams} upstreams have no usable peers; "
+            f"{warning_upstreams} degraded ({backup_serving_upstreams} serving from backup)",
         )
     elif warning_upstreams:
         emit(
             1,
             "NGINX Plus upstream summary",
             summary_metrics,
-            f"{warning_upstreams} upstreams degraded",
+            f"{warning_upstreams} upstreams degraded "
+            f"({backup_serving_upstreams} serving from backup)",
         )
     else:
         emit(

--- a/roles/nginxplus/tasks/keys/apt-key.yml
+++ b/roles/nginxplus/tasks/keys/apt-key.yml
@@ -64,7 +64,9 @@
 - name: Nginxplus | Add NGINX Plus repository
   ansible.builtin.lineinfile:
     path: /etc/apt/sources.list.d/nginx-plus.list
-    line: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/ubuntu {{ ansible_distribution_release }} nginx-plus"
+    # until we close https://github.com/pulibrary/princeton_ansible/issues/7130 we are holding it at R36 below
+    # line: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/ubuntu {{ ansible_distribution_release }} nginx-plus"
+    line: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/R36/ubuntu {{ ansible_distribution_release }} nginx-plus"
     create: true
     mode: "0644"
   when:

--- a/roles/nginxplus/tasks/modules/install-modules.yml
+++ b/roles/nginxplus/tasks/modules/install-modules.yml
@@ -12,10 +12,14 @@
   when: nginx_modules.image_filter | default(false)
 
 - import_tasks: install-rtmp.yml
-  when: nginx_modules.rtmp | default(false) and nginx_type == "plus"
+  when:
+    - nginx_modules.rtmp | default(false)
+    - nginx_type == "plus"
 
 - import_tasks: install-otel.yml
-  when: nginx_modules.otel | default(false) and nginx_type == "plus"
+  when:
+    - nginx_modules.otel | default(false)
+    - nginx_type == "plus"
 
 - import_tasks: install-xslt.yml
   when: nginx_modules.xslt | default(false)

--- a/roles/nginxplus/tasks/plus/setup-debian.yml
+++ b/roles/nginxplus/tasks/plus/setup-debian.yml
@@ -8,7 +8,9 @@
   become: true
   ansible.builtin.lineinfile:
     path: /etc/apt/sources.list.d/nginx-plus.list
-    line: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/ubuntu {{ ansible_distribution_release }} nginx-plus"
+    # until we close https://github.com/pulibrary/princeton_ansible/issues/7130 we are holding it at R36 below
+    # line: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/ubuntu {{ ansible_distribution_release }} nginx-plus"
+    line: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/R36/ubuntu {{ ansible_distribution_release }} nginx-plus"
     mode: "0644"
     create: true
 

--- a/roles/nginxplus/templates/etc_nginx.conf.j2
+++ b/roles/nginxplus/templates/etc_nginx.conf.j2
@@ -30,7 +30,7 @@ load_module modules/ngx_http_image_filter_module.so;
 load_module modules/ngx_rtmp_module.so;
 {% endif %}
 
-{% if nginx_modules.otel and nginx_type == "plus" %}
+{% if nginx_modules.otel | default(false) | bool and nginx_type == "plus" %}
 load_module modules/ngx_otel_module.so;
 {% endif %}
 
@@ -67,7 +67,7 @@ http {
         '"user_agent": "$http_user_agent",'
         '"request_id": "$request_id",'
         '"traceparent": "$http_traceparent",'
-{% if nginx_modules.otel and nginx_type == "plus" %}
+{% if nginx_modules.otel | default(false) | bool and nginx_type == "plus" %}
         '"trace_id": "$otel_trace_id",'
         '"span_id": "$otel_span_id",'
         '"parent_span_id": "$otel_parent_id",'

--- a/roles/nginxplus/templates/nginx.conf.j2
+++ b/roles/nginxplus/templates/nginx.conf.j2
@@ -28,7 +28,7 @@ load_module modules/ngx_rtmp_module.so;
 {% if nginx_modules.xslt %}
 load_module modules/ngx_http_xslt_filter_module.so;
 {% endif %}
-{% if nginx_modules.otel %}
+{% if nginx_modules.otel | default(false) | bool %}
 load_module modules/ngx_otel_module.so;
 {% endif %}
 {% if nginx_modules.waf and nginx_type == "plus" %}


### PR DESCRIPTION
Refine Checkmk local check for NGINX Plus upstream health using the
node-local NGINX Plus API. The check reports one service per upstream
and a summary service so Checkmk can alert when an entire backend
service is unavailable.

The check distinguishes between primary and backup peers. If at least
one primary peer is usable, the upstream is OK or WARN depending on
whether any peers are unhealthy. If all primaries are unavailable but
backup peers are serving, the upstream reports WARN instead of CRIT.
If no primary or backup peers are usable, the upstream reports CRIT.

closes #7165 