### PR TITLE
[Nomad] Disable DNSMasq caching.

### DIFF
--- a/group_vars/nomad_sandbox.yml
+++ b/group_vars/nomad_sandbox.yml
@@ -1,5 +1,5 @@
 ---
-nomad_http_address: nomad-sandbox.lib.princeton.edu
+nomad_http_address: 'https://nomad-sandbox.lib.princeton.edu'
 nomad_server_group: "nomad_servers_sandbox"
 consul_version: '1.20.3'
 consul_gossip_encryption_key: '{{ vault_consul_gossip_encryption_key }}'

--- a/roles/pul_nomad/files/dnsmasq/dnsmasq.conf
+++ b/roles/pul_nomad/files/dnsmasq/dnsmasq.conf
@@ -572,10 +572,10 @@ group=dnsmasq
 #dhcp-script=/bin/echo
 
 # Set the cachesize here.
-#cache-size=150
+cache-size=0
 
 # If you want to disable negative caching, uncomment this.
-#no-negcache
+no-negcache
 
 # Normally responses which come from /etc/hosts and the DHCP lease
 # file have Time-To-Live set as zero, which conventionally means


### PR DESCRIPTION
We use it for routing, so don't really want to take over caching and it contributed to an outage. This might end up with a bunch more DNS requests to OIT infrastructure, we'll have to see.

The TTL of the DNS records is usually 12 hours.

Closes #7168

This has been deployed.