### PR TITLE
[signoz] move signoz UI behind microk8s ingress

### DIFF
--- a/group_vars/microk8s/production.yml
+++ b/group_vars/microk8s/production.yml
@@ -1,0 +1,6 @@
+---
+microk8s_ingress_allowed_sources:
+  - 128.112.200.245
+  - 128.112.201.34
+
+nfs_allowed_cidr: "128.112.200.0/21"

--- a/group_vars/microk8s/staging.yml
+++ b/group_vars/microk8s/staging.yml
@@ -1,0 +1,7 @@
+---
+microk8s_enable_nfs_addon: true
+microk8s_ingress_allowed_sources:
+  - "172.20.80.13"
+  - "172.20.80.14"
+
+nfs_allowed_cidr: "172.20.80.0/24"

--- a/group_vars/signoz/production.yml
+++ b/group_vars/signoz/production.yml
@@ -1,0 +1,4 @@
+---
+signoz_ingress_enabled: true
+signoz_ingress_host: signoz.lib.princeton.edu
+signoz_ingress_class_name: public

--- a/group_vars/signoz/staging.yml
+++ b/group_vars/signoz/staging.yml
@@ -1,0 +1,4 @@
+---
+signoz_ingress_enabled: true
+signoz_ingress_host: signoz-staging.lib.princeton.edu
+signoz_ingress_class_name: public

--- a/inventory/all_projects/k8s.ini
+++ b/inventory/all_projects/k8s.ini
@@ -3,3 +3,8 @@ k8s-staging1.lib.princeton.edu
 k8s-staging2.lib.princeton.edu
 k8s-staging3.lib.princeton.edu
 k8s-fs-staging.lib.princeton.edu
+[microk8s_production]
+k8s-fs-prod.lib.princeton.edu
+k8s-prod1.lib.princeton.edu
+k8s-prod2.lib.princeton.edu
+k8s-prod3.lib.princeton.edu

--- a/inventory/all_projects/microk8s.ini
+++ b/inventory/all_projects/microk8s.ini
@@ -1,23 +1,47 @@
+[microk8s_production]
+k8s-prod1.lib.princeton.edu
+k8s-prod2.lib.princeton.edu
+k8s-prod3.lib.princeton.edu
+k8s-fs-prod.lib.princeton.edu
+
 [microk8s_staging]
 k8s-staging1.lib.princeton.edu
 k8s-staging2.lib.princeton.edu
 k8s-staging3.lib.princeton.edu
 k8s-fs-staging.lib.princeton.edu
 
-[k8s_microk8s_primary]
+[k8s_microk8s_primary_production]
+k8s-prod1.lib.princeton.edu
+
+[k8s_microk8s_primary_staging]
 k8s-staging1.lib.princeton.edu
 
-[k8s_microk8s_secondaries]
+[k8s_microk8s_secondaries_production]
+k8s-prod2.lib.princeton.edu
+k8s-prod3.lib.princeton.edu
+
+[k8s_microk8s_secondaries_staging]
 k8s-staging2.lib.princeton.edu
 k8s-staging3.lib.princeton.edu
 
-[k8s_microk8s:children]
-k8s_microk8s_primary
-k8s_microk8s_secondaries
+[k8s_microk8s_production:children]
+k8s_microk8s_primary_production
+k8s_microk8s_secondaries_production
 
-[k8s_nfs]
+[k8s_microk8s_staging:children]
+k8s_microk8s_primary_staging
+k8s_microk8s_secondaries_staging
+
+[k8s_nfs_production]
+k8s-fs-prod.lib.princeton.edu
+
+[k8s_nfs_staging]
 k8s-fs-staging.lib.princeton.edu
 
 [k8s_staging:children]
-k8s_microk8s
-k8s_nfs
+k8s_microk8s_staging
+k8s_nfs_staging
+
+[k8s_production:children]
+k8s_microk8s_production
+k8s_nfs_production

--- a/inventory/by_environment/production.ini
+++ b/inventory/by_environment/production.ini
@@ -16,6 +16,8 @@ figgy_production
 fred_production
 geniza_production
 gitlab_production
+k8s_nfs_production
+k8s_microk8s_primary_production
 lae_production
 lib_jobs_production
 libsftp_production

--- a/inventory/by_environment/production.ini
+++ b/inventory/by_environment/production.ini
@@ -23,6 +23,7 @@ lib_fs_production
 loadtest_production
 lockers_and_study_spaces_production
 mflux_training
+microk8s_production
 mysql_production
 nomad_production
 oawaiver_production

--- a/inventory/by_environment/staging.ini
+++ b/inventory/by_environment/staging.ini
@@ -17,6 +17,8 @@ gcploadbalancer_staging
 geniza_staging
 gitlab_staging
 iiif_manifests
+k8s_microk8s_primary_staging
+k8s_nfs_staging
 lae_staging
 lib_jobs_staging
 libsftp_staging

--- a/playbooks/signoz.yml
+++ b/playbooks/signoz.yml
@@ -24,5 +24,7 @@
   hosts: k8s_microk8s_primary
   remote_user: pulsys
   become: true
+  vars_files:
+    - ../group_vars/signoz/staging.yml
   roles:
     - role: signoz_k8s

--- a/playbooks/signoz.yml
+++ b/playbooks/signoz.yml
@@ -1,30 +1,36 @@
 ---
 - name: Configure k8s NFS
-  hosts: k8s_nfs
+  hosts: k8s_nfs_{{ runtime_env | default('staging') }}
   remote_user: pulsys
   become: true
+  vars_files:
+    - ../group_vars/microk8s/{{ runtime_env | default('staging') }}.yml
   roles:
     - role: k8s_nfs
 
 - name: Configure Microk8s Cluster
-  hosts: k8s_microk8s_primary
+  hosts: k8s_microk8s_{{ runtime_env | default('staging') }}
   remote_user: pulsys
   become: true
+  vars_files:
+    - ../group_vars/microk8s/{{ runtime_env | default('staging') }}.yml
   roles:
     - role: microk8s_cluster
 
 - name: Configure Microk8s Provisioner
-  hosts: k8s_microk8s_primary
+  hosts: k8s_microk8s_primary_{{ runtime_env | default('staging') }}
   remote_user: pulsys
   become: true
+  vars_files:
+    - ../group_vars/microk8s/{{ runtime_env | default('staging') }}.yml
   roles:
     - role: k8s_nfs_provisioner
 
 - name: Deploy Signoz
-  hosts: k8s_microk8s_primary
+  hosts: k8s_microk8s_primary_{{ runtime_env | default('staging') }}
   remote_user: pulsys
   become: true
   vars_files:
-    - ../group_vars/signoz/staging.yml
+    - ../group_vars/signoz/{{ runtime_env | default('staging') }}.yml
   roles:
     - role: signoz_k8s

--- a/roles/microk8s_cluster/defaults/main.yml
+++ b/roles/microk8s_cluster/defaults/main.yml
@@ -20,15 +20,24 @@ microk8s_base_addons:
   - dns
   - rbac
   - metrics-server
+  - ingress
 
 microk8s_enable_ha_cluster: true
-microk8s_enable_nfs_addon: true
 
 microk8s_install_kubectl_snap: true
 
 microk8s_manage_admin_home_owner: true
 
 microk8s_manage_ufw: true
+
+microk8s_ingress_allowed_sources:
+  - "172.20.80.13"
+  - "172.20.80.14"
+
+microk8s_ingress_ufw_rules:
+  - port: "80"
+    proto: tcp
+    comment: "MicroK8s ingress HTTP"
 
 microk8s_cluster_allowed_cidr:
   - "172.20.80.0/24"
@@ -71,6 +80,14 @@ microk8s_ufw_rules:
     proto: tcp
     comment: "SigNoz OTLP HTTP NodePort"
 
+  - port: "32080"
+    proto: tcp
+    comment: "SigNoz UI NodePort"
+
+  - port: "80"
+    proto: tcp
+    comment: "MicroK8s ingress HTTP"
+
 # Adjust this to the staging subnet if you want to restrict it.
 nfs_export_allowed_clients: "*"
 
@@ -96,36 +113,3 @@ nfs_ufw_rules:
   - port: "111"
     proto: udp
     comment: "rpcbind UDP"
-
-microk8s_ufw_rules:
-  - port: "16443"
-    proto: tcp
-    comment: "MicroK8s Kubernetes API"
-
-  - port: "25000"
-    proto: tcp
-    comment: "MicroK8s cluster agent join endpoint"
-
-  - port: "10250"
-    proto: tcp
-    comment: "MicroK8s kubelet"
-
-  - port: "12379"
-    proto: tcp
-    comment: "MicroK8s dqlite"
-
-  - port: "19001"
-    proto: tcp
-    comment: "MicroK8s dqlite"
-
-  - port: "4789"
-    proto: udp
-    comment: "MicroK8s VXLAN pod networking"
-
-  - port: "179"
-    proto: tcp
-    comment: "MicroK8s Calico BGP if used"
-
-  - port: "32080"
-    proto: tcp
-    comment: "SigNoz UI NodePort"

--- a/roles/microk8s_cluster/defaults/main.yml
+++ b/roles/microk8s_cluster/defaults/main.yml
@@ -9,10 +9,10 @@ microk8s_admin_home: "/home/{{ microk8s_admin_user }}"
 # microk8s_snap_channel: "1.32/stable"
 microk8s_snap_channel: ""
 
-microk8s_primary_group: k8s_microk8s_primary
-microk8s_secondary_group: k8s_microk8s_secondaries
-microk8s_cluster_group: k8s_microk8s
-microk8s_nfs_group: k8s_nfs
+microk8s_primary_group:  "k8s_microk8s_primary_{{ runtime_env | default('staging') }}"
+microk8s_secondary_group: "k8s_microk8s_secondaries_{{ runtime_env | default('staging') }}"
+microk8s_cluster_group: "k8s_microk8s_{{ runtime_env | default('staging') }}"
+microk8s_nfs_group: "k8s_nfs_{{ runtime_env | default('staging') }}"
 
 microk8s_enable_community_addons: true
 microk8s_enable_nfs_addon: false
@@ -29,10 +29,6 @@ microk8s_install_kubectl_snap: true
 microk8s_manage_admin_home_owner: true
 
 microk8s_manage_ufw: true
-
-microk8s_ingress_allowed_sources:
-  - "172.20.80.13"
-  - "172.20.80.14"
 
 microk8s_ingress_ufw_rules:
   - port: "80"
@@ -79,10 +75,6 @@ microk8s_ufw_rules:
   - port: "32318"
     proto: tcp
     comment: "SigNoz OTLP HTTP NodePort"
-
-  - port: "32080"
-    proto: tcp
-    comment: "SigNoz UI NodePort"
 
   - port: "80"
     proto: tcp

--- a/roles/microk8s_cluster/tasks/firewall.yml
+++ b/roles/microk8s_cluster/tasks/firewall.yml
@@ -24,6 +24,20 @@
     - microk8s_ufw_binary.stat.exists
     - "'Status: active' in microk8s_ufw_status.stdout"
 
+- name: Allow MicroK8s ingress traffic from load balancers
+  community.general.ufw:
+    rule: allow
+    from_ip: "{{ item.0 }}"
+    port: "{{ item.1.port }}"
+    proto: "{{ item.1.proto }}"
+    comment: "{{ item.1.comment }} from {{ item.0 }}"
+  loop: "{{ microk8s_ingress_allowed_sources | product(microk8s_ingress_ufw_rules) | list }}"
+  when:
+    - microk8s_manage_ufw | bool
+    - microk8s_ufw_binary.stat.exists
+    - "'Status: active' in microk8s_ufw_status.stdout"
+    - microk8s_ingress_allowed_sources | length > 0
+
 - name: Reload UFW
   community.general.ufw:
     state: reloaded

--- a/roles/microk8s_cluster/tasks/primary.yml
+++ b/roles/microk8s_cluster/tasks/primary.yml
@@ -7,6 +7,12 @@
     - "'is already enabled' not in microk8s_enable_addon.stdout"
   loop: "{{ microk8s_base_addons }}"
 
+- name: MicroK8s | Enable ingress addon
+  ansible.builtin.command: microk8s enable ingress
+  register: microk8s_enable_ingress
+  changed_when: "'already enabled' not in microk8s_enable_ingress.stdout"
+  when: inventory_hostname in groups[microk8s_primary_group] | default([])
+
 - name: Enable MicroK8s community addon repository
   ansible.builtin.command: microk8s enable community
   register: microk8s_enable_community

--- a/roles/nginxplus/files/conf/http/dev/staging_signoz.conf
+++ b/roles/nginxplus/files/conf/http/dev/staging_signoz.conf
@@ -2,9 +2,9 @@ upstream signoz-k8s {
     least_conn;
     zone signoz-k8s 64k;
 
-    server k8s-staging1.lib.princeton.edu:32080 max_fails=3 fail_timeout=10s;
-    server k8s-staging2.lib.princeton.edu:32080 max_fails=3 fail_timeout=10s;
-    server k8s-staging3.lib.princeton.edu:32080 max_fails=3 fail_timeout=10s;
+    server k8s-staging1.lib.princeton.edu:80 max_fails=3 fail_timeout=10s;
+    server k8s-staging2.lib.princeton.edu:80 max_fails=3 fail_timeout=10s;
+    server k8s-staging3.lib.princeton.edu:80 max_fails=3 fail_timeout=10s;
 }
 
 map $http_upgrade $connection_upgrade {

--- a/roles/nginxplus/files/conf/http/signoz_prod.conf
+++ b/roles/nginxplus/files/conf/http/signoz_prod.conf
@@ -1,0 +1,47 @@
+upstream signoz-k8s {
+    least_conn;
+    zone signoz-k8s 64k;
+
+    server k8s-prod1.lib.princeton.edu:80 max_fails=3 fail_timeout=10s;
+    server k8s-prod2.lib.princeton.edu:80 max_fails=3 fail_timeout=10s;
+    server k8s-prod3.lib.princeton.edu:80 max_fails=3 fail_timeout=10s;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    server_name signoz.lib.princeton.edu;
+
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name signoz.lib.princeton.edu;
+
+    ssl_certificate     /etc/letsencrypt/live/signoz.lib/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/signoz.lib/privkey.pem;
+
+    client_max_body_size 50m;
+
+    location / {
+        proxy_pass http://signoz-k8s;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP         $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}

--- a/roles/signoz_k8s/defaults/main.yml
+++ b/roles/signoz_k8s/defaults/main.yml
@@ -8,6 +8,14 @@ signoz_chart_repo_url: https://charts.signoz.io
 signoz_chart_ref: signoz/signoz
 signoz_chart_version: ""
 
+# SigNoz ingress
+signoz_ingress_enabled: false
+signoz_ingress_name: signoz
+signoz_ingress_namespace: "{{ signoz_namespace }}"
+signoz_ingress_class_name: public
+signoz_ingress_service_name: "{{ signoz_release_name }}"
+signoz_ingress_service_port: 8080
+
 signoz_storage_class: k8s-fs-nfs
 signoz_service_type: NodePort
 signoz_http_node_port: 32080

--- a/roles/signoz_k8s/tasks/main.yml
+++ b/roles/signoz_k8s/tasks/main.yml
@@ -85,6 +85,21 @@
   delay: 10
   until: signoz_service_lookup.rc == 0
 
+- name: SigNoz | Write ingress manifest
+  ansible.builtin.template:
+    src: ingress.yaml.j2
+    dest: /etc/signoz/ingress.yaml
+    owner: root
+    group: root
+    mode: "0644"
+  when: signoz_ingress_enabled | default(false) | bool
+
+- name: SigNoz | Apply ingress
+  ansible.builtin.command: microk8s kubectl apply -f /etc/signoz/ingress.yaml
+  changed_when: "'configured' in signoz_apply_ingress.stdout or 'created' in signoz_apply_ingress.stdout"
+  register: signoz_apply_ingress
+  when: signoz_ingress_enabled | default(false) | bool
+
 - name: Check SigNoz pods
   ansible.builtin.command: "microk8s kubectl -n {{ signoz_namespace }} get pods"
   changed_when: false

--- a/roles/signoz_k8s/templates/ingress.yaml.j2
+++ b/roles/signoz_k8s/templates/ingress.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ signoz_ingress_name }}
+  namespace: {{ signoz_ingress_namespace }}
+spec:
+  ingressClassName: {{ signoz_ingress_class_name }}
+  rules:
+    - host: {{ signoz_ingress_host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ signoz_ingress_service_name }}
+                port:
+                  number: {{ signoz_ingress_service_port }}


### PR DESCRIPTION
Replace the static SigNoz UI NodePort with a ClusterIP service and Kubernetes Ingress. The external nginxplus HA load balancers now target the MicroK8s ingress listener on each k8s-staging node instead of a hardcoded SigNoz service NodePort.

closes #7113 