### PR TITLE
removes Denzil from authorized keys

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -10,7 +10,6 @@ deploy_user_github_keys:
   - https://github.com/carolyncole.keys
   - https://github.com/christinach.keys
   - https://github.com/cwulfman.keys
-  - https://github.com/dphillips-39.keys
   - https://github.com/eliotjordan.keys
   - https://github.com/escowles.keys
   - https://github.com/hackartisan.keys


### PR DESCRIPTION
Denzil successfully completed his Fellowship and has accepted a position elsewhere. This PR removes his keys from our authorized keys list.