### PR TITLE
[Postgres] Configure pg_hba as a client task

### DIFF
--- a/roles/postgresql/tasks/client.yml
+++ b/roles/postgresql/tasks/client.yml
@@ -1,5 +1,5 @@
 ---
-- name: PostgreSQL | create remote postgresql database
+- name: Create remote postgresql database
   community.postgresql.postgresql_db:
     name: '{{ application_db_name }}'
     port: '{{ postgres_port }}'
@@ -13,7 +13,7 @@
     # - not postgresql_is_local
   run_once: true
 
-- name: PostgreSQL | create postgresql db users
+- name: Create postgresql db users
   community.postgresql.postgresql_user:
     name: '{{ application_dbuser_name }}'
     port: '{{ postgres_port }}'
@@ -30,7 +30,7 @@
   changed_when: false
   run_once: true
 
-- name: PostgreSQL | change postgresql database owner
+- name: Change postgresql database owner
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
     port: "{{ postgres_port }}"
@@ -45,3 +45,13 @@
     # - not postgresql_is_local
   changed_when: false
   run_once: true
+
+- name: Configure pg_hba for client connections to postgres server
+  ansible.builtin.lineinfile:
+    path: '/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf'
+    line: 'host  {{ pg_hba_postgresql_database }}      {{ pg_hba_postgresql_user }} {{ ansible_default_ipv4.address }}/32       {{ pg_hba_method }}'
+  delegate_to: "{{ postgres_host | default(inventory_hostname, true) }}"
+  when:
+    - running_on_server | bool
+    - (postgres_host | default('', true) | length) > 0
+  notify: reload remote postgres


### PR DESCRIPTION
In #7191 we divided the server tasks from the client tasks. However, we missed the task that configures pg_hba for client access. This won't break existing systems, but it will cause a failure the next time we rebuild a server from scratch.

This PR reinstates the task to configure the pg_hba file as part of a client-side run of the postgresql role. 

It also removes the `PostgreSQL` prefix from task names, since Ansible now prints out the role name when it runs, so the prefix is unnecessary. 