### PR TITLE
[Postgres] Use non-boolean vars

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -114,8 +114,6 @@ maria_db_cluster_host: "{{ vault_maria_db_cluster_host }}"
 # change the libwww role to use this???
 percona_xtra_cluster_host: "maria-staging"
 running_on_server: true
-postgresql_is_cloud: false
-postgresql_is_local: false
 slack_alerts_channel: "#ansible-alerts"
 # active directory bind info
 sssd_bind_dn: "{{ vault_sssd_bind_dn }}"

--- a/group_vars/allsearch_api/common.yml
+++ b/group_vars/allsearch_api/common.yml
@@ -11,7 +11,7 @@ passenger_app_env: "{{ rails_app_env }}"
 rails_app_name: "allsearch_api"
 rails_app_directory: "allsearch_api"
 
-postgresql_is_local: false
+postgres_db_type: client
 postgres_version: 15
 postgres_admin_user: postgres
 

--- a/group_vars/ansible_tower/main.yml
+++ b/group_vars/ansible_tower/main.yml
@@ -17,8 +17,9 @@ pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
+postgres_db_type: client
 postgres_version: 13
+# when we upgrade to 16 for realsies, set type to server
 ansible_tower_db_host: "{{ postgres_host }}"
 ansible_tower_db_name: 'ansible-tower'
 ansible_tower_db_user: 'ansible-tower'

--- a/group_vars/approvals/common.yml
+++ b/group_vars/approvals/common.yml
@@ -5,3 +5,4 @@ ruby_version_override: "ruby-3.3.6"
 passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
+postgres_db_type: client

--- a/group_vars/approvals/production.yml
+++ b/group_vars/approvals/production.yml
@@ -1,6 +1,5 @@
 ---
 postgres_version: 15
-postgres_is_local: false
 passenger_server_name: "lib-approvals-prod2.princeton.edu"
 passenger_app_env: "production"
 approvals_secret_key_base: '{{ vault_prod_approvals_secret_key_base }}'

--- a/group_vars/approvals/staging.yml
+++ b/group_vars/approvals/staging.yml
@@ -2,7 +2,6 @@
 passenger_server_name: "{{ inventory_hostname }}"
 passenger_app_env: "staging"
 approvals_secret_key_base: '{{ vault_staging_approvals_secret_key_base }}'
-postgres_is_local: false
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 app_db_host: '{{ postgres_host }}'
 app_db_name: '{{ vault_approvals_staging_db_name }}'

--- a/group_vars/bibdata/common.yml
+++ b/group_vars/bibdata/common.yml
@@ -3,6 +3,7 @@ desired_nodejs_version: v22.14.0
 passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
+postgres_db_type: client
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.4.4"
 bundler_version: "2.6.3"

--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -136,7 +136,6 @@ db_clusteradmin_user: "postgres"
 postgres_port: "{{ bibdata_db_port }}"
 postgres_admin_user: "{{ db_clusteradmin_user }}"
 postgres_admin_password: "{{ db_clusteradmin_password }}"
-postgresql_is_local: false
 
 datadog_api_key: "{{ vault_datadog_key }}"
 datadog_config:

--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -136,5 +136,4 @@ db_clusteradmin_user: "postgres"
 postgres_port: "{{ bibdata_db_port }}"
 postgres_admin_user: "{{ db_clusteradmin_user }}"
 postgres_admin_password: "{{ db_clusteradmin_password }}"
-postgresql_is_local: false
 timezone: "America/New_York"

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -149,7 +149,6 @@ db_clusteradmin_user: "postgres"
 postgres_port: "{{ bibdata_db_port }}"
 postgres_admin_user: "{{ db_clusteradmin_user }}"
 postgres_admin_password: "{{ db_clusteradmin_password }}"
-postgresql_is_local: false
 timezone: "America/New_York"
 # signoz
 otel_default_resource_attributes:

--- a/group_vars/dpul/production.yml
+++ b/group_vars/dpul/production.yml
@@ -32,7 +32,7 @@ rails_app_dependencies:
   - memcached
   - libidn-dev
 sidekiq_worker_threads: 3
-postgresql_is_local: false
+postgres_db_type: client
 dpul_db_name: 'dpul_production'
 dpul_db_user: 'dpul'
 dpul_db_password: '{{ vault_dpul_db_password }}'

--- a/group_vars/dpul/staging.yml
+++ b/group_vars/dpul/staging.yml
@@ -21,7 +21,7 @@ pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
 postgres_port: "5432"
-postgresql_is_local: false
+postgres_db_type: client
 passenger_server_name: "dpul-staging.princeton.edu"
 passenger_app_root: "/opt/dpul/current/public"
 passenger_app_env: "staging"

--- a/group_vars/dss/common.yml
+++ b/group_vars/dss/common.yml
@@ -6,3 +6,4 @@ ruby_yjit: true
 passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
+postgres_db_type: client

--- a/group_vars/dss/production.yml
+++ b/group_vars/dss/production.yml
@@ -7,7 +7,6 @@ pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
 application_db_name: "{{ dss_db_name }}"
 application_dbuser_name: "{{ dss_db_user }}"
 application_dbuser_password: "{{ dss_db_password }}"

--- a/group_vars/dss/staging.yml
+++ b/group_vars/dss/staging.yml
@@ -7,7 +7,6 @@ pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
 application_db_name: "{{ dss_db_name }}"
 application_dbuser_name: "{{ dss_db_user }}"
 application_dbuser_password: "{{ dssdb_password }}"

--- a/group_vars/figgy/common.yml
+++ b/group_vars/figgy/common.yml
@@ -20,7 +20,7 @@ passenger_max_pool_size: '12'
 passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
-postgresql_is_local: false
+postgres_db_type: client
 postgres_version: 15
 project_db_host: '{{postgres_host}}'
 rabbitmq_user: '{{figgy_rabbit_user}}'

--- a/group_vars/lae/production.yml
+++ b/group_vars/lae/production.yml
@@ -18,7 +18,7 @@ passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 desired_nodejs_version: "v22.10.0"
-postgresql_is_local: false
+postgres_db_type: client
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"
 rails_app_symlinks: []

--- a/group_vars/lae/staging.yml
+++ b/group_vars/lae/staging.yml
@@ -27,7 +27,7 @@ passenger_ruby: "/usr/local/bin/ruby"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 desired_nodejs_version: "v22.10.0"
-postgresql_is_local: false
+postgres_db_type: client
 rails_app_name: "lae-blacklight"
 rails_app_directory: "lae-blacklight"
 rails_app_symlinks: []

--- a/group_vars/lib_jobs/common.yml
+++ b/group_vars/lib_jobs/common.yml
@@ -13,7 +13,7 @@ application_dbuser_name: '{{ app_db_user }}'
 application_dbuser_password: '{{ app_db_password }}'
 application_host_protocol: 'https'
 install_nodejs: false
-postgresql_is_local: false
+postgres_db_type: client
 open_marc_records_directory: 'open_marc_records'
 install_ruby_from_source: true
 passenger_ruby: /usr/local/bin/ruby

--- a/group_vars/lockers_and_study_spaces/common.yml
+++ b/group_vars/lockers_and_study_spaces/common.yml
@@ -4,3 +4,4 @@ passenger_ruby: "/usr/local/bin/ruby"
 ruby_version_override: "ruby-3.4.1"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"
+postgres_db_type: client

--- a/group_vars/lockers_and_study_spaces/production.yml
+++ b/group_vars/lockers_and_study_spaces/production.yml
@@ -7,7 +7,6 @@ pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
-postgres_is_local: false
 passenger_server_name: "lockers-and-study-spaces-prod1.princeton.edu"
 passenger_app_env: "production"
 lockers_secret_key_base: '{{ vault_prod_lockers_and_study_spaces_secret_key_base }}'

--- a/group_vars/lockers_and_study_spaces/staging.yml
+++ b/group_vars/lockers_and_study_spaces/staging.yml
@@ -1,6 +1,5 @@
 ---
 postgres_host: 'lib-postgres-staging1.princeton.edu'
-postgresql_is_local: false
 postgres_version: 15
 postgres_admin_user: "postgres"
 pg_hba_contype: "host"
@@ -8,7 +7,6 @@ pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
-postgres_is_local: false
 passenger_server_name: "lockers-and-study-spaces-staging2.princeton.edu"
 passenger_app_env: "staging"
 lockers_secret_key_base: '{{ vault_staging_lockers_and_study_spaces_secret_key_base }}'

--- a/group_vars/oawaiver/production.yml
+++ b/group_vars/oawaiver/production.yml
@@ -10,7 +10,7 @@ solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"
 
 # PostgreSQL
 postgres_host: "lib-postgres-prod1.princeton.edu"
-postgresql_is_local: false
+postgres_db_type: client
 postgres_admin_password: "{{ vault_postgres_admin_password }}"
 postgres_port: "{{ app_db_port }}"
 postgres_admin_user: "postgres"

--- a/group_vars/oawaiver/staging.yml
+++ b/group_vars/oawaiver/staging.yml
@@ -17,7 +17,7 @@ solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"
 
 # PostgreSQL
 postgres_host: "lib-postgres-staging1.princeton.edu"
-postgresql_is_local: false
+postgres_db_type: client
 postgres_admin_password: "{{ vault_postgres_admin_password }}"
 postgres_port: "{{ app_db_port }}"
 postgres_admin_user: "postgres"

--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -43,7 +43,7 @@ pg_hba_method: "md5"
 pg_hba_postgresql_database: "all"
 pg_hba_postgresql_user: "all"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
+postgres_db_type: client
 postgres_version: 15
 # logrotation
 orangelight_logrotate_rules:

--- a/group_vars/orcid/main.yml
+++ b/group_vars/orcid/main.yml
@@ -1,5 +1,5 @@
 ---
-postgresql_is_local: false
+postgres_db_type: client
 postgres_port: "5432"
 postgres_admin_user: 'postgres'
 postgres_admin_password: '{{ vault_postgres_admin_password }}'

--- a/group_vars/pdc_describe/main.yml
+++ b/group_vars/pdc_describe/main.yml
@@ -1,5 +1,5 @@
 ---
-postgresql_is_local: false
+postgres_db_type: client
 postgres_port: "5432"
 postgres_admin_user: 'postgres'
 postgres_admin_password: '{{ vault_postgres_admin_password }}'

--- a/group_vars/pdc_discovery/main.yml
+++ b/group_vars/pdc_discovery/main.yml
@@ -1,6 +1,6 @@
 ---
 
-postgresql_is_local: false
+postgres_db_type: client
 postgres_port: "5432"
 postgres_admin_user: 'postgres'
 postgres_admin_password: '{{ vault_postgres_admin_password }}'

--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -21,7 +21,7 @@ postgresql_users:
   - name: datadog
     password: "{{ vault_datadog_db_password }}"
     db: "postgres"
-postgresql_is_local: true
+postgres_db_type: server
 postgresadmin: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_port: 5432

--- a/group_vars/postgresql/qa.yml
+++ b/group_vars/postgresql/qa.yml
@@ -17,7 +17,7 @@ postgresql_users:
     db: "postgres"
     priv: "ALL"
     role_attr_flags: "SUPERUSER"
-postgresql_is_local: true
+postgres_db_type: server
 postgresadmin: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_port: 5432

--- a/group_vars/postgresql/staging.yml
+++ b/group_vars/postgresql/staging.yml
@@ -17,7 +17,7 @@ postgresql_users:
     db: "postgres"
     priv: "ALL"
     role_attr_flags: "SUPERUSER"
-postgresql_is_local: true
+postgres_db_type: server
 postgresadmin: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_port: 5432

--- a/group_vars/pulfalight/production.yml
+++ b/group_vars/pulfalight/production.yml
@@ -12,7 +12,6 @@ pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
 pg_hba_method: "md5"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
 solr_cores:
   - "{{ pulfalight_solr_core }}"
 solr_mirror: "https://pulmirror.princeton.edu/mirror/solr/dist"
@@ -98,7 +97,7 @@ rails_app_vars:
     value: "{{ vault_pulfalight_ask_a_question_queue }}"
   - name: LIBANSWERS_CLIENT_ID
     value: "{{ vault_pulfalight_lib_answers_client_id }}"
-  - name: LIBANSWERS_CLIENT_SECRET       
+  - name: LIBANSWERS_CLIENT_SECRET
     value: "{{ vault_pulfalight_lib_answers_client_secret }}"
 sidekiq_worker_name: pulfalight-workers
 sidekiq_worker_threads: 3

--- a/group_vars/pulfalight/shared.yml
+++ b/group_vars/pulfalight/shared.yml
@@ -1,3 +1,4 @@
 ---
 # vars file for roles/pulfalight
 ruby_version_override: "ruby-3.4.8"
+postgres_db_type: client

--- a/group_vars/pulmap/production.yml
+++ b/group_vars/pulmap/production.yml
@@ -41,7 +41,7 @@ pg_hba_method: "md5"
 pg_hba_postgresql_database: "all"
 pg_hba_postgresql_user: "all"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
+postgres_db_type: client
 redis_bind_interface: '0.0.0.0'
 rails_app_vars:
   - name: PULMAP_SOLR_URL

--- a/group_vars/pulmap/staging.yml
+++ b/group_vars/pulmap/staging.yml
@@ -40,7 +40,7 @@ pg_hba_method: "md5"
 pg_hba_postgresql_database: "all"
 pg_hba_postgresql_user: "all"
 pg_hba_source: "{{ ansible_host }}/32"
-postgresql_is_local: false
+postgres_db_type: client
 rails_app_vars:
   - name: PULMAP_SOLR_URL
     value: "http://{{ pulmap_solr_host }}:8983/solr/{{ pulmap_solr_collection }}"

--- a/group_vars/repec/production.yml
+++ b/group_vars/repec/production.yml
@@ -2,7 +2,7 @@
 
 postgres_host: "lib-postgres-prod1.princeton.edu"
 postgres_version: 15
-postgresql_is_local: false
+postgres_db_type: client
 postgres_admin_user: 'postgres'
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 

--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -1,7 +1,7 @@
 ---
 ansible_python_interpreter: /usr/bin/python3
 
-postgresql_is_local: false
+postgres_db_type: client
 postgres_version: 15
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 pg_hba_contype: "host"

--- a/group_vars/whichiso/main.yml
+++ b/group_vars/whichiso/main.yml
@@ -1,5 +1,5 @@
 ---
-postgresql_is_local: false
+postgres_db_type: client
 postgres_port: "5432"
 postgres_admin_user: 'postgres'
 postgres_admin_password: '{{ vault_postgres_admin_password }}'

--- a/roles/postgresql/README.md
+++ b/roles/postgresql/README.md
@@ -22,7 +22,7 @@ These vars provide connection information to the database server. By convention 
   postgres_admin_password: '{{ vault_postgres_admin_password }}'
   postgres_port: 5432
   postgres_admin_user: "{{ postgresadmin }}"
-  postgresql_is_local: true  # rarely true unless one is testing creating a new db server
+  postgres_db_type: server # set to 'client' to create a db on an existing server
   postgres_version: 15  # on server side this will install the postgresql server version
 ```
 
@@ -44,7 +44,6 @@ These vars provide connection information for the database you want to create or
   application_dbuser_name: "{{ ol_db_user }}"
   application_dbuser_password: "{{ ol_db_password }}"
   application_dbuser_role_attr_flags: "CREATEDB"
-  postgresql_is_local: "false" # should always be false
   postgres_version: 15  # on application side this will install the postgresql client version
 ```
 

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -2,8 +2,9 @@
 postgres_host: null
 # PostgreSQL-related settings
 postgres_max_connections: 400
-postgresql_is_local: true
-# postgresql_is_local: "{{ 'true' if project_db_host | search( 'localhost|127\\.0\\.0\\.1|^/') else 'false' }}"
+postgres_db_type: server
+# by default we build a database server
+# group vars set 'postgres_db_type: client'  to create a db on an existing server
 application_dbuser_role_attr_flags: ''
 # https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
 # 1/4 memory to Shared Buffers

--- a/roles/postgresql/handlers/main.yml
+++ b/roles/postgresql/handlers/main.yml
@@ -10,14 +10,12 @@
   # is this pair of conditions functionally the same?
   when:
     - (postgres_host | default('', true) | length) > 0
-    - not (postgresql_is_local | bool)
 
 - name: reload local postgres
   ansible.builtin.service:
     name: "{{ postgres_service_name | default(postgresql) }}"
     state: reloaded
   become: true
-  when: postgresql_is_local | bool
 
 - name: save repmgr log
   ansible.builtin.copy:

--- a/roles/postgresql/tasks/client.yml
+++ b/roles/postgresql/tasks/client.yml
@@ -10,7 +10,6 @@
     state: 'present'
   when:
     - running_on_server
-    # - not postgresql_is_local
   run_once: true
 
 - name: PostgreSQL | create postgresql db users
@@ -26,7 +25,6 @@
     state: 'present'
   when:
     - running_on_server
-    # - not postgresql_is_local
   changed_when: false
   run_once: true
 
@@ -42,6 +40,5 @@
     owner: "{{ application_dbuser_name }}"
   when:
     - running_on_server
-    # - not postgresql_is_local
   changed_when: false
   run_once: true

--- a/roles/postgresql/tasks/create_users.yml
+++ b/roles/postgresql/tasks/create_users.yml
@@ -8,7 +8,6 @@
     role_attr_flags: "{{ item.role_attr_flags | default(omit) }}"
   when:
     - running_on_server
-    - postgresql_is_local | bool
     - postgresql_users | length > 0
   become: true
   become_user: "{{ postgres_admin_user }}"
@@ -26,7 +25,6 @@
     state: "present"
   when:
     - running_on_server
-    - postgresql_is_local | bool
     - postgresql_users | length > 0
     - item.priv is defined
   become: true

--- a/roles/postgresql/tasks/install_debian.yml
+++ b/roles/postgresql/tasks/install_debian.yml
@@ -46,8 +46,6 @@
     state: present
   loop:
     - "{{ postgres_packages }}"
-  when:
-    - postgresql_is_local | bool
 
 - name: PostgreSQL | Prefer PGDG PostgreSQL packages
   ansible.builtin.copy:
@@ -74,8 +72,6 @@
 
 - name: Ubuntu | add extensions
   ansible.builtin.import_tasks: extensions.yml
-  when:
-    - postgresql_is_local | bool
 
 - name: Ubuntu | install configuration file
   ansible.builtin.template:
@@ -85,8 +81,6 @@
     owner: postgres
     mode: "0644"
   register: configure_postgres
-  when:
-    - postgresql_is_local | bool
   notify: restart postgresql
 
 - name: Ubuntu | install pg_stats file
@@ -97,8 +91,6 @@
     owner: postgres
     mode: "0644"
   register: configure_postgres
-  when:
-    - postgresql_is_local | bool
   notify: restart postgresql
 
 - name: Ubuntu | configure pg_hba for client connections to postgres server
@@ -109,6 +101,5 @@
   register: remote_postgres_configured
   when:
     - running_on_server | bool
-    - not (postgresql_is_local | bool)
     - (postgres_host | default('', true) | length) > 0
   notify: reload remote postgres

--- a/roles/postgresql/tasks/install_redhat.yml
+++ b/roles/postgresql/tasks/install_redhat.yml
@@ -19,16 +19,12 @@
   ansible.builtin.dnf:
     name: "{{ postgres_packages }}"
     state: present
-  when:
-    - postgresql_is_local | bool
 
 - name: RHEL | Initialize PostgreSQL database
   ansible.builtin.command:
     cmd: /usr/pgsql-{{ postgres_version }}/bin/postgresql-{{ postgres_version }}-setup initdb
   args:
     creates: "/var/lib/pgsql/{{ postgres_version }}/initdb.log"
-  when:
-    - postgresql_is_local | bool
 
 - name: RHEL | install postgresql client packages
   ansible.builtin.dnf:
@@ -45,8 +41,6 @@
     owner: postgres
     mode: "0644"
   register: configure_postgres
-  when:
-    - postgresql_is_local | bool
   notify: restart postgresql
 
 - name: RHEL | ensure access to postgres database

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -4,8 +4,8 @@
 # when building a new or updated postgres server, run server.yml
 - name: Include client tasks
   ansible.builtin.include_tasks: client.yml
-  when: not (postgresql_is_local | bool)
+  when: postgres_db_type==client
 
 - name: Include server tasks
   ansible.builtin.include_tasks: server.yml
-  when: postgresql_is_local | bool
+  when: postgres_db_type==server

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -4,8 +4,8 @@
 # when building a new or updated postgres server, run server.yml
 - name: Include client tasks
   ansible.builtin.include_tasks: client.yml
-  when: postgres_db_type==client
+  when: postgres_db_type == "client"
 
 - name: Include server tasks
   ansible.builtin.include_tasks: server.yml
-  when: postgres_db_type==server
+  when: postgres_db_type == "server"

--- a/roles/postgresql/tasks/server.yml
+++ b/roles/postgresql/tasks/server.yml
@@ -42,7 +42,6 @@
     name: "{{ postgres_service_name | default(postgresql) }}"
     state: started
   when:
-    - postgresql_is_local | bool
     - postgresql_leader == true
 
 - name: Ensure pgpass
@@ -52,7 +51,6 @@
     mode: "0600"
     owner: postgres
   changed_when: false
-  when: postgresql_is_local | bool
   become: true
 
 - name: Configure warm standby leader
@@ -74,9 +72,6 @@
     - inventory_hostname == postgresql_cluster.leader
     - postgresql_logical_replication != false
 
-# - name: Create databases
-#   ansible.builtin.include_tasks: create_db.yml
-
 - name: PostgreSQL | create local postgresql database
   community.postgresql.postgresql_db:
     name: "{{ item.name }}"
@@ -86,7 +81,6 @@
     owner: "{{ item.owner | default(postgres_admin_user) }}"
   when:
     - running_on_server
-    - postgresql_is_local | bool
     - postgresql_databases|length > 0
   changed_when: false
   become: true


### PR DESCRIPTION
Follows up on #7191.

This PR explores what it would look like to use a var like `postgres_db_type` instead of `postgresql_is_local` to control the logic in the postgresql role.

We currently have a few places that use `postgres_is_local` instead of `postgresql_is_local`, and we have the var set in `group_vars/all`, which surprised me. We also have some duplication across environments.

This PR:
- changes the variable from the boolean `postgresql_is_local` to `postgres_db_type`
- sets the default in the postgresql role to `server`
- sets the value in most group vars files to `client`
- removes the var from `group_vars/all` because the same value does not apply across all our inventory
- where applicable, moves the var from environment-specific group vars files into the `shared` or `main` or ` common` group vars file for a project
- removes conditions on handlers, which should run any time they are called
- removes conditions on other tasks where the condition is applied to an include