### PR TITLE
[reservoir] remove staging VMs from inventory

### DIFF
--- a/inventory/all_projects/reservoir.ini
+++ b/inventory/all_projects/reservoir.ini
@@ -1,3 +1,0 @@
-[reservoir_staging]
-reservoir-staging1.lib.princeton.edu
-reservoir-staging2.lib.princeton.edu

--- a/inventory/by_environment/staging.ini
+++ b/inventory/by_environment/staging.ini
@@ -46,7 +46,6 @@ prds_staging
 prosody_staging
 pulfalight_staging
 pulmap_staging
-reservoir_staging
 recap_staging
 redis_staging
 repec_staging


### PR DESCRIPTION
We are decommissioning the `reservoir-staging{1,2}.lib.princeton.edu` VMs now that this project is running on the Nomad infrastructure.

Related to [Ops team-handbook 317](https://gitlab.lib.princeton.edu/ops/team-handbook/-/work_items/317)