### PR TITLE
[EZProxy] add internal IP range to allow list

### DIFF
--- a/roles/ezproxy/templates/princeton_allow.txt.j2
+++ b/roles/ezproxy/templates/princeton_allow.txt.j2
@@ -5,6 +5,6 @@ IncludeIP 0.0.0.0 - 255.255.255.255
 ExcludeIP 128.112.0.0 - 128.112.255.255
 ExcludeIP 140.180.0.0 - 140.180.255.255
 ExcludeIP 172.24.0.0 - 172.24.31.255
-ExcludeIP 10.249.0.0 - 10.249.0.255
+ExcludeIP 10.48.0.0 - 10.49.255.255
 ### Permitted for Anywhere Access Support - Autologin is not otherwise used
 AutoLoginIP 35.153.163.236

--- a/roles/ezproxy/templates/princeton_allow.txt.j2
+++ b/roles/ezproxy/templates/princeton_allow.txt.j2
@@ -5,5 +5,6 @@ IncludeIP 0.0.0.0 - 255.255.255.255
 ExcludeIP 128.112.0.0 - 128.112.255.255
 ExcludeIP 140.180.0.0 - 140.180.255.255
 ExcludeIP 172.24.0.0 - 172.24.31.255
+ExcludeIP 10.249.0.0 - 10.249.0.255
 ### Permitted for Anywhere Access Support - Autologin is not otherwise used
 AutoLoginIP 35.153.163.236


### PR DESCRIPTION
Add internal IP range to princeton_allow.txt so that on campus workstations can connect to resources without the proxy

Related to ServiceNow ticket: TKT0448806