### PR TITLE
[Posgtres] Add psql client role

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -60,6 +60,7 @@ jobs:
           - php
           - postfix
           - postgresql
+          - psql-client
           - pulfalight
           - pul_nomad
           - pulmap
@@ -131,4 +132,3 @@ jobs:
         run: |
           docker ps -a
           docker logs $(docker ps -aq --filter name=instance) || true
-

--- a/roles/approvals/meta/main.yml
+++ b/roles/approvals/meta/main.yml
@@ -16,4 +16,4 @@ galaxy_info:
 dependencies:
   - role: 'ruby_app'
   - role: 'mailcatcher'
-  - role: 'psql-client'
+  # - role: 'psql-client'

--- a/roles/approvals/meta/main.yml
+++ b/roles/approvals/meta/main.yml
@@ -16,10 +16,3 @@ galaxy_info:
 dependencies:
   - role: 'ruby_app'
   - role: 'mailcatcher'
-  # the ruby_app role already has a dependency on a role that
-  # sets up the postgresql client
-  # in the main branch it's the postgresql role
-  # in this branch, it's the psql-client role
-  # so I think we can ditch this dependency, but I'm commenting
-  # it out until I'm more confident
-  # - role: 'psql-client'

--- a/roles/approvals/meta/main.yml
+++ b/roles/approvals/meta/main.yml
@@ -16,4 +16,4 @@ galaxy_info:
 dependencies:
   - role: 'ruby_app'
   - role: 'mailcatcher'
-  - role: 'postgresql'
+  - role: 'psql-client'

--- a/roles/approvals/meta/main.yml
+++ b/roles/approvals/meta/main.yml
@@ -16,4 +16,10 @@ galaxy_info:
 dependencies:
   - role: 'ruby_app'
   - role: 'mailcatcher'
+  # the ruby_app role already has a dependency on a role that
+  # sets up the postgresql client
+  # in the main branch it's the postgresql role
+  # in this branch, it's the psql-client role
+  # so I think we can ditch this dependency, but I'm commenting
+  # it out until I'm more confident
   # - role: 'psql-client'

--- a/roles/psql-client/.yamllint
+++ b/roles/psql-client/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/psql-client/README.md
+++ b/roles/psql-client/README.md
@@ -4,8 +4,6 @@
 
 Connects to a remote postgres server and uses provided admin credentials to create a new database and user account for a given application. It can also manage database backups.
 
-Based on [the `postgresql` role from `pulibrary/princeton_ansible`](https://github.com/pulibrary/princeton_ansible/tree/main/roles/postgresql).
-
 ## Requirements
 
 ------------

--- a/roles/psql-client/README.md
+++ b/roles/psql-client/README.md
@@ -1,0 +1,58 @@
+# Postgresql
+
+=========
+
+Connects to a remote postgres server and uses provided admin credentials to create a new database and user account for a given application. It can also manage database backups.
+
+Based on [the `postgresql` role from `pulibrary/princeton_ansible`](https://github.com/pulibrary/princeton_ansible/tree/main/roles/postgresql).
+
+## Requirements
+
+------------
+
+This role requires the `community.postgresql` collection to manage the database and users.
+
+## Variables
+
+------------
+
+### Database Connection & Credentials
+
+- `postgres_port`: port at which remote postgres server is accessible (default: `5432`)
+- `postgres_host`: hostname for remote postgres server (default: `postgres`)
+- `postgres_version`: version of postgres in use (default: `15`)
+- `vault_postgres_admin_user`: account on postgres server with db creation permissions (default: `postgres`)
+- `vault_postgres_admin_password`: password for admin postgres account (default: `postgres`)
+
+### Application Settings
+
+- `application_db_name`: postgres database to create for app (default: `app`)
+- `application_dbuser_name`: postgres account for app that will be created with access to app's database (default: `app_user`)
+- `application_dbuser_password`: password for app's postgres account (default: `changethis`)
+- `application_dbuser_role_attr_flags`: capabilities to grant to app's postgres account (default: `""`)
+
+### Deployment & Backup Settings
+
+- `deploy_user`: the system user on the app host that will own the backup files (default: `deploy`)
+- `deploy_user_venv`: path to the virtual environment for the deploy user (default: `/home/{{ deploy_user }}/venv`)
+- `db_backup_path`: the path on the app host where the database backup will be saved (default: `/home/{{ deploy_user }}/last_{{ application_db_name }}.sql`)
+
+### Feature Flags
+
+- `postgres_setup_enabled`: whether to run the installation, configuration, and user/db creation tasks (default: `true`)
+- `postgres_backup_enabled`: whether to run the database backup tasks (default: `true`)
+
+## Example Playbook
+
+------------
+
+```yml
+    - hosts: servers
+      vars:
+        postgres_setup_enabled: true
+        postgres_backup_enabled: true
+        application_db_name: my_app_db
+        deploy_user: my_deploy_user
+      roles:
+         - postgresql
+```

--- a/roles/psql-client/README.md
+++ b/roles/psql-client/README.md
@@ -1,17 +1,14 @@
-# Postgresql
-
+# psql-client
 =========
 
 Connects to a remote postgres server and uses provided admin credentials to create a new database and user account for a given application. It can also manage database backups.
 
 ## Requirements
-
 ------------
 
 This role requires the `community.postgresql` collection to manage the database and users.
 
 ## Variables
-
 ------------
 
 ### Database Connection & Credentials
@@ -41,7 +38,6 @@ This role requires the `community.postgresql` collection to manage the database 
 - `postgres_backup_enabled`: whether to run the database backup tasks (default: `true`)
 
 ## Example Playbook
-
 ------------
 
 ```yml
@@ -52,5 +48,5 @@ This role requires the `community.postgresql` collection to manage the database 
         application_db_name: my_app_db
         deploy_user: my_deploy_user
       roles:
-         - postgresql
+         - psql-client
 ```

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -14,7 +14,7 @@ application_dbuser_role_attr_flags: ""
 postgres_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 postgres_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgres_version }}'
 # task settings
-deploy_user: conan
+deploy_user: deploy
 deploy_user_venv: "/home/{{ deploy_user }}/venv"
 db_backup_path: "/home/{{ deploy_user }}/last_{{ application_db_name }}.sql"
 # feature flags

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -4,7 +4,6 @@ postgres_port: 5432
 postgres_version: 15
 postgres_host: postgres
 postgres_admin_user: postgres
-postgres_admin_login_host: "127.0.0.1"
 vault_postgres_admin_password: postgres
 # application settings
 application_db_name: app

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# postgres VM settings
+postgres_port: 5432
+postgres_version: 15
+postgres_host: postgres
+vault_postgres_admin_user: postgres
+vault_postgres_admin_password: postgres
+# application settings
+application_db_name: app
+application_dbuser_name: app_user
+application_dbuser_password: changethis
+application_dbuser_role_attr_flags: ""
+# apt settings
+postgres_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+postgres_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgres_version }}'
+# task settings
+deploy_user: conan
+deploy_user_venv: "/home/{{ deploy_user }}/venv"
+db_backup_path: "/home/{{ deploy_user }}/last_{{ application_db_name }}.sql"
+# feature flags
+postgres_setup_enabled: true
+postgres_backup_enabled: true

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -12,7 +12,7 @@ application_dbuser_password: changethis
 application_dbuser_role_attr_flags: ""
 # apt settings
 postgres_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-postgres_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgres_version }}'
+postgres_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
 # task settings
 deploy_user: deploy
 deploy_user_venv: "/home/{{ deploy_user }}/venv"

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -4,6 +4,7 @@ postgres_port: 5432
 postgres_version: 15
 postgres_host: postgres
 postgres_admin_user: postgres
+postgres_admin_login_host: "127.0.0.1"
 vault_postgres_admin_password: postgres
 # application settings
 application_db_name: app

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -3,7 +3,7 @@
 postgres_port: 5432
 postgres_version: 15
 postgres_host: postgres
-vault_postgres_admin_user: postgres
+postgres_admin_user: postgres
 vault_postgres_admin_password: postgres
 # application settings
 application_db_name: app

--- a/roles/psql-client/handlers/main.yml
+++ b/roles/psql-client/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# handlers file for postgresql
+- name: Reload remote postgres
+  ansible.builtin.systemd:
+    name: postgresql
+    state: reloaded
+  become: yes
+  delegate_to: '{{ postgres_host }}'

--- a/roles/psql-client/handlers/main.yml
+++ b/roles/psql-client/handlers/main.yml
@@ -3,6 +3,8 @@
 - name: Reload remote postgres
   ansible.builtin.systemd:
     name: postgresql
+    # the service name on RHEL/Rocky is different
+    # but we shouldn't need that here
     state: reloaded
   become: yes
   delegate_to: '{{ postgres_host }}'

--- a/roles/psql-client/meta/main.yml
+++ b/roles/psql-client/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: cdh
+  description: Set up a remote postgres database and user
+  company: Center for Digital Humanities @ Princeton
+  license: Apache-2.0
+
+  min_ansible_version: "2.12"
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+  galaxy_tags:
+    - postgresql
+    - database
+    - backup
+    - ubuntu
+
+dependencies:
+  - role: setup

--- a/roles/psql-client/meta/main.yml
+++ b/roles/psql-client/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  author: cdh
+  role_name: psql-client
+  author: Princeton University Library
   description: Set up a remote postgres database and user
-  company: Center for Digital Humanities @ Princeton
   license: Apache-2.0
 
   min_ansible_version: "2.12"
@@ -10,14 +10,11 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - focal
         - jammy
+        - noble
 
   galaxy_tags:
     - postgresql
     - database
     - backup
     - ubuntu
-
-dependencies:
-  - role: setup

--- a/roles/psql-client/molecule/default/Dockerfile.j2
+++ b/roles/psql-client/molecule/default/Dockerfile.j2
@@ -1,0 +1,9 @@
+FROM pulibrary/puldocker-ubuntu1804-ansible:latest
+
+# Install postgres
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql
+
+# Ensure postgres service is running
+RUN service postgresql restart
+CMD ["/sbin/my_init"]

--- a/roles/psql-client/molecule/default/converge.yml
+++ b/roles/psql-client/molecule/default/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: all
+  hosts: instance
   vars:
     running_on_server: false
     ansible_default_ipv4: { address: "127.0.0.1" }

--- a/roles/psql-client/molecule/default/converge.yml
+++ b/roles/psql-client/molecule/default/converge.yml
@@ -1,0 +1,27 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    running_on_server: false
+  become: true
+  pre_tasks:
+    - name: Update cache
+      ansible.builtin.apt:
+        name: locales
+        update_cache: true
+        cache_valid_time: 600
+
+    - name: Ensure en_US.UTF-8 locale is uncommented in /etc/locale.gen
+      ansible.builtin.lineinfile:
+        path: /etc/locale.gen
+        regexp: '^# en_US.UTF-8 UTF-8'
+        line: 'en_US.UTF-8 UTF-8'
+        state: present
+
+    - name: Generate locales
+      ansible.builtin.command: locale-gen
+      changed_when: false
+  tasks:
+    - name: "Include postgresql"
+      ansible.builtin.include_role:
+        name: postgresql

--- a/roles/psql-client/molecule/default/converge.yml
+++ b/roles/psql-client/molecule/default/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     running_on_server: false
-    ansible_default_ipv4.address: 127.0.0.1
+    ansible_default_ipv4: { address: "127.0.0.1" }
   become: true
   pre_tasks:
     - name: Update cache

--- a/roles/psql-client/molecule/default/converge.yml
+++ b/roles/psql-client/molecule/default/converge.yml
@@ -3,6 +3,7 @@
   hosts: all
   vars:
     running_on_server: false
+    ansible_default_ipv4.address: 127.0.0.1
   become: true
   pre_tasks:
     - name: Update cache

--- a/roles/psql-client/molecule/default/converge.yml
+++ b/roles/psql-client/molecule/default/converge.yml
@@ -22,6 +22,6 @@
       ansible.builtin.command: locale-gen
       changed_when: false
   tasks:
-    - name: "Include postgresql"
+    - name: "Include psql-client role"
       ansible.builtin.include_role:
-        name: postgresql
+        name: psql-client

--- a/roles/psql-client/molecule/default/create.yml
+++ b/roles/psql-client/molecule/default/create.yml
@@ -1,0 +1,55 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    molecule_inventory:
+      all:
+        children:
+          molecule:
+            hosts: {}
+
+  tasks:
+    - name: Set async_dir for HOME env (Ansible 2.19+ safe)
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME') | default('') | length) > 0
+
+    - name: Create container(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        state: started
+        recreate: false
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        # Only pass command if it’s non-empty; otherwise use image CMD (/sbin/init in your image)
+        command: "{{ (item.command | default('') | length > 0) | ternary(item.command, omit) }}"
+        log_driver: json-file
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Add containers to dynamic inventory
+      vars:
+        inventory_partial_yaml: |
+          all:
+            children:
+              molecule:
+                hosts:
+                  "{{ item.name }}":
+                    ansible_connection: community.docker.docker
+      ansible.builtin.set_fact:
+        molecule_inventory: "{{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Write dynamic inventory file
+      ansible.builtin.copy:
+        dest: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        content: "{{ molecule_inventory | to_yaml }}"
+        mode: "0600"
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory

--- a/roles/psql-client/molecule/default/create.yml
+++ b/roles/psql-client/molecule/default/create.yml
@@ -19,9 +19,8 @@
 
     - name: Create docker network(s)
       community.docker.docker_network:
-        name: "{{ item }}"
+        name: CI
         state: present
-      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
 
     - name: Create container(s)
       community.docker.docker_container:

--- a/roles/psql-client/molecule/default/create.yml
+++ b/roles/psql-client/molecule/default/create.yml
@@ -33,6 +33,7 @@
         cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
         tmpfs: "{{ item.tmpfs | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
         # Only pass command if it’s non-empty; otherwise use image CMD (/sbin/init in your image)
         command: "{{ (item.command | default('') | length > 0) | ternary(item.command, omit) }}"
         log_driver: json-file

--- a/roles/psql-client/molecule/default/create.yml
+++ b/roles/psql-client/molecule/default/create.yml
@@ -27,6 +27,7 @@
         name: "{{ item.name }}"
         image: "{{ item.image }}"
         state: started
+        platform: "{{ item.platform | default(omit) }}"
         recreate: false
         privileged: "{{ item.privileged | default(omit) }}"
         cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"

--- a/roles/psql-client/molecule/default/create.yml
+++ b/roles/psql-client/molecule/default/create.yml
@@ -17,6 +17,12 @@
         ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
       when: (lookup('env', 'HOME') | default('') | length) > 0
 
+    - name: Create docker network(s)
+      community.docker.docker_network:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
     - name: Create container(s)
       community.docker.docker_container:
         name: "{{ item.name }}"

--- a/roles/psql-client/molecule/default/destroy.yml
+++ b/roles/psql-client/molecule/default/destroy.yml
@@ -1,0 +1,18 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Stop and remove container(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: true
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Remove dynamic inventory file
+      ansible.builtin.file:
+        path: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        state: absent

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -61,10 +61,6 @@ provisioner:
     create: create.yml
     destroy: destroy.yml
   # inventory:
-  #   group_vars:
-  #     all:
-  #       postgres_host: postgres
-  #       ansible_python_interpreter: /usr/bin/python3.12
   config_options:
     defaults:
       remote_tmp: /tmp

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -32,6 +32,18 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+  - name: postgres
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    command: "" # image above already has the /sbin/init
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   playbooks:

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -24,6 +24,10 @@ platforms:
     image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
     platform: linux/amd64
     command: "" # image above already has the /sbin/init
+    networks:
+      - name: CI
+        aliases:
+          - instance
     tmpfs:
       - /run
       - /run/lock
@@ -39,6 +43,10 @@ platforms:
     image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
     platform: linux/amd64
     command: "" # image above already has the /sbin/init
+    networks:
+      - name: CI
+        aliases:
+          - postgres
     tmpfs:
       - /run
       - /run/lock

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -22,6 +22,7 @@ lint: |
 platforms:
   - name: instance
     image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    platform: linux/amd64
     command: "" # image above already has the /sbin/init
     tmpfs:
       - /run
@@ -36,6 +37,7 @@ platforms:
       - name: CI
   - name: postgres
     image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    platform: linux/amd64
     command: "" # image above already has the /sbin/init
     tmpfs:
       - /run

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -1,0 +1,50 @@
+---
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup 
+    - destroy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    command: "" # image above already has the /sbin/init
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    create: create.yml
+    destroy: destroy.yml
+  inventory:
+    group_vars:
+      all:
+        postgres_host: postgres
+  config_options:
+    defaults:
+      remote_tmp: /tmp
+  log: true
+verifier:
+  name: ansible

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -37,8 +37,6 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
-    networks:
-      - name: CI
   - name: postgres
     image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
     platform: linux/amd64
@@ -56,19 +54,17 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
-    networks:
-      - name: CI
 provisioner:
   name: ansible
   playbooks:
     prepare: prepare.yml
     create: create.yml
     destroy: destroy.yml
-  inventory:
-    group_vars:
-      all:
-        postgres_host: postgres
-        ansible_python_interpreter: /usr/bin/python3.12
+  # inventory:
+  #   group_vars:
+  #     all:
+  #       postgres_host: postgres
+  #       ansible_python_interpreter: /usr/bin/python3.12
   config_options:
     defaults:
       remote_tmp: /tmp

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -32,6 +32,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    networks:
+      - name: CI
   - name: postgres
     image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
     command: "" # image above already has the /sbin/init
@@ -44,6 +46,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    networks:
+      - name: CI
 provisioner:
   name: ansible
   playbooks:

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ scenario:
     - converge
     - idempotence
     - verify
-    - cleanup 
+    - cleanup
     - destroy
 driver:
   name: docker
@@ -54,6 +54,7 @@ provisioner:
     group_vars:
       all:
         postgres_host: postgres
+        ansible_python_interpreter: /usr/bin/python3.12
   config_options:
     defaults:
       remote_tmp: /tmp

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -1,0 +1,34 @@
+---
+- name: Prepare Postgres Database Server
+  hosts: postgres
+  become: true
+  tasks:
+    - name: Install Postgresql and Python on DB host
+      ansible.builtin.apt:
+        name:
+          - postgresql
+          - postgresql-contrib
+          - python3-psycopg2
+          - sudo
+        state: present
+        update_cache: true
+
+    - name: Start postgresql service
+      ansible.builtin.service:
+        name: postgresql
+        state: started
+        enabled: true
+
+    - name: Set postgres user password for testing
+      become_user: postgres
+      ansible.builtin.command: psql -c "ALTER USER postgres PASSWORD 'postgres';"
+      changed_when: false
+
+- name: Prepare Application Instance
+  hosts: instance
+  become: true
+  tasks:
+    - name: Ensure deploy user exists
+      ansible.builtin.user:
+        name: conan
+        state: present

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -24,8 +24,10 @@
     - name: Install Postgresql and Python on DB host
       ansible.builtin.apt:
         name:
-          - "postgresql-{{ postgres_version }}"
-          - "postgresql-contrib-{{ postgres_version }}"
+          - libpq-dev
+          - postgresql-{{ postgres_version }}
+          - postgresql-contrib-{{ postgres_version }}
+          - postgresql-client-{{ postgres_version }}
           - python3-psycopg2
           - sudo
         state: present

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -3,6 +3,8 @@
   become: true
   vars_files:
     - ../../defaults/main.yml
+  vars:
+    - ansible_python_interpreter: /usr/bin/python3.12
   tasks:
     - name: Make sure CA certificates are available
       ansible.builtin.apt:

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -30,5 +30,5 @@
   tasks:
     - name: Ensure deploy user exists
       ansible.builtin.user:
-        name: conan
+        name: deploy
         state: present

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -1,34 +1,54 @@
----
 - name: Prepare Postgres Database Server
   hosts: postgres
   become: true
+  vars_files:
+    - ../../defaults/main.yml
   tasks:
+    - name: Make sure CA certificates are available
+      ansible.builtin.apt:
+        name: ca-certificates
+        state: present
+        update_cache: true
+
+    - name: Add postgres repository apt-key
+      ansible.builtin.apt_key:
+        url: "{{ postgres_apt_key_url }}"
+        state: present
+
+    - name: Add postgres repository
+      ansible.builtin.apt_repository:
+        repo: "{{ postgres_apt_repository }}"
+        update_cache: true
+        state: present
+
     - name: Install Postgresql and Python on DB host
       ansible.builtin.apt:
         name:
-          - postgresql
-          - postgresql-contrib
+          - "postgresql-{{ postgres_version }}"
+          - "postgresql-contrib-{{ postgres_version }}"
           - python3-psycopg2
           - sudo
         state: present
         update_cache: true
 
+    - name: Listen on all container addresses
+      ansible.builtin.lineinfile:
+        path: "/etc/postgresql/{{ postgres_version }}/main/postgresql.conf"
+        regexp: '^#?listen_addresses\s*='
+        line: "listen_addresses = '*'"
+
+    - name: Allow password auth from Molecule containers
+      ansible.builtin.lineinfile:
+        path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
+        line: "host    all             all             0.0.0.0/0               md5"
+
     - name: Start postgresql service
       ansible.builtin.service:
         name: postgresql
-        state: started
+        state: restarted
         enabled: true
 
     - name: Set postgres user password for testing
       become_user: postgres
       ansible.builtin.command: psql -c "ALTER USER postgres PASSWORD 'postgres';"
       changed_when: false
-
-- name: Prepare Application Instance
-  hosts: instance
-  become: true
-  tasks:
-    - name: Ensure deploy user exists
-      ansible.builtin.user:
-        name: deploy
-        state: present

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -65,3 +65,12 @@
       become_user: postgres
       ansible.builtin.command: psql -c "ALTER USER postgres PASSWORD 'postgres';"
       changed_when: false
+
+- name: Prepare Application Instance
+  hosts: instance
+  become: true
+  tasks:
+    - name: Ensure deploy user exists
+      ansible.builtin.user:
+        name: deploy
+        state: present

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
   vars_files:
     - ../../defaults/main.yml
   vars:
-    - ansible_python_interpreter: /usr/bin/python3.12
+    ansible_python_interpreter: "/usr/bin/python3.12"
   tasks:
     - name: Make sure CA certificates are available
       ansible.builtin.apt:

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -35,6 +35,12 @@
         state: present
         update_cache: true
 
+    - name: Install psycopg2 for Ansible Python
+      ansible.builtin.pip:
+        name: psycopg2-binary
+        executable: pip3
+        extra_args: --break-system-packages
+
     - name: Debug paths and versions on DB host
       ansible.builtin.command: ansible-playbook --version
 

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -3,8 +3,6 @@
   become: true
   vars_files:
     - ../../defaults/main.yml
-  # vars:
-  #   ansible_python_interpreter: "/usr/bin/python3.12"
   tasks:
     - name: Make sure CA certificates are available
       ansible.builtin.apt:
@@ -40,9 +38,6 @@
         name: psycopg2-binary
         executable: pip3
         extra_args: --break-system-packages
-
-    # - name: Debug paths and versions on DB host
-    #   ansible.builtin.command: ansible-playbook --version
 
     - name: Listen on all container addresses
       ansible.builtin.lineinfile:

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -3,8 +3,8 @@
   become: true
   vars_files:
     - ../../defaults/main.yml
-  vars:
-    ansible_python_interpreter: "/usr/bin/python3.12"
+  # vars:
+  #   ansible_python_interpreter: "/usr/bin/python3.12"
   tasks:
     - name: Make sure CA certificates are available
       ansible.builtin.apt:
@@ -34,6 +34,9 @@
           - sudo
         state: present
         update_cache: true
+
+    - name: Debug paths and versions on DB host
+      ansible.builtin.command: ansible-playbook --version
 
     - name: Listen on all container addresses
       ansible.builtin.lineinfile:

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -41,8 +41,8 @@
         executable: pip3
         extra_args: --break-system-packages
 
-    - name: Debug paths and versions on DB host
-      ansible.builtin.command: ansible-playbook --version
+    # - name: Debug paths and versions on DB host
+    #   ansible.builtin.command: ansible-playbook --version
 
     - name: Listen on all container addresses
       ansible.builtin.lineinfile:

--- a/roles/psql-client/molecule/default/verify.yml
+++ b/roles/psql-client/molecule/default/verify.yml
@@ -1,0 +1,23 @@
+---
+- name: Verify
+  hosts: instance
+  gather_facts: false
+  vars_files:
+    - ../../defaults/main.yml
+  tasks:
+    - name: Ensure postgresql db user can create tables
+      community.postgresql.postgresql_query:
+        login_host: "{{ postgres_host }}"
+        port: "{{ postgres_port }}"
+        login_user: "{{ application_dbuser_name }}"
+        login_password: "{{ application_dbuser_password }}"
+        db: "{{ application_db_name }}"
+        query: "CREATE TABLE IF NOT EXISTS test_table (id serial PRIMARY KEY);"
+      register: table_creation
+      failed_when: table_creation.msg is defined and 'error' in table_creation.msg.lower()
+
+    - name: Verify backup file exists
+      ansible.builtin.stat:
+        path: "{{ db_backup_path }}"
+      register: backup_file
+      failed_when: not backup_file.stat.exists

--- a/roles/psql-client/molecule/default/verify.yml
+++ b/roles/psql-client/molecule/default/verify.yml
@@ -8,7 +8,7 @@
     - name: Ensure postgresql db user can create tables
       community.postgresql.postgresql_query:
         login_host: "{{ postgres_host }}"
-        port: "{{ postgres_port }}"
+        login_port: "{{ postgres_port }}"
         login_user: "{{ application_dbuser_name }}"
         login_password: "{{ application_dbuser_password }}"
         db: "{{ application_db_name }}"

--- a/roles/psql-client/requirements.yml
+++ b/roles/psql-client/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.postgresql

--- a/roles/psql-client/tasks/backup_db.yml
+++ b/roles/psql-client/tasks/backup_db.yml
@@ -6,7 +6,6 @@
   block:
     - name: Check postgres backup path
       become: true
-      become_user: "{{ deploy_user }}"
       ansible.builtin.file:
         dest: "{{ db_backup_path | dirname }}"
         state: directory

--- a/roles/psql-client/tasks/backup_db.yml
+++ b/roles/psql-client/tasks/backup_db.yml
@@ -20,7 +20,7 @@
       community.postgresql.postgresql_db:
         name: "{{ application_db_name }}"
         login_host: "{{ postgres_host }}"
-        port: "{{ postgres_port }}"
+        login_port: "{{ postgres_port }}"
         login_user: "{{ application_dbuser_name }}"
         login_password: "{{ application_dbuser_password }}"
         encoding: "UTF-8"

--- a/roles/psql-client/tasks/backup_db.yml
+++ b/roles/psql-client/tasks/backup_db.yml
@@ -1,0 +1,29 @@
+---
+# back up the database to a location on the app's host (not the db host)
+- name: Backup postgres database
+  run_once: true
+  tags: db_backup
+  block:
+    - name: Check postgres backup path
+      become: true
+      become_user: "{{ deploy_user }}"
+      ansible.builtin.file:
+        dest: "{{ db_backup_path | dirname }}"
+        state: directory
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_user }}"
+        mode: "0755"
+
+    - name: Dump postgres database to backup path
+      become: true
+      become_user: "{{ deploy_user }}"
+      community.postgresql.postgresql_db:
+        name: "{{ application_db_name }}"
+        login_host: "{{ postgres_host }}"
+        port: "{{ postgres_port }}"
+        login_user: "{{ application_dbuser_name }}"
+        login_password: "{{ application_dbuser_password }}"
+        encoding: "UTF-8"
+        owner: "{{ application_dbuser_name }}"
+        state: "dump"
+        target: "{{ db_backup_path }}"

--- a/roles/psql-client/tasks/backup_db.yml
+++ b/roles/psql-client/tasks/backup_db.yml
@@ -26,3 +26,4 @@
         owner: "{{ application_dbuser_name }}"
         state: "dump"
         target: "{{ db_backup_path }}"
+      changed_when: false

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -9,7 +9,7 @@
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
     login_host: "{{ postgres_host }}"
-    port: "{{ postgres_port }}"
+    login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"
     encoding: "UTF-8"

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -4,7 +4,7 @@
 
 - name: Ensure postgres database for app exists
   run_once: true
-  delegate_to: "{{ postgres_host }}"
+  # delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -4,7 +4,6 @@
 
 - name: Ensure postgres database for app exists
   run_once: true
-  # delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -4,11 +4,11 @@
 
 - name: Ensure postgres database for app exists
   run_once: true
-  # delegate_to: "{{ postgres_host }}"
+  delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
-    login_host: "{{ postgres_host }}"
+    login_host: "{{ postgres_admin_login_host }}"
     login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -4,6 +4,8 @@
 
 - name: Ensure postgres database for app exists
   run_once: true
+  delegate_to: "{{ postgres_host }}"
+  become: true
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
     login_host: "{{ postgres_host }}"

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -4,11 +4,11 @@
 
 - name: Ensure postgres database for app exists
   run_once: true
-  delegate_to: "{{ postgres_host }}"
+  # delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
-    login_host: "{{ postgres_admin_login_host }}"
+    login_host: "{{ postgres_host }}"
     login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -1,0 +1,16 @@
+---
+# Based on:
+# https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_db.yml
+
+- name: Ensure postgres database for app exists
+  run_once: true
+  community.postgresql.postgresql_db:
+    name: "{{ application_db_name }}"
+    login_host: "{{ postgres_host }}"
+    port: "{{ postgres_port }}"
+    login_user: "{{ postgres_admin_user }}"
+    login_password: "{{ vault_postgres_admin_password }}"
+    encoding: "UTF-8"
+    owner: "{{ application_dbuser_name }}"
+    state: "present"
+  changed_when: false

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -1,0 +1,16 @@
+---
+# Based on:
+# https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_users.yml
+
+- name: Ensure postgres user account for app exists
+  run_once: true
+  community.postgresql.postgresql_user:
+    name: "{{ application_dbuser_name }}"
+    login_host: "{{ postgres_host }}"
+    port: "{{ postgres_port }}"
+    login_user: "{{ postgres_admin_user }}"
+    login_password: "{{ vault_postgres_admin_password }}"
+    password: "{{ application_dbuser_password }}"
+    encrypted: true
+    role_attr_flags: "{{ application_dbuser_role_attr_flags }}"
+    state: "present"

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -1,20 +1,6 @@
 ---
 # Based on:
 # https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_users.yml
-#
-# Don't leave this task! Just seeing ifI can get the tests passing
-- name: Install postgresql libraries on the test psql server
-  become: true
-  run_once: true
-  delegate_to: "{{ postgres_host }}"
-  ansible.builtin.apt:
-    name:
-      - libpq-dev
-      - python3-dev
-      - python3-psycopg2
-      - "postgresql-client-{{ postgres_version }}"
-    state: present
-    update_cache: true
 
 - name: Ensure postgres user account for app exists
   run_once: true

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -1,6 +1,20 @@
 ---
 # Based on:
 # https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_users.yml
+#
+# Don't leave this task! Just seeing ifI can get the tests passing
+- name: Install postgresql libraries on the test psql server
+  become: true
+  run_once: true
+  delegate_to: "{{ postgres_host }}"
+  ansible.builtin.apt:
+    name:
+      - libpq-dev
+      - python3-dev
+      - python3-psycopg2
+      - "postgresql-client-{{ postgres_version }}"
+    state: present
+    update_cache: true
 
 - name: Ensure postgres user account for app exists
   run_once: true

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -4,11 +4,11 @@
 
 - name: Ensure postgres user account for app exists
   run_once: true
-  delegate_to: "{{ postgres_host }}"
+  # delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"
-    login_host: "{{ postgres_admin_login_host }}"
+    login_host: "{{ postgres_host }}"
     login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -9,7 +9,7 @@
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"
     login_host: "{{ postgres_host }}"
-    port: "{{ postgres_port }}"
+    login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"
     password: "{{ application_dbuser_password }}"

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -4,11 +4,11 @@
 
 - name: Ensure postgres user account for app exists
   run_once: true
-  # delegate_to: "{{ postgres_host }}"
+  delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"
-    login_host: "{{ postgres_host }}"
+    login_host: "{{ postgres_admin_login_host }}"
     login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -4,7 +4,6 @@
 
 - name: Ensure postgres user account for app exists
   run_once: true
-  # delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -4,7 +4,7 @@
 
 - name: Ensure postgres user account for app exists
   run_once: true
-  delegate_to: "{{ postgres_host }}"
+  # delegate_to: "{{ postgres_host }}"
   become: true
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -4,6 +4,8 @@
 
 - name: Ensure postgres user account for app exists
   run_once: true
+  delegate_to: "{{ postgres_host }}"
+  become: true
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"
     login_host: "{{ postgres_host }}"

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -8,6 +8,19 @@
         pkg: ca-certificates
         state: present
 
+    - name: Add postgres repository apt-key
+      become: true
+      ansible.builtin.apt_key:
+        url: "{{ postgres_apt_key_url }}"
+        state: present
+
+    - name: Add postgres repository
+      become: true
+      ansible.builtin.apt_repository:
+        repo: "{{ postgres_apt_repository }}"
+        update_cache: true
+        state: present
+
     - name: Install postgres client libraries
       become: true
       ansible.builtin.apt:

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -38,11 +38,15 @@
         executable: pip3
         extra_args: --break-system-packages
 
+    - name: set fqdn for use in pg_hba
+      ansible.builtin.set_fact:
+        "pg_hba_fqdn={{ ansible_facts['fqdn'] }}"
+
     - name: Ensure access to postgres server
       become: true
       ansible.builtin.lineinfile:
         path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
-        line: "host    all             all             {{ ansible_default_ipv4.address }}/32       md5"
+        line: "host    all             all             {{ pg_hba_fqdn }}/32       md5"
       delegate_to: "{{ postgres_host }}"
       notify: Reload remote postgres
 

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -32,6 +32,12 @@
         state: present
         update_cache: true
 
+    - name: Install psycopg2 for Ansible Python
+      ansible.builtin.pip:
+        name: psycopg2-binary
+        executable: pip3
+        extra_args: --break-system-packages
+
     - name: Ensure access to postgres server
       become: true
       ansible.builtin.lineinfile:

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -8,19 +8,6 @@
         pkg: ca-certificates
         state: present
 
-    - name: Add postgres repository apt-key
-      become: true
-      ansible.builtin.apt_key:
-        url: "{{ postgres_apt_key_url }}"
-        state: present
-
-    - name: Add postgres repository
-      become: true
-      ansible.builtin.apt_repository:
-        repo: "{{ postgres_apt_repository }}"
-        update_cache: true
-        state: present
-
     - name: Install postgres client libraries
       become: true
       ansible.builtin.apt:

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -46,7 +46,7 @@
       become: true
       ansible.builtin.lineinfile:
         path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
-        line: "host    all             all             {{ pg_hba_fqdn }}/32       md5"
+        line: "host    all             all             {{ pg_hba_fqdn }}       md5"
       delegate_to: "{{ postgres_host }}"
       notify: Reload remote postgres
 

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+- name: Setup Postgres Client and Configuration
+  when: postgres_setup_enabled | bool
+  block:
+    - name: Make sure CA certificates are available
+      become: true
+      ansible.builtin.apt:
+        pkg: ca-certificates
+        state: present
+
+    - name: Add postgres repository apt-key
+      become: true
+      ansible.builtin.apt_key:
+        url: "{{ postgres_apt_key_url }}"
+        state: present
+
+    - name: Add postgres repository
+      become: true
+      ansible.builtin.apt_repository:
+        repo: "{{ postgres_apt_repository }}"
+        update_cache: true
+        state: present
+
+    - name: Install postgres client libraries
+      become: true
+      ansible.builtin.apt:
+        name:
+          - libpq-dev
+          - python3-dev
+          - python3-psycopg2
+          - "postgresql-client-{{ postgres_version }}"
+        state: present
+        update_cache: true
+
+    - name: Ensure access to postgres server
+      become: true
+      ansible.builtin.lineinfile:
+        path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
+        line: "host    all             all             {{ ansible_default_ipv4.address }}/32       md5"
+      delegate_to: "{{ postgres_host }}"
+      notify: Reload remote postgres
+
+- name: Create postgres user
+  ansible.builtin.import_tasks: create_user.yml
+  when: postgres_setup_enabled | bool
+
+- name: Create postgres database
+  ansible.builtin.import_tasks: create_db.yml
+  when: postgres_setup_enabled | bool
+
+- name: Backup postgres database
+  ansible.builtin.import_tasks: backup_db.yml
+  when: postgres_backup_enabled | bool

--- a/roles/ruby_app/meta/main.yml
+++ b/roles/ruby_app/meta/main.yml
@@ -18,11 +18,7 @@ dependencies:
   - role: 'bind9'
   - role: 'deploy_user'
   - role: 'passenger'
-  # switching from the postgresql role to the psql-client role
-  # as part of using Approvals to test the new role
-  # the Approvals role now relies on this role to call psql-client
-  # - role: postgresql
-  #   tags: 'postgresql'
-  - role: psql-client
+  - role: postgresql
+    tags: 'postgresql'
   - role: nodejs
     when: install_nodejs|default(true)

--- a/roles/ruby_app/meta/main.yml
+++ b/roles/ruby_app/meta/main.yml
@@ -18,7 +18,9 @@ dependencies:
   - role: 'bind9'
   - role: 'deploy_user'
   - role: 'passenger'
-  - role: postgresql
-    tags: 'postgresql'
+  # disabling the postgresql role for psql-client test
+  # we're using Approvals to test, and the Approvals role already calls psql-client
+  # - role: postgresql
+  #   tags: 'postgresql'
   - role: nodejs
     when: install_nodejs|default(true)

--- a/roles/ruby_app/meta/main.yml
+++ b/roles/ruby_app/meta/main.yml
@@ -22,5 +22,6 @@ dependencies:
   # we're using Approvals to test, and the Approvals role already calls psql-client
   # - role: postgresql
   #   tags: 'postgresql'
+  - role: psql-client
   - role: nodejs
     when: install_nodejs|default(true)

--- a/roles/ruby_app/meta/main.yml
+++ b/roles/ruby_app/meta/main.yml
@@ -18,8 +18,9 @@ dependencies:
   - role: 'bind9'
   - role: 'deploy_user'
   - role: 'passenger'
-  # disabling the postgresql role for psql-client test
-  # we're using Approvals to test, and the Approvals role already calls psql-client
+  # switching from the postgresql role to the psql-client role
+  # as part of using Approvals to test the new role
+  # the Approvals role now relies on this role to call psql-client
   # - role: postgresql
   #   tags: 'postgresql'
   - role: psql-client


### PR DESCRIPTION
As discussed today in the Ansible Open House, we're exploring ways to simplify and streamline our database installation and maintenance playbooks.

This PR:

- adds a 'psql-client' role based on @kayiwa's work in the cdh-ansible repo
- updates the variables, README, and tests in the role for use in the Prancible repo
- adds the 'psql-client' role to our molecule roster
- uses the approvals project as a test case
  - changes the approvals role by removing the postgresql role as a dependency
  - changes the ruby-app role to use the psql-client role instead of the postgresql role
