### PR TITLE
[EZProxy] add more internal IP ranges to allow list 

### DIFF
--- a/roles/ezproxy/templates/princeton_allow.txt.j2
+++ b/roles/ezproxy/templates/princeton_allow.txt.j2
@@ -5,7 +5,9 @@ IncludeIP 0.0.0.0 - 255.255.255.255
 ExcludeIP 128.112.0.0 - 128.112.255.255
 ExcludeIP 140.180.0.0 - 140.180.255.255
 ExcludeIP 172.24.0.0 - 172.24.31.255
-ExcludeIP 10.48.0.0 - 10.49.255.255
-ExcludeIP 10.249.0.0 - 10.249.255.255
+ExcludeIP 10.8.0.0 - 10.9.255.255 #EduroamSecure/Servicenet
+ExcludeIP 10.48.0.0 - 10.49.255.255 #EduroamUndergrad
+ExcludeIP 10.50.0.0 - 10.51.255.255 #EduroamGraduate
+ExcludeIP 10.249.0.0 - 10.249.255.255 #NextGenNetwork
 ### Permitted for Anywhere Access Support - Autologin is not otherwise used
 AutoLoginIP 35.153.163.236


### PR DESCRIPTION
adding more Eduroam IP ranges for campus networks

Related to ServiceNow ticket: TKT0448806