### PR TITLE
[Allsearch API] make passive health checks more permissive on load balancer

### DIFF
--- a/roles/nginxplus/files/conf/http/allsearch_prod.conf
+++ b/roles/nginxplus/files/conf/http/allsearch_prod.conf
@@ -12,8 +12,8 @@ limit_req_zone $external_traffic zone=allsearch-prod-ratelimit:10m rate=10r/s;
 upstream allsearch {
     zone allsearch 128k;
     least_conn;
-    server allsearch-prod1.princeton.edu resolve;
-    server allsearch-prod2.princeton.edu resolve;
+    server allsearch-prod1.princeton.edu resolve max_fails=3 fail_timeout=5s;
+    server allsearch-prod2.princeton.edu resolve max_fails=3 fail_timeout=5s;
     sticky learn
           create=$upstream_cookie_allsearchcookie
           lookup=$cookie_allsearchcookie


### PR DESCRIPTION
Yesterday, we saw a scenario where passive health checks were failing frequently for both allsearch api boxes, taking the application down for a few seconds at a time.

We have not yet figured out why this is happening: there is not a backlog of requests in the queue on the upstreams.  However, we can make the passive health checks a bit more permissive in the meantime while we investigate.