### PR TITLE
[PostgreSQL] adds a role for postgreSQL client actions

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -60,6 +60,7 @@ jobs:
           - php
           - postfix
           - postgresql
+          - psql-client
           - pulfalight
           - pul_nomad
           - pulmap
@@ -131,4 +132,3 @@ jobs:
         run: |
           docker ps -a
           docker logs $(docker ps -aq --filter name=instance) || true
-

--- a/roles/approvals/meta/main.yml
+++ b/roles/approvals/meta/main.yml
@@ -16,4 +16,3 @@ galaxy_info:
 dependencies:
   - role: 'ruby_app'
   - role: 'mailcatcher'
-  - role: 'postgresql'

--- a/roles/psql-client/.yamllint
+++ b/roles/psql-client/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/psql-client/README.md
+++ b/roles/psql-client/README.md
@@ -1,0 +1,52 @@
+# psql-client
+=========
+
+Connects to a remote postgres server and uses provided admin credentials to create a new database and user account for a given application. It can also manage database backups.
+
+## Requirements
+------------
+
+This role requires the `community.postgresql` collection to manage the database and users.
+
+## Variables
+------------
+
+### Database Connection & Credentials
+
+- `postgres_port`: port at which remote postgres server is accessible (default: `5432`)
+- `postgres_host`: hostname for remote postgres server (default: `postgres`)
+- `postgres_version`: version of postgres in use (default: `15`)
+- `vault_postgres_admin_user`: account on postgres server with db creation permissions (default: `postgres`)
+- `vault_postgres_admin_password`: password for admin postgres account (default: `postgres`)
+
+### Application Settings
+
+- `application_db_name`: postgres database to create for app (default: `app`)
+- `application_dbuser_name`: postgres account for app that will be created with access to app's database (default: `app_user`)
+- `application_dbuser_password`: password for app's postgres account (default: `changethis`)
+- `application_dbuser_role_attr_flags`: capabilities to grant to app's postgres account (default: `""`)
+
+### Deployment & Backup Settings
+
+- `deploy_user`: the system user on the app host that will own the backup files (default: `deploy`)
+- `deploy_user_venv`: path to the virtual environment for the deploy user (default: `/home/{{ deploy_user }}/venv`)
+- `db_backup_path`: the path on the app host where the database backup will be saved (default: `/home/{{ deploy_user }}/last_{{ application_db_name }}.sql`)
+
+### Feature Flags
+
+- `postgres_setup_enabled`: whether to run the installation, configuration, and user/db creation tasks (default: `true`)
+- `postgres_backup_enabled`: whether to run the database backup tasks (default: `true`)
+
+## Example Playbook
+------------
+
+```yml
+    - hosts: servers
+      vars:
+        postgres_setup_enabled: true
+        postgres_backup_enabled: true
+        application_db_name: my_app_db
+        deploy_user: my_deploy_user
+      roles:
+         - psql-client
+```

--- a/roles/psql-client/defaults/main.yml
+++ b/roles/psql-client/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# postgres VM settings
+postgres_port: 5432
+postgres_version: 15
+postgres_host: postgres
+postgres_admin_user: postgres
+vault_postgres_admin_password: postgres
+# application settings
+application_db_name: app
+application_dbuser_name: app_user
+application_dbuser_password: changethis
+application_dbuser_role_attr_flags: ""
+# apt settings
+postgres_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+postgres_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
+# task settings
+deploy_user: deploy
+deploy_user_venv: "/home/{{ deploy_user }}/venv"
+db_backup_path: "/home/{{ deploy_user }}/last_{{ application_db_name }}.sql"
+# feature flags
+postgres_setup_enabled: true
+postgres_backup_enabled: true

--- a/roles/psql-client/handlers/main.yml
+++ b/roles/psql-client/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# handlers file for postgresql
+- name: Reload remote postgres
+  ansible.builtin.systemd:
+    name: postgresql
+    # the service name on RHEL/Rocky is different
+    # but we shouldn't need that here
+    state: reloaded
+  become: yes
+  delegate_to: '{{ postgres_host }}'

--- a/roles/psql-client/meta/main.yml
+++ b/roles/psql-client/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: psql-client
+  author: Princeton University Library
+  description: Set up a remote postgres database and user
+  license: Apache-2.0
+
+  min_ansible_version: "2.12"
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+
+  galaxy_tags:
+    - postgresql
+    - database
+    - backup
+    - ubuntu

--- a/roles/psql-client/molecule/default/Dockerfile.j2
+++ b/roles/psql-client/molecule/default/Dockerfile.j2
@@ -1,0 +1,9 @@
+FROM pulibrary/puldocker-ubuntu1804-ansible:latest
+
+# Install postgres
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql
+
+# Ensure postgres service is running
+RUN service postgresql restart
+CMD ["/sbin/my_init"]

--- a/roles/psql-client/molecule/default/converge.yml
+++ b/roles/psql-client/molecule/default/converge.yml
@@ -1,0 +1,28 @@
+---
+- name: Converge
+  hosts: instance
+  vars:
+    running_on_server: false
+    ansible_default_ipv4: { address: "127.0.0.1" }
+  become: true
+  pre_tasks:
+    - name: Update cache
+      ansible.builtin.apt:
+        name: locales
+        update_cache: true
+        cache_valid_time: 600
+
+    - name: Ensure en_US.UTF-8 locale is uncommented in /etc/locale.gen
+      ansible.builtin.lineinfile:
+        path: /etc/locale.gen
+        regexp: '^# en_US.UTF-8 UTF-8'
+        line: 'en_US.UTF-8 UTF-8'
+        state: present
+
+    - name: Generate locales
+      ansible.builtin.command: locale-gen
+      changed_when: false
+  tasks:
+    - name: "Include psql-client role"
+      ansible.builtin.include_role:
+        name: psql-client

--- a/roles/psql-client/molecule/default/create.yml
+++ b/roles/psql-client/molecule/default/create.yml
@@ -1,0 +1,62 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    molecule_inventory:
+      all:
+        children:
+          molecule:
+            hosts: {}
+
+  tasks:
+    - name: Set async_dir for HOME env (Ansible 2.19+ safe)
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME') | default('') | length) > 0
+
+    - name: Create docker network(s)
+      community.docker.docker_network:
+        name: CI
+        state: present
+
+    - name: Create container(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        state: started
+        platform: "{{ item.platform | default(omit) }}"
+        recreate: false
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
+        # Only pass command if it’s non-empty; otherwise use image CMD (/sbin/init in your image)
+        command: "{{ (item.command | default('') | length > 0) | ternary(item.command, omit) }}"
+        log_driver: json-file
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Add containers to dynamic inventory
+      vars:
+        inventory_partial_yaml: |
+          all:
+            children:
+              molecule:
+                hosts:
+                  "{{ item.name }}":
+                    ansible_connection: community.docker.docker
+      ansible.builtin.set_fact:
+        molecule_inventory: "{{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Write dynamic inventory file
+      ansible.builtin.copy:
+        dest: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        content: "{{ molecule_inventory | to_yaml }}"
+        mode: "0600"
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory

--- a/roles/psql-client/molecule/default/destroy.yml
+++ b/roles/psql-client/molecule/default/destroy.yml
@@ -1,0 +1,18 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Stop and remove container(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: true
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Remove dynamic inventory file
+      ansible.builtin.file:
+        path: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        state: absent

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -1,0 +1,69 @@
+---
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    platform: linux/amd64
+    command: "" # image above already has the /sbin/init
+    networks:
+      - name: CI
+        aliases:
+          - instance
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+  - name: postgres
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    platform: linux/amd64
+    command: "" # image above already has the /sbin/init
+    networks:
+      - name: CI
+        aliases:
+          - postgres
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    create: create.yml
+    destroy: destroy.yml
+  # inventory:
+  config_options:
+    defaults:
+      remote_tmp: /tmp
+  log: true
+verifier:
+  name: ansible

--- a/roles/psql-client/molecule/default/prepare.yml
+++ b/roles/psql-client/molecule/default/prepare.yml
@@ -1,0 +1,71 @@
+- name: Prepare Postgres Database Server
+  hosts: postgres
+  become: true
+  vars_files:
+    - ../../defaults/main.yml
+  tasks:
+    - name: Make sure CA certificates are available
+      ansible.builtin.apt:
+        name: ca-certificates
+        state: present
+        update_cache: true
+
+    - name: Add postgres repository apt-key
+      ansible.builtin.apt_key:
+        url: "{{ postgres_apt_key_url }}"
+        state: present
+
+    - name: Add postgres repository
+      ansible.builtin.apt_repository:
+        repo: "{{ postgres_apt_repository }}"
+        update_cache: true
+        state: present
+
+    - name: Install Postgresql and Python on DB host
+      ansible.builtin.apt:
+        name:
+          - libpq-dev
+          - postgresql-{{ postgres_version }}
+          - postgresql-contrib-{{ postgres_version }}
+          - postgresql-client-{{ postgres_version }}
+          - python3-psycopg2
+          - sudo
+        state: present
+        update_cache: true
+
+    - name: Install psycopg2 for Ansible Python
+      ansible.builtin.pip:
+        name: psycopg2-binary
+        executable: pip3
+        extra_args: --break-system-packages
+
+    - name: Listen on all container addresses
+      ansible.builtin.lineinfile:
+        path: "/etc/postgresql/{{ postgres_version }}/main/postgresql.conf"
+        regexp: '^#?listen_addresses\s*='
+        line: "listen_addresses = '*'"
+
+    - name: Allow password auth from Molecule containers
+      ansible.builtin.lineinfile:
+        path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
+        line: "host    all             all             0.0.0.0/0               md5"
+
+    - name: Start postgresql service
+      ansible.builtin.service:
+        name: postgresql
+        state: restarted
+        enabled: true
+
+    - name: Set postgres user password for testing
+      become_user: postgres
+      ansible.builtin.command: psql -c "ALTER USER postgres PASSWORD 'postgres';"
+      changed_when: false
+
+- name: Prepare Application Instance
+  hosts: instance
+  become: true
+  tasks:
+    - name: Ensure deploy user exists
+      ansible.builtin.user:
+        name: deploy
+        state: present

--- a/roles/psql-client/molecule/default/verify.yml
+++ b/roles/psql-client/molecule/default/verify.yml
@@ -1,0 +1,23 @@
+---
+- name: Verify
+  hosts: instance
+  gather_facts: false
+  vars_files:
+    - ../../defaults/main.yml
+  tasks:
+    - name: Ensure postgresql db user can create tables
+      community.postgresql.postgresql_query:
+        login_host: "{{ postgres_host }}"
+        login_port: "{{ postgres_port }}"
+        login_user: "{{ application_dbuser_name }}"
+        login_password: "{{ application_dbuser_password }}"
+        db: "{{ application_db_name }}"
+        query: "CREATE TABLE IF NOT EXISTS test_table (id serial PRIMARY KEY);"
+      register: table_creation
+      failed_when: table_creation.msg is defined and 'error' in table_creation.msg.lower()
+
+    - name: Verify backup file exists
+      ansible.builtin.stat:
+        path: "{{ db_backup_path }}"
+      register: backup_file
+      failed_when: not backup_file.stat.exists

--- a/roles/psql-client/requirements.yml
+++ b/roles/psql-client/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.postgresql

--- a/roles/psql-client/tasks/backup_db.yml
+++ b/roles/psql-client/tasks/backup_db.yml
@@ -1,0 +1,29 @@
+---
+# back up the database to a location on the app's host (not the db host)
+- name: Backup postgres database
+  run_once: true
+  tags: db_backup
+  block:
+    - name: Check postgres backup path
+      become: true
+      ansible.builtin.file:
+        dest: "{{ db_backup_path | dirname }}"
+        state: directory
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_user }}"
+        mode: "0755"
+
+    - name: Dump postgres database to backup path
+      become: true
+      become_user: "{{ deploy_user }}"
+      community.postgresql.postgresql_db:
+        name: "{{ application_db_name }}"
+        login_host: "{{ postgres_host }}"
+        login_port: "{{ postgres_port }}"
+        login_user: "{{ application_dbuser_name }}"
+        login_password: "{{ application_dbuser_password }}"
+        encoding: "UTF-8"
+        owner: "{{ application_dbuser_name }}"
+        state: "dump"
+        target: "{{ db_backup_path }}"
+      changed_when: false

--- a/roles/psql-client/tasks/create_db.yml
+++ b/roles/psql-client/tasks/create_db.yml
@@ -1,0 +1,17 @@
+---
+# Based on:
+# https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_db.yml
+
+- name: Ensure postgres database for app exists
+  run_once: true
+  become: true
+  community.postgresql.postgresql_db:
+    name: "{{ application_db_name }}"
+    login_host: "{{ postgres_host }}"
+    login_port: "{{ postgres_port }}"
+    login_user: "{{ postgres_admin_user }}"
+    login_password: "{{ vault_postgres_admin_password }}"
+    encoding: "UTF-8"
+    owner: "{{ application_dbuser_name }}"
+    state: "present"
+  changed_when: false

--- a/roles/psql-client/tasks/create_user.yml
+++ b/roles/psql-client/tasks/create_user.yml
@@ -1,0 +1,17 @@
+---
+# Based on:
+# https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_users.yml
+
+- name: Ensure postgres user account for app exists
+  run_once: true
+  become: true
+  community.postgresql.postgresql_user:
+    name: "{{ application_dbuser_name }}"
+    login_host: "{{ postgres_host }}"
+    login_port: "{{ postgres_port }}"
+    login_user: "{{ postgres_admin_user }}"
+    login_password: "{{ vault_postgres_admin_password }}"
+    password: "{{ application_dbuser_password }}"
+    encrypted: true
+    role_attr_flags: "{{ application_dbuser_role_attr_flags }}"
+    state: "present"

--- a/roles/psql-client/tasks/main.yml
+++ b/roles/psql-client/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Setup Postgres Client and Configuration
+  when: postgres_setup_enabled | bool
+  block:
+    - name: Make sure CA certificates are available
+      become: true
+      ansible.builtin.apt:
+        pkg: ca-certificates
+        state: present
+
+    - name: Add postgres repository apt-key
+      become: true
+      ansible.builtin.apt_key:
+        url: "{{ postgres_apt_key_url }}"
+        state: present
+
+    - name: Add postgres repository
+      become: true
+      ansible.builtin.apt_repository:
+        repo: "{{ postgres_apt_repository }}"
+        update_cache: true
+        state: present
+
+    - name: Install postgres client libraries
+      become: true
+      ansible.builtin.apt:
+        name:
+          - libpq-dev
+          - python3-dev
+          - python3-psycopg2
+          - "postgresql-client-{{ postgres_version }}"
+        state: present
+        update_cache: true
+
+    - name: Install psycopg2 for Ansible Python
+      ansible.builtin.pip:
+        name: psycopg2-binary
+        executable: pip3
+        extra_args: --break-system-packages
+
+    - name: set fqdn for use in pg_hba
+      ansible.builtin.set_fact:
+        "pg_hba_fqdn={{ ansible_facts['fqdn'] }}"
+
+    - name: Ensure access to postgres server
+      become: true
+      ansible.builtin.lineinfile:
+        path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
+        line: "host    all             all             {{ pg_hba_fqdn }}       md5"
+      delegate_to: "{{ postgres_host }}"
+      notify: Reload remote postgres
+
+- name: Create postgres user
+  ansible.builtin.import_tasks: create_user.yml
+  when: postgres_setup_enabled | bool
+
+- name: Create postgres database
+  ansible.builtin.import_tasks: create_db.yml
+  when: postgres_setup_enabled | bool
+
+- name: Backup postgres database
+  ansible.builtin.import_tasks: backup_db.yml
+  when: postgres_backup_enabled | bool


### PR DESCRIPTION
Follow up to #7184, #7191, and #7195.

The current `postgresql` role includes tasks for building a postgres server, building a postgres cluster, and creating a database for use by a client application. This PR continues the work of separating out those tasks.

This PR:
- creates a psql-client role
- tests the psql-client role by creating two containers: one for the client application and one for the database server
- removes the extra dependency on the postgresql role from the approvals role
- uses FQDNs instead of IPs for enabling connections to our postgresql servers

We agreed to try moving one client application over to the `psql-client` role at a time. However, this will be challenging, because the `ruby_app` role lists a dependency on the `postgresql` role. If we change that dependency from `postgresql` to `psql-client`, all applications that call the `ruby_app` role from their playbooks will switch at the same time. 

Also, right now the tests for those client applications fail if we switch them over. The `psql-client` tests require two containers and a network, which are created by settings in `roles/psql-client/molecule/default/molecule.yml` and tasks in `roles/psql-client/molecule/default/prepare.yml`. Any other role that calls the `psql-client` role as part of its testing currently only runs the tasks in the `psql-client` role, skipping the `prepare.yml`, which means the tests fail for lack of preparation. 