### PR TITLE
[microk8s] Allow routed MicroK8s pod traffic through UFW

### DIFF
--- a/group_vars/pulmap/staging.yml
+++ b/group_vars/pulmap/staging.yml
@@ -166,9 +166,9 @@ otel_exporters:
     resolver:
       static:
         hostnames:
-          - k8s-staging1.lib.princeton.edu:30374
-          - k8s-staging2.lib.princeton.edu:30374
-          - k8s-staging3.lib.princeton.edu:30374
+          - k8s-staging1.lib.princeton.edu:32317
+          - k8s-staging2.lib.princeton.edu:32317
+          - k8s-staging3.lib.princeton.edu:32317
 
   debug:
     verbosity: basic

--- a/roles/microk8s_cluster/defaults/main.yml
+++ b/roles/microk8s_cluster/defaults/main.yml
@@ -80,7 +80,25 @@ microk8s_ufw_rules:
     proto: tcp
     comment: "MicroK8s ingress HTTP"
 
-# Adjust this to the staging subnet if you want to restrict it.
+microk8s_pod_cidr: "10.1.0.0/16"
+
+microk8s_ufw_route_rules:
+  - interface_in: vxlan.calico
+    interface_out: cali+
+    comment: "MicroK8s Calico VXLAN to pod interface forwarding"
+
+  - interface_in: cali+
+    interface_out: vxlan.calico
+    comment: "MicroK8s pod interface to Calico VXLAN forwarding"
+
+  - interface_in: cali+
+    interface_out: cali+
+    comment: "MicroK8s pod-to-pod same-node forwarding"
+
+  - from_ip: "{{ microk8s_pod_cidr }}"
+    to_ip: "{{ microk8s_pod_cidr }}"
+    comment: "MicroK8s pod CIDR routed traffic"
+
 nfs_export_allowed_clients: "*"
 
 nfs_export_options:

--- a/roles/microk8s_cluster/tasks/firewall.yml
+++ b/roles/microk8s_cluster/tasks/firewall.yml
@@ -24,6 +24,21 @@
     - microk8s_ufw_binary.stat.exists
     - "'Status: active' in microk8s_ufw_status.stdout"
 
+- name: Allow MicroK8s routed pod traffic
+  community.general.ufw:
+    rule: allow
+    route: true
+    interface_in: "{{ item.interface_in | default(omit) }}"
+    interface_out: "{{ item.interface_out | default(omit) }}"
+    from_ip: "{{ item.from_ip | default(omit) }}"
+    to_ip: "{{ item.to_ip | default(omit) }}"
+    comment: "{{ item.comment }}"
+  loop: "{{ microk8s_ufw_route_rules }}"
+  when:
+    - microk8s_manage_ufw | bool
+    - microk8s_ufw_binary.stat.exists
+    - "'Status: active' in microk8s_ufw_status.stdout"
+
 - name: Allow MicroK8s ingress traffic from load balancers
   community.general.ufw:
     rule: allow


### PR DESCRIPTION
Add UFW route rules for Calico VXLAN and pod CIDR traffic so pod-to-pod
forwarded traffic is not blocked by the host firewall. This prevents DNS
traffic such as vxlan.calico -> cali+ UDP/53 from being dropped.

Also keep explicit MicroK8s interface rules for vxlan.calico and cali+.

We suspect this to have impacted the staging hosts
<img width="1655" height="555" alt="Screenshot 2026-06-15 at 8 24 48 AM" src="https://github.com/user-attachments/assets/d33f1315-56ed-4556-82ce-28a0266bbcb6" />
