### PR TITLE
[towerdeploy] Pin i18n for Ruby 3.1 compatibility

### DIFF
--- a/roles/towerdeploy/defaults/main.yml
+++ b/roles/towerdeploy/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for towerdeploy
 cap_version: "3.19.2"
+i18n_version: "1.14.8"

--- a/roles/towerdeploy/tasks/main.yml
+++ b/roles/towerdeploy/tasks/main.yml
@@ -1,32 +1,30 @@
 ---
 # tasks file for towerdeploy
 
-- name: towerdeploy | install capistrano
-  ansible.builtin.command: gem install capistrano --version "{{ cap_version }}"
-  register: gemoutput
-  # note: upgrading the cap version will not report 'changed'
-  changed_when: gemoutput.rc != 0
-  failed_when: gemoutput.rc !=0
-
-- name: towerdeploy | install capistrano dependencies
-  ansible.builtin.command: gem install "{{ item }}"
-  register: capgemoutput
-  changed_when: capgemoutput.rc != 0
-  failed_when: capgemoutput.rc !=0
+- name: towerdeploy | install ruby gems
+  community.general.gem:
+    name: "{{ item.name }}"
+    version: "{{ item.version | default(omit) }}"
+    state: present
+    user_install: false
+    include_doc: false
   loop:
-    - activesupport
-    - airbrussh
-    - capistrano-composer
-    - capistrano-passenger
-    - capistrano-rails
-    - capistrano-rails-console
-    - capistrano-yarn
-    - concurrent-ruby
-    - flipper
-    - honeybadger
-    - i18n
-    - net-scp
-    - net-ssh
-    - rake
-    - sshkit
-    - whenever
+    - name: i18n
+      version: "{{ i18n_version }}"
+    - name: capistrano
+      version: "{{ cap_version }}"
+    - name: activesupport
+    - name: airbrussh
+    - name: capistrano-composer
+    - name: capistrano-passenger
+    - name: capistrano-rails
+    - name: capistrano-rails-console
+    - name: capistrano-yarn
+    - name: concurrent-ruby
+    - name: flipper
+    - name: honeybadger
+    - name: net-scp
+    - name: net-ssh
+    - name: rake
+    - name: sshkit
+    - name: whenever


### PR DESCRIPTION
Pin the i18n gem to 1.14.8 for towerdeploy because newer 1.15.x releases call Fiber.[], which is only available in Ruby 3.2+.

Replace shell-based gem installs with community.general.gem so the role is idempotent and can pin versions cleanly.