### PR TITLE
adds a playbook that just tests connectivity

### DIFF
--- a/playbooks/utils/connection_audit.yml
+++ b/playbooks/utils/connection_audit.yml
@@ -1,0 +1,17 @@
+---
+# This playbook checks whether Tower can connect to all hosts in inventory
+# this should enable us to identify and solve connection problems
+#
+- name: confirm Ansible access to all inventory
+  hosts: all
+  remote_user: pulsys
+  become: true
+  vars_files:
+    - ../../group_vars/all/vars.yml
+    - ../../group_vars/all/vault.yml
+
+  tasks:
+  # connection failures should happen in the Gather Facts section
+  - name: Report success of connection
+    ansible.builtin.debug:
+      msg: Ansible successfully connected to {{ inventory_hostname }}


### PR DESCRIPTION
As part of updating OS packages, installing security tools, and other tasks that apply across our infrastructure, we have struggled with unreachable hosts.

This PR adds a playbook that just checks whether Ansible can reach all hosts in our inventory. This should help us identify and correct connection issues.

Related to #7099 #3915 