### PR TITLE
removes decomissioned hosts: a sandbox VM and e PRDS-dataspace cloud instances

### DIFF
--- a/inventory/all_projects/sandboxes.ini
+++ b/inventory/all_projects/sandboxes.ini
@@ -16,6 +16,5 @@ sandbox-fkayiwa1.lib.princeton.edu
 # sandbox-dp1285.lib.princeton.edu
 sandbox-heberlei.lib.princeton.edu
 sandbox-pp9425.lib.princeton.edu
-sandbox-rl36771.lib.princeton.edu
 sandbox-signoz1.lib.princeton.edu
 sandbox-vkarasic.lib.princeton.edu

--- a/inventory/by_cloud/aws.ini
+++ b/inventory/by_cloud/aws.ini
@@ -11,18 +11,11 @@ pdc-globus-staging-precuration ansible_host=pdc-globus-staging-precuration.pulcl
 pdc-globus-staging-postcuration ansible_host=pdc-globus-staging-postcuration.pulcloud.net
 pdc-globus-staging-embargo ansible_host=pdc-globus-staging-embargo.pulcloud.net
 
-[prds_production]
-prds-dataspace-dtn1 ansible_host=prds-dataspace-dtn1.pulcloud.net
-prds-dataspace-endpoint1 ansible_host=prds-dataspace-endpoint1.pulcloud.net
-
-[prds_staging]
-prds-dataspace-staging-endpoint1 ansible_host=prds-dataspace-staging-endpoint1.pulcloud.net
-
 [pulcheck_aws]
 pulmonitor-aws ansible_host=pulmonitor-aws.pulcloud.net
 # do not add to the aws_production group
 # already included in the main 'production' group
-# otherwise we'll have a race condition, monitoring the monitoring 
+# otherwise we'll have a race condition, monitoring the monitoring
 
 
 [aws_production:children]


### PR DESCRIPTION
As part of our audit of security tool installation, we discovered a few hosts in our inventory that no longer exist.

This PR removes one sandbox VM and three AWS instances:
- sandbox-rl36771.lib.princeton.edu
- prds-dataspace-dtn1
- prds-dataspace-endpoint1
- prds-dataspace-staging-endpoint1