### PR TITLE
[Security] Installing XDR on FreeBSD is not possible, stop trying

### DIFF
--- a/playbooks/utils/security_install.yml
+++ b/playbooks/utils/security_install.yml
@@ -21,80 +21,84 @@
     ansible.builtin.service_facts:
 
   tasks:
-  - name: Download the XDR deb file (Ubuntu)
-    ansible.builtin.unarchive:
-      src: "https://pulmirror.princeton.edu/mirror/palo/Linux-{{ xdr_version }}_deb.tar.gz"
-      dest: /opt/
-      creates: /opt/{{ cortex_install }}.deb
-      remote_src: true
-    become: true
+  - name: Install XDR except on FreeBSD
     when:
-      - ansible_os_family == "Debian"
+      - ansible_distribution != "FreeBSD"
+    block:
+    - name: Download the XDR deb file (Ubuntu)
+      ansible.builtin.unarchive:
+        src: "https://pulmirror.princeton.edu/mirror/palo/Linux-{{ xdr_version }}_deb.tar.gz"
+        dest: /opt/
+        creates: /opt/{{ cortex_install }}.deb
+        remote_src: true
+      become: true
+      when:
+        - ansible_os_family == "Debian"
 
-  - name: Download the XDR rpm file (RedHat)
-    ansible.builtin.unarchive:
-      src: "https://pulmirror.princeton.edu/mirror/palo/Linux-{{ xdr_version }}_rpm.tar.gz"
-      dest: /opt/
-      creates: /opt/{{ cortex_install }}.rpm
-      remote_src: true
-    become: true
-    when:
-      - ansible_os_family == "RedHat"
+    - name: Download the XDR rpm file (RedHat)
+      ansible.builtin.unarchive:
+        src: "https://pulmirror.princeton.edu/mirror/palo/Linux-{{ xdr_version }}_rpm.tar.gz"
+        dest: /opt/
+        creates: /opt/{{ cortex_install }}.rpm
+        remote_src: true
+      become: true
+      when:
+        - ansible_os_family == "RedHat"
 
-  - name: Install Cortex XDR dependencies (RedHat)
-    ansible.builtin.dnf:
-      name: selinux-policy-devel
-      state: present
-    become: true
-    when:
-      - ansible_os_family == "RedHat"
+    - name: Install Cortex XDR dependencies (RedHat)
+      ansible.builtin.dnf:
+        name: selinux-policy-devel
+        state: present
+      become: true
+      when:
+        - ansible_os_family == "RedHat"
 
-  # Create config directory
-  - name: Create /etc/panw directory
-    ansible.builtin.file:
-      path: /etc/panw
-      state: directory
-      owner: root
-      group: root
-      mode: '0755'
-    become: true
+    # Create config directory
+    - name: Create /etc/panw directory
+      ansible.builtin.file:
+        path: /etc/panw
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      become: true
 
-  # Build the config file
-  - name: Build the XDR config file
-    ansible.builtin.copy:
-      content: |
-        --distribution-id {{ xdr_vault_distribution_id }}
-        --distribution-server {{ xdr_distribution_server }}
-      dest: /etc/panw/cortex.conf
-      owner: root
-      group: root
-      mode: '0744'
-    become: true
+    # Build the config file
+    - name: Build the XDR config file
+      ansible.builtin.copy:
+        content: |
+          --distribution-id {{ xdr_vault_distribution_id }}
+          --distribution-server {{ xdr_distribution_server }}
+        dest: /etc/panw/cortex.conf
+        owner: root
+        group: root
+        mode: '0744'
+      become: true
 
-  # apt module equiv of sudo dpkg -i filename for ubuntu
-  - name: install XDR agent (Ubuntu)
-    ansible.builtin.apt:
-      deb: "/opt/{{ cortex_install }}.deb"
-    when:
-      - ansible_os_family == "Debian"
-      - "'traps_pmd.service' not in ansible_facts.services"
+    # apt module equiv of sudo dpkg -i filename for ubuntu
+    - name: install XDR agent (Ubuntu)
+      ansible.builtin.apt:
+        deb: "/opt/{{ cortex_install }}.deb"
+      when:
+        - ansible_os_family == "Debian"
+        - "'traps_pmd.service' not in ansible_facts.services"
 
-  # yum module equiv of sudo yum -y install for rocky
-  - name: install XDR agent (RedHat)
-    ansible.builtin.dnf:
-      name: "/opt/{{ cortex_install }}.rpm"
-      state: present
-      disable_gpg_check: true
-    when:
-      - ansible_os_family == "RedHat"
-  #
-  # Force agent checkin after installation
-  - name: Run cytool checkin
-    ansible.builtin.command:
-      cmd: /opt/traps/bin/cytool checkin
-    become: true
-    register: cytool_result
-    changed_when: cytool_result.rc == 0
+    # yum module equiv of sudo yum -y install for rocky
+    - name: install XDR agent (RedHat)
+      ansible.builtin.dnf:
+        name: "/opt/{{ cortex_install }}.rpm"
+        state: present
+        disable_gpg_check: true
+      when:
+        - ansible_os_family == "RedHat"
+    #
+    # Force agent checkin after installation
+    - name: Run cytool checkin
+      ansible.builtin.command:
+        cmd: /opt/traps/bin/cytool checkin
+      become: true
+      register: cytool_result
+      changed_when: cytool_result.rc == 0
 
   - name: Install, configure, and start Rapid7
     when: "ansible_facts.services['ir_agent.service'] is not defined"

--- a/playbooks/utils/security_install.yml
+++ b/playbooks/utils/security_install.yml
@@ -24,6 +24,7 @@
   - name: Install XDR except on FreeBSD
     when:
       - ansible_distribution != "FreeBSD"
+      - "'traps_pmd.service' not in ansible_facts.services"
     block:
     - name: Download the XDR deb file (Ubuntu)
       ansible.builtin.unarchive:
@@ -81,7 +82,6 @@
         deb: "/opt/{{ cortex_install }}.deb"
       when:
         - ansible_os_family == "Debian"
-        - "'traps_pmd.service' not in ansible_facts.services"
 
     # yum module equiv of sudo yum -y install for rocky
     - name: install XDR agent (RedHat)
@@ -101,7 +101,8 @@
       changed_when: cytool_result.rc == 0
 
   - name: Install, configure, and start Rapid7
-    when: "ansible_facts.services['ir_agent.service'] is not defined"
+    when:
+     - "'ir_agent.service' not in ansible_facts.services"
     block:
       - name: Download the Rapid7 deb file (Ubuntu)
         ansible.builtin.get_url:
@@ -154,7 +155,8 @@
         become: true
 
   - name: Install and configure the Rapid7 Scan Assistant Service
-    when: "ansible_facts.services['R7ScanAssistant.service'] is not defined"
+    when:
+      - "'R7ScanAssistant.service' not in ansible_facts.services"
     block:
       - name: Download package with checksum verification deb file (Ubuntu)
         ansible.builtin.get_url:

--- a/playbooks/utils/security_install.yml
+++ b/playbooks/utils/security_install.yml
@@ -16,11 +16,10 @@
     - ../../group_vars/all/vars.yml
     - ../../group_vars/all/vault.yml
 
-  pre_tasks:
+  tasks:
   - name: Populate service facts
     ansible.builtin.service_facts:
 
-  tasks:
   - name: Install XDR except on FreeBSD
     when:
       - ansible_distribution != "FreeBSD"

--- a/playbooks/utils/security_install.yml
+++ b/playbooks/utils/security_install.yml
@@ -99,9 +99,10 @@
       register: cytool_result
       changed_when: cytool_result.rc == 0
 
-  - name: Install, configure, and start Rapid7
+  - name: Install, configure, and start Rapid7 except on FreeBSD
     when:
-     - "'ir_agent.service' not in ansible_facts.services"
+      - ansible_distribution != "FreeBSD"
+      - "'ir_agent.service' not in ansible_facts.services"
     block:
       - name: Download the Rapid7 deb file (Ubuntu)
         ansible.builtin.get_url:
@@ -153,8 +154,9 @@
           state: restarted
         become: true
 
-  - name: Install and configure the Rapid7 Scan Assistant Service
+  - name: Install and configure the Rapid7 Scan Assistant Service except on FreeBSD
     when:
+      - ansible_distribution != "FreeBSD"
       - "'R7ScanAssistant.service' not in ansible_facts.services"
     block:
       - name: Download package with checksum verification deb file (Ubuntu)


### PR DESCRIPTION
The XDR tool will not run on FreeBSD. This PR acknowledges that fact, and adjusts the security-tools installation playbook so it will not fail against FreeBSD machines. The absence of XDR will still be noticeable on the security tools audit whenver we run that.

This PR:
- puts the XDR installation tasks into a block which only runs when the service is not present and the OS is not FreeBSD
- uses a standard syntax for the conditions that check the presence or absence of services: rapid7, rapid7 Scan Assistant, and XDR

