### PR TITLE
Update gcp inventory, remove Simrisk

### DIFF
--- a/inventory/by_cloud/google_cloud.ini
+++ b/inventory/by_cloud/google_cloud.ini
@@ -9,7 +9,10 @@ bastion-prod.pulcloud.io
 bastion-staging.pulcloud.io
 
 [cdhapps_staging]
-gcp-simrisk-staging ansible_host=10.140.0.17
+# gcp-simrisk-staging ansible_host=10.140.0.17
+
+[cdhapps_production]
+simrisk ansible_host=10.140.0.17
 
 [dspace_production]
 gcp-dataspace-prod1 ansible_host=10.244.0.2
@@ -38,6 +41,7 @@ proquestdrop.pulcloud.io ansible_ssh_common_args=''
 
 [gcp_production:children]
 dspace_production
+cdhapps_production
 
 [gcp_production:vars]
 ansible_ssh_common_args=-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p"

--- a/inventory/by_cloud/google_cloud.ini
+++ b/inventory/by_cloud/google_cloud.ini
@@ -8,12 +8,6 @@ bastion-prod.pulcloud.io
 [bastion_staging]
 bastion-staging.pulcloud.io
 
-[cdhapps_staging]
-# gcp-simrisk-staging ansible_host=10.140.0.17
-
-[cdhapps_production]
-simrisk ansible_host=10.140.0.17
-
 [dspace_production]
 gcp-dataspace-prod1 ansible_host=10.244.0.2
 gcp-oar-prod1 ansible_host=10.244.0.3
@@ -41,14 +35,13 @@ proquestdrop.pulcloud.io ansible_ssh_common_args=''
 
 [gcp_production:children]
 dspace_production
-cdhapps_production
+gcploadbalancer_production
 
 [gcp_production:vars]
 ansible_ssh_common_args=-o ProxyCommand="ssh '-o ForwardAgent yes' '-o StrictHostKeyChecking=accept-new' -q pulsys@bastion-prod.pulcloud.io -W %h:%p"
 checkmk_folder=linux/production
 
 [gcp_staging:children]
-cdhapps_staging
 dspace_staging
 gcploadbalancer_staging
 


### PR DESCRIPTION
Closes #7246.

At some point the staging Simrisk instance on GCP was renamed / promoted to production. But CDH is not currently runnign this service. I've deleted the instance in GCP. This PR removes all traces of Simrisk from our inventory.