### PR TITLE
Updates inventory group membership for prds and GCP

### DIFF
--- a/inventory/by_cloud/google_cloud.ini
+++ b/inventory/by_cloud/google_cloud.ini
@@ -53,6 +53,8 @@ checkmk_folder=linux/staging
 [freebsd:children]
 bastion_production
 bastion_staging
+gcploadbalancer_production
+gcploadbalancer_staging
 pulmirror_production
 proquestdrop_production
 

--- a/inventory/by_environment/production.ini
+++ b/inventory/by_environment/production.ini
@@ -38,7 +38,6 @@ pdc_discovery_production
 pdc_production
 postfix_production
 postgresql_production
-prds_production
 prosody_production
 pulcheck_production
 pulcheck_aws

--- a/inventory/by_environment/staging.ini
+++ b/inventory/by_environment/staging.ini
@@ -42,7 +42,6 @@ pdc_describe_redis_staging
 pdc_discovery_staging
 postfix_staging
 postgresql_staging
-prds_staging
 prosody_staging
 pulfalight_staging
 pulmap_staging


### PR DESCRIPTION
Follow up on #7244.

Removes the inventory groups for the PRDS hosts, since groups are useless when they don't have any hosts in them.

Adds the GCP load balancer groups to the FreeBSD group.