### PR TITLE
[inventory] really, really get rid of PRDS groups

### DIFF
--- a/inventory/by_cloud/aws.ini
+++ b/inventory/by_cloud/aws.ini
@@ -19,14 +19,12 @@ pulmonitor-aws ansible_host=pulmonitor-aws.pulcloud.net
 
 
 [aws_production:children]
-prds_production
 pdc_production
 
 [aws_production:vars]
 checkmk_folder=linux/rdss
 
 [aws_staging:children]
-prds_staging
 pdc_staging
 
 [aws_staging:vars]

--- a/inventory/by_environment/production.ini
+++ b/inventory/by_environment/production.ini
@@ -99,7 +99,6 @@ pdc_discovery_production
 pdc_production
 postfix_production
 postgresql_production
-prds_production
 prosody_production
 pulcheck_production
 

--- a/inventory/by_environment/staging.ini
+++ b/inventory/by_environment/staging.ini
@@ -96,7 +96,6 @@ postfix_staging
 
 [staging_3:children]
 postgresql_staging
-prds_staging
 prosody_staging
 pulfalight_staging
 pulmap_staging


### PR DESCRIPTION
Follow up to #7251 

We still had the PRDS groups mentioned in the main staging and production groups, and in sub-groups. 