### PR TITLE
updated the script to work with both rhel and ubuntu

### DIFF
--- a/roles/common/files/logrotatecheck.sh
+++ b/roles/common/files/logrotatecheck.sh
@@ -4,15 +4,14 @@
 #   If it was updated yesterday the status is warn
 #   Otherwise the status is critical
 #
-message=$(find /var/lib/logrotate/status -mtime 0)
-if [ "$message" = "/var/lib/logrotate/status" ]; then
+message=$(find /var/lib/logrotate/*status -mtime 0)
+if [[ $message == /var/lib/logrotate/*status ]]; then
   echo "0 \"Log Rotate\" - Logs were rotated today"
 else
-  yest_message=$(find /var/lib/logrotate/status -mtime 1)
-  if [ "$yest_message" = "/var/lib/logrotate/status" ]; then
+  yest_message=$(find /var/lib/logrotate/*status -mtime 1)
+  if [[ $yest_message == /var/lib/logrotate/*status ]]; then
     echo "1 \"Log Rotate\" - No logs were rotated today, but they were yesterday"
   else
     echo "2 \"Log Rotate\" - No logs were rotated today or yesterday"
   fi
 fi
-


### PR DESCRIPTION
Updated the local checkmk script that checks the status of log rotation.  
It should work now for either rhel or ubuntu.

closes #7172  