### PR TITLE
Updating the ruby version to hopefully get a newer default stringio

### DIFF
--- a/group_vars/tigerdata/common.yml
+++ b/group_vars/tigerdata/common.yml
@@ -21,7 +21,7 @@ tigerdata_honeybadger_key: '{{ vault_honeybadger_api_key }}'
 desired_nodejs_version: "v22.12.0"
 passenger_ruby: "/usr/local/bin/ruby"
 install_ruby_from_source: true
-ruby_version_override: "ruby-3.3.2"
+ruby_version_override: "ruby-3.3.11"
 passenger_app_root: "/opt/tigerdata/current/public"
 passenger_extra_config: "passenger_preload_bundler on;"
 nginx_remove_default_vhost: true


### PR DESCRIPTION
refs #7267 

This PR was run on the servers with no harm done.  That said it did not change the stringio version to `3.2.0`.  Only running an update to the gem solved the issue.
