### PR TITLE
Update orangelight.yml to use psql-client role

### DIFF
--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -16,7 +16,7 @@
     - role: bind9
     - role: ruby_s
     - role: passenger
-    - role: postgresql
+    - role: psql-client
     - role: nodejs
     - role: sidekiq_worker
       when: "'indexer' in inventory_hostname"


### PR DESCRIPTION
The Orangelight playbook has been failiing its daily run.

Althogh the role started testing the psql-client functionality  in #7272, the playbook was still calling the postgresql role. This updates the playbook. 