### PR TITLE
require single reboots of vms

### DIFF
--- a/playbooks/utils/os_updates.yml
+++ b/playbooks/utils/os_updates.yml
@@ -120,6 +120,7 @@
       when:
         - ansible_os_family == "RedHat"
         - yum_update_status.changed
-        - "'ansible' in inventory_hostname"
-        - "'recap' not in inventory_hostname"
+        - "'ansible' in inventory_hostnamee"
+        - "'k8s' not in inventory_hostname"
         - "'libserv171' not in inventory_hostname"
+        - "'recap' not in inventory_hostname"


### PR DESCRIPTION
prevent all our k8s hosts from rebooting all at once. 