### PR TITLE
[pas] update php to new package archive

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -8,4 +8,3 @@ datadog_environment: none
 php_memory_limit: '256M'
 php_webserver: 'apache2'
 php_version: '8.3'
-php_unwanted_version: '8.1'

--- a/roles/php/molecule/default/verify.yml
+++ b/roles/php/molecule/default/verify.yml
@@ -13,12 +13,12 @@
           - dirmngr
         state: present
       changed_when: false
-
-    - name: Php | Verify ondrej sury repository is added
+  
+    - name: Php | Verify official sury.org repository is added
       ansible.builtin.apt_repository:
-        repo: "ppa:ondrej/php"
-        state: present
+        repo:  "deb https://packages.sury.org/php/ {{ ansible_distribution_release }} main"
         codename: "{{ ansible_distribution_release }}"
+        state: present
       changed_when: false
 
     - name: Php | Verify PHP packages are installed

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -3,36 +3,24 @@
   ansible.builtin.debug:
     msg: PHP Web Server {{ php_webserver }}
 
-# See https://github.com/ansible/ansible/issues/62262 for why this is required
-# Short version: There is a bug in the ansible.builtin.apt module where, when using wildcards,
-# the 'absent' state fails if there are already no packages that match the wildcard.
-- name: Php | check if unwanted php packages are installed
-  ansible.builtin.shell: dpkg -l | grep php{{ php_unwanted_version }}*
-  ignore_errors: true
-  changed_when: false
-  no_log: true
-  register: php_unwanted_packages
-
-- name: Php | remove packages that begin with 'php{{ php_unwanted_version }}'
-  ansible.builtin.apt:
-    name: php{{ php_unwanted_version }}*
-    state: absent
-    autoremove: true
-  notify: restart apache
-  when: php_version != php_unwanted_version and php_unwanted_packages.rc == 0
-
 - name: Php | install required Ubuntu dependencies
   ansible.builtin.apt:
     name:
       - apt-transport-https
       - dirmngr
 
-- name: Php | Add ondrej sury repository
+- name: Php | Add official sury.org repository
   ansible.builtin.apt_repository:
-    repo: "ppa:ondrej/php"
+    repo:  "deb https://packages.sury.org/php/ {{ ansible_distribution_release }} main"
     codename: "{{ ansible_distribution_release }}"
     state: present
     update_cache: false
+
+- name: Add the Sury.org GPG key
+  ansible.builtin.apt_key:
+    url: https://packages.sury.org/php/apt.gpg
+    state: present
+  become: true
 
 - name: Php | Clean apt cache
   ansible.builtin.command: apt-get clean


### PR DESCRIPTION
ondrej no longer hosts a personal package archive and has moved it to his own dedicated domain: packages.sury.org/php

closes #7286 