### PR TITLE
use staging zone for datacommons staging site

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/datacommons_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/datacommons_staging.conf
@@ -13,8 +13,8 @@ proxy_cache_path /var/cache/nginx/describe-staging/ keys_zone=describe-stagingca
 
 upstream staging-discovery {
 	zone discovery-staging 64k;
-	server pdc-discovery-staging1.princeton.edu resolve;
-	server pdc-discovery-staging2.princeton.edu resolve;
+	server pdc-discovery-staging1.lib.princeton.edu resolve;
+	server pdc-discovery-staging2.lib.princeton.edu resolve;
 }
 
 

--- a/roles/nginxplus/files/conf/http/dev/datacommons_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/datacommons_staging.conf
@@ -12,14 +12,14 @@ proxy_cache_path /var/cache/nginx/describe-staging/ keys_zone=describe-stagingca
 
 
 upstream staging-discovery {
-	zone discovery-prod 64k;
+	zone discovery-staging 64k;
 	server pdc-discovery-staging1.princeton.edu resolve;
 	server pdc-discovery-staging2.princeton.edu resolve;
 }
 
 
 upstream staging-describe {
-	zone describe-prod 64k;
+	zone describe-staging 64k;
 	server pdc-describe-staging1.princeton.edu resolve;
 	server pdc-describe-staging2.princeton.edu resolve;
 }


### PR DESCRIPTION
Closes #7295 

We're seeing failures on dattacommons-staging.princeteon.edu/discovery. We're not entirely sure why.

The nginxplus config for datacommons-staging has been referencing the `prod` zones for describe and discovery for a while. This may or may not be related. It's possible this worked at one time, then broke after we added Traefik to the production zones, or after we moved staging to the dev load balancers, or both.

 I'm not sure this will fix the issues with datacommons-staging, but at least it'ss tidier.