### PR TITLE
fix typo in os updates playbook

### DIFF
--- a/playbooks/utils/os_updates.yml
+++ b/playbooks/utils/os_updates.yml
@@ -120,7 +120,7 @@
       when:
         - ansible_os_family == "RedHat"
         - yum_update_status.changed
-        - "'ansible' in inventory_hostnamee"
+        - "'ansible' in inventory_hostname"
         - "'k8s' not in inventory_hostname"
         - "'libserv171' not in inventory_hostname"
         - "'recap' not in inventory_hostname"


### PR DESCRIPTION
This morning's patching had several failures with this message:

```
fatal: [<hostname>]: FAILED! => {"msg": "The conditional check ''ansible' in inventory_hostnamee' failed. The error was: error while evaluating conditional ('ansible' in inventory_hostnamee): 'inventory_hostnamee' is undefined. 'inventory_hostnamee' is undefined\n\nThe error appears to be in '/runner/project/playbooks/utils/os_updates.yml': line 115, column 7,
```

The var name has a typo in it (hostnamee instead of hostname). This PR fixes the typo.