### PR TITLE
Update ORCID production host to PostgreSQL 18

### DIFF
--- a/group_vars/orcid/main.yml
+++ b/group_vars/orcid/main.yml
@@ -1,8 +1,9 @@
 ---
 postgresql_is_local: false
 postgres_port: "5432"
-postgres_admin_user: 'postgres'
-postgres_admin_password: '{{ vault_postgres_admin_password }}'
+postgres_admin_user: "postgres"
+postgres_admin_password: "{{ vault_postgres_admin_password }}"
+postgres_version: 18
 pg_hba_contype: "host"
 pg_hba_postgresql_user: "all"
 pg_hba_postgresql_database: "all"
@@ -17,14 +18,14 @@ ruby_app_name: "orcid_princeton"
 ruby_app_directory: "orcid_princeton"
 ruby_app_symlinks: []
 
-application_db_name: '{{orcid_db_name}}'
-application_dbuser_name: '{{orcid_db_user}}'
-application_dbuser_password: '{{orcid_db_password}}'
-application_dbuser_role_attr_flags: 'CREATEDB'
-application_host: '{{passenger_server_name}}'
-application_host_protocol: 'https'
-application_port: '443'
-project_db_host: '{{postgres_host}}'
+application_db_name: "{{orcid_db_name}}"
+application_dbuser_name: "{{orcid_db_user}}"
+application_dbuser_password: "{{orcid_db_password}}"
+application_dbuser_role_attr_flags: "CREATEDB"
+application_host: "{{passenger_server_name}}"
+application_host_protocol: "https"
+application_port: "443"
+project_db_host: "{{postgres_host}}"
 
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.4.7"
@@ -33,77 +34,77 @@ passenger_extra_http_config:
   - "passenger_preload_bundler on;"
 passenger_ruby: "/usr/local/bin/ruby"
 
-cas_host: 'fed.princeton.edu'
-cas_url: 'https://fed.princeton.edu/cas'
-database_url: 'postgres://{{ orcid_db_user }}:{{ orcid_db_password }}@{{ postgres_host }}/{{ orcid_db_name }}'
+cas_host: "fed.princeton.edu"
+cas_url: "https://fed.princeton.edu/cas"
+database_url: "postgres://{{ orcid_db_user }}:{{ orcid_db_password }}@{{ postgres_host }}/{{ orcid_db_name }}"
 
 ruby_app_vars:
   - name: SECRET_KEY_BASE
-    value: '{{orcid_secret_key}}'
+    value: "{{orcid_secret_key}}"
   - name: APP_DB
-    value: '{{orcid_db_name}}'
+    value: "{{orcid_db_name}}"
   - name: APP_DB_USERNAME
-    value: '{{orcid_db_user}}'
+    value: "{{orcid_db_user}}"
   - name: APP_DB_PASSWORD
-    value: '{{orcid_db_password}}'
+    value: "{{orcid_db_password}}"
   - name: APP_DB_HOST
-    value: '{{postgres_host}}'
+    value: "{{postgres_host}}"
   - name: APPLICATION_HOST
-    value: '{{orcid_host_name}}'
+    value: "{{orcid_host_name}}"
   - name: APPLICATION_HOST_PROTOCOL
-    value: '{{application_host_protocol}}'
+    value: "{{application_host_protocol}}"
   - name: APPLICATION_PORT
-    value: '{{application_port}}'
+    value: "{{application_port}}"
   - name: HONEYBADGER_API_KEY
-    value: '{{orcid_honeybadger_key}}'
+    value: "{{orcid_honeybadger_key}}"
   - name: RAILS_MASTER_KEY
-    value: '{{orcid_rails_main_key}}'
+    value: "{{orcid_rails_main_key}}"
   - name: ORCID_CLIENT_ID
-    value: '{{orcid_client_id}}'
+    value: "{{orcid_client_id}}"
   - name: ORCID_CLIENT_SECRET
-    value: '{{orcid_client_secret}}'
+    value: "{{orcid_client_secret}}"
   - name: ORCID_SANDBOX
-    value: '{{ orcid_sandbox }}'
+    value: "{{ orcid_sandbox }}"
   - name: HANAMI_ENV
-    value: '{{ passenger_app_env }}'
+    value: "{{ passenger_app_env }}"
   - name: CAS_URL
-    value: '{{ cas_url }}'
+    value: "{{ cas_url }}"
   - name: CAS_HOST
-    value: '{{ cas_host }}'
+    value: "{{ cas_host }}"
   - name: DATABASE_URL
-    value: '{{ database_url }}'
+    value: "{{ database_url }}"
   - name: OPENSSL_ALGORITHM
-    value: 'AES-256-CBC'
+    value: "AES-256-CBC"
   - name: OPENSSL_IV_LEN
-    value: '16'
+    value: "16"
   - name: OPENSSL_KEY
-    value: '{{ orcid_token_secret }}'
+    value: "{{ orcid_token_secret }}"
   - name: BANNER_TITLE
-    value: '{{ app_banner_title }}'
+    value: "{{ app_banner_title }}"
   - name: BANNER_BODY
-    value: '{{ app_banner_body }}'
+    value: "{{ app_banner_body }}"
   - name: ORCID_SANDBOX
-    value: '{{ app_orcid_sandbox }}'
+    value: "{{ app_orcid_sandbox }}"
   - name: ORCID_URL
-    value: '{{ app_orcid_url }}'
+    value: "{{ app_orcid_url }}"
   - name: PEOPLESOFT_OUTPUT_LOCATION
-    value: '{{ peoplesoft_output_location }}'
+    value: "{{ peoplesoft_output_location }}"
   - name: OTEL_SERVICE_NAME
-    value: 'orcid'
+    value: "orcid"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: 'http://127.0.0.1:4318'
+    value: "http://127.0.0.1:4318"
   - name: OTEL_EXPORTER_OTLP_INSECURE
-    value: 'true'
+    value: "true"
   - name: OTEL_EXPORTER_OTLP_PROTOCOL
-    value: 'http/protobuf'
+    value: "http/protobuf"
   - name: ENTRA_CLIENT_ID
-    value: '{{ entra_client_id }}'
+    value: "{{ entra_client_id }}"
   - name: ENTRA_CLIENT_SECRET
-    value: '{{ entra_client_secret }}'
+    value: "{{ entra_client_secret }}"
   - name: USE_ENTRA
-    value: '{{ use_entra }}'
-peoplesoft_share: '{{ vault_orcid_peoplesoft_share }}'
-peoplesoft_host: '{{ vault_orcid_peoplesoft_host }}'
+    value: "{{ use_entra }}"
+peoplesoft_share: "{{ vault_orcid_peoplesoft_share }}"
+peoplesoft_host: "{{ vault_orcid_peoplesoft_host }}"
 
 ruby_app_dependencies:
   - cifs-utils

--- a/group_vars/orcid/production.yml
+++ b/group_vars/orcid/production.yml
@@ -1,32 +1,31 @@
 ---
-postgres_host: 'lib-postgres-prod1.princeton.edu'
-postgres_version: 15
+postgres_host: "lib-postgres-prod1.lib.princeton.edu"
 
 passenger_server_name: "orcid-prod1.princeton.edu"
 passenger_app_env: "production"
 passenger_extra_config: "client_max_body_size 0;"
 
-orcid_db_name: 'orcid_prod'
+orcid_db_name: "orcid_prod"
 
-orcid_db_user: '{{vault_orcid_production_db_user}}'
-orcid_db_password: '{{vault_orcid_production_db_password}}'
+orcid_db_user: "{{vault_orcid_production_db_user}}"
+orcid_db_password: "{{vault_orcid_production_db_password}}"
 ruby_app_env: "production"
 
-orcid_host_name: 'orcid-prod.princeton.edu'
-orcid_honeybadger_key: '{{vault_orcid_honeybadger_key}}'
+orcid_host_name: "orcid-prod.princeton.edu"
+orcid_honeybadger_key: "{{vault_orcid_honeybadger_key}}"
 
-orcid_secret_key: '{{vault_orcid_production_secret_key}}'
-orcid_rails_main_key: '{{vault_orcid_production_rails_main_key}}'
+orcid_secret_key: "{{vault_orcid_production_secret_key}}"
+orcid_rails_main_key: "{{vault_orcid_production_rails_main_key}}"
 
-orcid_client_id: '{{vault_orcid_production_client_id}}'
-orcid_client_secret: '{{vault_orcid_production_client_secret}}'
+orcid_client_id: "{{vault_orcid_production_client_id}}"
+orcid_client_secret: "{{vault_orcid_production_client_secret}}"
 orcid_sandbox: false
-orcid_token_secret: '{{ vault_orcid_production_token_secret }}'
-app_banner_title: ''
-app_banner_body: ''
+orcid_token_secret: "{{ vault_orcid_production_token_secret }}"
+app_banner_title: ""
+app_banner_body: ""
 app_orcid_sandbox: false
-app_orcid_url: 'https://api.orcid.org/v3.0'
-peoplesoft_output_location: '/mnt/peoplesoft/sr_orcid/prod/ORCID_portal_report.csv'
+app_orcid_url: "https://api.orcid.org/v3.0"
+peoplesoft_output_location: "/mnt/peoplesoft/sr_orcid/prod/ORCID_portal_report.csv"
 
 entra_client_id: "{{ vault_entra_client_id_production }}"
 entra_client_secret: "{{ vault_entra_client_secret_production }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ Pygments==2.20.0
 python-consul==1.1.0
 python-dateutil==2.9.0.post0
 python-slugify==8.0.1
-PyYAML==6.0
+PyYAML==6.0.1
 referencing==0.32.1
 requests==2.33.0
 requirements-parser==0.5.0


### PR DESCRIPTION
This advances https://github.com/pulibrary/orcid_princeton_hanami/issues/396

- Update postgres_version to 18 in group_vars/orcid/main.yml
- Remove postgres_version: 15 from group_vars/orcid/production.yml and update postgres_host to postgres18-prod1.lib.princeton.edu
- Standardize YAML string quotes from single to double quotes across orcid main and production configuration files
- Upgrade PyYAML dependency from 6.0 to 6.0.1 in requirements.txt (6.0.0 kept breaking my local macOS development environment)