### PR TITLE
Remove lib-screen01L from inventory

### DIFF
--- a/inventory/all_projects/_orphans.ini
+++ b/inventory/all_projects/_orphans.ini
@@ -19,7 +19,6 @@ lib-proc4.princeton.edu
 [utilities]
 lib-bkpsvr.princeton.edu # runs VEEAM VM backups
 lib-proc-staging1.princeton.edu
-lib-screen01L # test firewall
 libserv122.princeton.edu # lib-reports runs backup reports
 libserv171.princeton.edu # lib-storage TD/Isilon access
 lib-smb-serve.princeton.edu # SMB server


### PR DESCRIPTION
We have seen failures for maintenance playbooks against `lib-screen01L` - that's because we decommissioned it. This VM was a test firewall device from 2024.

This PR removes it from inventory.