### PR TITLE
Removing nginx plus extras

### DIFF
--- a/roles/passenger/molecule/default/verify.yml
+++ b/roles/passenger/molecule/default/verify.yml
@@ -11,7 +11,7 @@
     register: pkg_status
     loop:
       - libnginx-mod-http-passenger
-      - nginx
+      - nginx-core
 
   - name: test for passenger packages
     assert:

--- a/roles/passenger/vars/main.yml
+++ b/roles/passenger/vars/main.yml
@@ -1,9 +1,9 @@
 ---
 __nginx_user: "www-data"
 nginx_passenger_packages:
-  - nginx
-  - passenger
+  - nginx-core
   - libnginx-mod-http-passenger
+  - passenger
 # logrotate rules
 logrotate_rules:
   - name: "nginx"
@@ -19,4 +19,4 @@ logrotate_rules:
       su_group: "{{ logrotate_global_defaults.su_group }}"
       # add passenger-config reopen nginx rotate line
       postrotate: |
-        passenger-config reopen-logs >/dev/null 2>&1 || true 
+        passenger-config reopen-logs >/dev/null 2>&1 || true


### PR DESCRIPTION
Phusion now depends on nginx-common. From `apt-cache show`

```sh
Version: 1:6.1.7-1~jammy1
Depends: ..., nginx-core (= 1.18.0-6ubuntu14.16), passenger (= 1:6.1.7-1~jammy1)
Version: 1:6.1.6-1~jammy1
Depends: ..., nginx-common, passenger (= 1:6.1.6-1~jammy1)
Version: 1:6.1.5-1~jammy1
Depends: ..., nginx-common, passenger (= 1:6.1.5-1~jammy1)`
```