### PR TITLE
[psql-client] Fix PGDG package priority in psql-client role

### DIFF
--- a/group_vars/tigerdata/ci.yml
+++ b/group_vars/tigerdata/ci.yml
@@ -40,3 +40,130 @@ app_mediaflux_alternate_host: "{{ vault_mediaflux_host }}"
 app_mediaflux_domain: "{{ vault_mediaflux_domain }}"
 app_mediaflux_user: "{{ vault_mediaflux_user }}"
 app_mediaflux_password: "{{ vault_mediaflux_password }}"
+# beyla
+beyla_enabled: true
+beyla_service_name: tigerdata
+beyla_environment: ci
+beyla_otlp_endpoint: "http://127.0.0.1:4318"
+beyla_otlp_protocol: "http/protobuf"
+beyla_bpf_context_propagation: "all"
+
+beyla_open_ports:
+  - 80
+
+# signoz
+otel_default_resource_attributes:
+  host.name: "{{ inventory_hostname }}"
+  service.name: tigerdata
+  service.version: ci
+  environment: ci
+
+otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+  filelog/nginx-access:
+    include: ["/var/log/nginx/access.log*"]
+    start_at: end
+    operators:
+      - type: regex_parser
+        regex: '^(?P<remote_addr>[^\s]+) \((?P<remote_user>[^)]*)\) - - \[(?P<time_local>[^\]]+)\] "(?P<method>\S+) (?P<path>\S+) (?P<protocol>[^"]+)" (?P<status>\d+) (?P<body_bytes_sent>\d+) "(?P<http_referer>[^"]*)" "(?P<http_user_agent>[^"]*)"'
+        parse_from: body
+      - type: time_parser
+        parse_from: attributes.time_local
+        layout_type: strptime
+        layout: "%d/%b/%Y:%H:%M:%S %z"
+      - type: add
+        field: attributes.log_type
+        value: "tigerdata_access"
+      - type: add
+        field: attributes.service_name
+        value: tigerdata_access
+
+  filelog/nginx-error:
+    include: ["/var/log/nginx/error.log*"]
+    start_at: end
+    operators:
+      - type: add
+        field: attributes.log_type
+        value: "tigerdata_error"
+      - type: add
+        field: attributes.service_name
+        value: "tigerdata"
+
+  hostmetrics:
+    collection_interval: 30s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+
+otel_processors:
+  batch:
+    send_batch_max_size: 1024
+    send_batch_size: 512
+    timeout: 30s
+
+otel_exporters:
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    resolver:
+      static:
+        hostnames:
+          - k8s-staging1.lib.princeton.edu:32317
+          - k8s-staging2.lib.princeton.edu:32317
+          - k8s-staging3.lib.princeton.edu:32317
+
+  debug:
+    verbosity: basic
+
+otel_service_pipelines:
+  logs:
+    receivers:
+      - filelog/nginx-access
+      - filelog/nginx-error
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
+  metrics:
+    receivers:
+      - hostmetrics
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing

--- a/roles/psql-client/tasks/install_debian_client.yml
+++ b/roles/psql-client/tasks/install_debian_client.yml
@@ -44,6 +44,19 @@
       Signed-By: {{ postgres_apt_key_path }}
   when: postgres_manage_pgdg_repo | bool
 
+- name: Prefer PGDG PostgreSQL client packages
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/apt/preferences.d/postgresql-pgdg.pref
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      Package: postgresql-client-* postgresql-* libpq5 libpq-dev
+      Pin: origin "apt.postgresql.org"
+      Pin-Priority: 700
+  when: postgres_manage_pgdg_repo | bool
+
 - name: Install PostgreSQL client packages
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Add an APT preference for PostgreSQL client and libpq packages so PGDG packages take precedence over the Princeton Ubuntu mirror. This prevents dependency conflicts when installing versioned PostgreSQL clients while remaining compatible with PostgreSQL 15 and 18.