### PR TITLE
[nodejs] make keyring refresh idempotent and refresh safe

### DIFF
--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -12,28 +12,29 @@
     url: "{{ nodejs__yarn_key_url }}"
     dest: /tmp/yarnpkg.gpg.key
     mode: "0644"
+    force: true
   when:
     - use_yarn
     - nodejs__yarn_upstream | bool
     - not nodejs_yarn_berry_enabled | bool
 
-- name: Nodejs | De-armor Yarn GPG key to binary keyring
-  ansible.builtin.shell: "gpg --dearmor < /tmp/yarnpkg.gpg.key > {{ nodejs__yarn_keyring_path }}"
-  args:
-    creates: "{{ nodejs__yarn_keyring_path }}"
+- name: Nodejs | De-armor Yarn GPG key
+  ansible.builtin.shell: "gpg --dearmor < /tmp/yarnpkg.gpg.key > /tmp/yarnkey.gpg"
+  changed_when: false
   when:
     - use_yarn
     - nodejs__yarn_upstream | bool
     - not nodejs_yarn_berry_enabled | bool
-  become: true
 
-- name: Nodejs | Ensure keyring permissions
-  ansible.builtin.file:
-    path: "{{ nodejs__yarn_keyring_path }}"
+- name: Nodejs | Install Yarn keyring
+  ansible.builtin.copy:
+    src: /tmp/yarnkey.gpg
+    dest: "{{ nodejs__yarn_keyring_path }}"
+    remote_src: true
     mode: "0644"
     owner: root
     group: root
-    state: file
+  become: true
   when:
     - use_yarn
     - nodejs__yarn_upstream | bool


### PR DESCRIPTION
Yarn published a new signing key in January https://github.com/alshedivat/al-folio/issues/3487 some of our hosts still have the old keyring, and the role can never refresh it because of two guards we remove with this PR. `gpg dearmor` is deterministic for the same input, and copy compares checksums, so this only reports changed when the upstream key actually changes — idempotence test in molecule stays green, and the next rotation self-heals

closes #7318