### PR TITLE
[ezproxy] manage dated logs outside logrotate

### DIFF
--- a/group_vars/ezproxy/common.yml
+++ b/group_vars/ezproxy/common.yml
@@ -8,19 +8,6 @@ shib_admin_user:
 # ezproxy logrotate
 ezproxy_directory: "/var/local/ezproxy/log"
 
-ezproxy_logrotate_rules:
-  - name: "ezproxy"
-    paths:
-      - "{{ ezproxy_directory }}/*.log"
-    options:
-      rotate: "{{ logrotate_global_defaults.rotate }}"
-      maxsize: "{{ logrotate_global_defaults.maxsize }}"
-      create_mode: "{{ logrotate_global_defaults.create_mode }}"
-      create_owner: "{{ deploy_user }}"
-      create_group: "{{ deploy_user }}"
-      su_user: "{{ logrotate_global_defaults.su_user }}"
-      su_group: "{{ logrotate_global_defaults.su_group }}"
-      postrotate: |
-        if /usr/sbin/service ezproxy status  > /dev/null ; then \
-          /usr/sbin/service ezproxy restart > /dev/null; \
-        fi;
+ezproxy_log_retention_days: 7
+
+ezproxy_logrotate_rules: []

--- a/roles/ezproxy/tasks/main.yml
+++ b/roles/ezproxy/tasks/main.yml
@@ -206,6 +206,16 @@
     - ezproxy_logrotate_rules is defined
     - ezproxy_logrotate_rules | length > 0
 
+- name: Install EZproxy log maintenance script
+  ansible.builtin.template:
+    src: ezproxy-log-maintenance.sh.j2
+    dest: /etc/cron.daily/ezproxy-log-maintenance
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - running_on_server
+
 - name: Ezproxy | add user config file
   ansible.builtin.template:
     src: "user.txt.j2"

--- a/roles/ezproxy/templates/ezproxy-log-maintenance.sh.j2
+++ b/roles/ezproxy/templates/ezproxy-log-maintenance.sh.j2
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -eu
+
+log_directory={{ ezproxy_directory | quote }}
+today="$(date +%Y%m%d)"
+retention_minutes={{ (ezproxy_log_retention_days | int) * 1440 }}
+
+# Compress completed logs. Do not touch today's active log files.
+find "$log_directory" \
+  -maxdepth 1 \
+  -type f \
+  \( \
+    -name 'ezp????????.log' \
+    -o -name 'spu????????.log' \
+  \) \
+  ! -name "*${today}.log" \
+  ! -empty \
+  -exec gzip --force -- {} +
+
+# Delete compressed application logs older than the retention period.
+find "$log_directory" \
+  -maxdepth 1 \
+  -type f \
+  \( \
+    -name 'ezp????????.log.gz' \
+    -o -name 'spu????????.log.gz' \
+  \) \
+  -mmin "+${retention_minutes}" \
+  -delete
+
+# Delete empty files left by the previous logrotate configuration.
+find "$log_directory" \
+  -maxdepth 1 \
+  -type f \
+  \( \
+    -name 'ezp????????.log' \
+    -o -name 'spu????????.log' \
+  \) \
+  -empty \
+  -mmin "+${retention_minutes}" \
+  -delete
+
+# Delete archives created by the previous logrotate configuration.
+find "$log_directory" \
+  -maxdepth 1 \
+  -type f \
+  \( \
+    -name 'ezp????????.log-*' \
+    -o -name 'spu????????.log-*' \
+  \) \
+  -mmin "+${retention_minutes}" \
+  -delete


### PR DESCRIPTION
EZproxy creates a new dated log file each day instead of writing to a stable filename. The common logrotate rule therefore treated every dated file as a separate logfile.

The rotate 7 setting retained seven rotations per individual filename, not seven days of logs across the directory. Each EZproxy log was rotated only once, and create left behind an empty copy of the original file.

Because delaycompress waits until the next rotation before compressing an archive, and notifempty prevented the empty files from rotating again, the archives were never compressed or removed.

Replace the generic logrotate rule with EZproxy-specific maintenance that compresses completed dated logs and deletes logs beyond the configured retention period. Remove the unnecessary EZproxy restart after rotation.

related to #7315 