### PR TITLE
[Security] streamlines install and audit of mandated security tools

### DIFF
--- a/playbooks/utils/security_audit.yml
+++ b/playbooks/utils/security_audit.yml
@@ -3,6 +3,7 @@
 # across the infrastructure we automate with Ansible
 # if there's a service called "traps_pmd", then Cortex XDR is installed
 # if there's a service called "ir_agent", then Rapid7 is installed
+# neither of these services will run on FreeBSD
 #
 - name: audit OIT Security Tools
   hosts: all
@@ -30,9 +31,17 @@
       msg: The traps_pmd service is missing on {{ inventory_hostname }}
     when:
       - "'traps_pmd.service' not in ansible_facts.services"
+      - ansible_distribution != "FreeBSD"
 
   - name: Report absence of Rapid7 service (ir_agent)
     ansible.builtin.debug:
       msg: The ir_agent service is missing on {{ inventory_hostname }}
     when:
       - "'ir_agent.service' not in ansible_facts.services"
+      - ansible_distribution != "FreeBSD"
+
+  - name: Report absence of security services on FreeBSD
+    ansible.builtin.debug:
+      msg: "{{ inventory_hostname }} runs FreeBSD and cannot run these tools"
+    when:
+      - ansible_distribution != "FreeBSD"

--- a/playbooks/utils/security_install.yml
+++ b/playbooks/utils/security_install.yml
@@ -135,6 +135,20 @@
                 - cytool_stat.stat.exists
                 - xdr_tag_add is changed
 
+        - name: remove .deb file to save space (Ubuntu)
+          ansible.builtin.file:
+            name: "/opt/{{ cortex_install }}.deb"
+            state: absent
+          when:
+            - ansible_os_family == "Debian"
+
+        - name: remove .rpm file to save space (RedHat)
+          ansible.builtin.file:
+            name: "/opt/{{ cortex_install }}.rpm"
+            state: absent
+          when:
+            - ansible_os_family == "RedHat"
+
     - name: Install, configure, and start Rapid7 except on FreeBSD
       when:
         - ansible_distribution != "FreeBSD"


### PR DESCRIPTION
We were getting disk-usage alerts on lib-redis-staging1. I deleted the package file for Cortex XDR to make a little room. Then I thought, "Hey, we could just always do this."

Also, our security audit playbook kept reporting that the mandated security tools are not installed on our FreeBSD machines. Which is true, but not actionable, since neither tool will run on FreeBSD.

This PR:
- adds tasks to delete the package (.deb/.rpm) files after installing Cortex XDR 
- adds a task to report FreeBSD machines separately in our security audit
- adds conditions to two other tasks to skip FreeBSD machines when reporting non-compliance