### PR TITLE
bibdata does not need the HR share any more

### DIFF
--- a/group_vars/bibdata/production.yml
+++ b/group_vars/bibdata/production.yml
@@ -76,8 +76,6 @@ rails_app_vars:
     value: '/opt/bibdata/shared/hathi/input'
   - name: HATHI_OUTPUT_DIR
     value: '/opt/bibdata/shared/hathi/output'
-  - name: BIBDATA_ACCESS_DIRECTORY
-    value: '/mnt/dms-smbserve/bi-library-hr/prod'
   - name: SCSB_S3_PARTNER_ACCESS_KEY
     value: '{{ vault_scsb_s3_access_key_prod }}'
   - name: SCSB_S3_PARTNER_SECRET_ACCESS_KEY
@@ -221,6 +219,7 @@ otel_receivers:
         parse_from: attributes.time_local
         layout_type: strptime
         layout: '%d/%b/%Y:%H:%M:%S %z'
+      # does the bibdata access log still get written if we remove the HR share?
       - type: add
         field: attributes.log_type
         value: "bibdata_access"

--- a/group_vars/bibdata/qa.yml
+++ b/group_vars/bibdata/qa.yml
@@ -72,8 +72,6 @@ rails_app_vars:
     value: '/opt/bibdata/shared/hathi/input'
   - name: HATHI_OUTPUT_DIR
     value: '/opt/bibdata/shared/hathi/output'
-  - name: BIBDATA_ACCESS_DIRECTORY
-    value: '/mnt/dms-smbserve/bi-library-hr/prod'
   - name: SCSB_S3_ACCESS_KEY
     value: '{{ vault_scsb_s3_access_key_uat }}'
   - name: SCSB_S3_SECRET_ACCESS_KEY

--- a/group_vars/bibdata/staging.yml
+++ b/group_vars/bibdata/staging.yml
@@ -76,8 +76,6 @@ rails_app_vars:
     value: '/opt/bibdata/shared/hathi/input'
   - name: HATHI_OUTPUT_DIR
     value: '/opt/bibdata/shared/hathi/output'
-  - name: BIBDATA_ACCESS_DIRECTORY
-    value: '/mnt/dms-smbserve/bi-library-hr/prod'
   - name: SCSB_S3_ACCESS_KEY
     value: '{{ vault_scsb_s3_access_key_uat }}'
   - name: SCSB_S3_SECRET_ACCESS_KEY
@@ -176,6 +174,7 @@ otel_receivers:
         parse_from: attributes.time_local
         layout_type: strptime
         layout: '%d/%b/%Y:%H:%M:%S %z'
+      # does the bibdata access log still get written if we remove the HR share?
       - type: add
         field: attributes.log_type
         value: "bibdata_access"

--- a/playbooks/bibdata.yml
+++ b/playbooks/bibdata.yml
@@ -31,7 +31,7 @@
     - role: sidekiq_worker
       when: "'worker' in inventory_hostname"
     - role: bibdata_sqs_poller
-      when: 
+      when:
         - "'worker' in inventory_hostname"
         - "'1' in inventory_hostname"
     - role: ruby_app
@@ -40,7 +40,6 @@
     - role: bibdata
     # samba must be before hr_share
     - role: samba
-    - role: hr_share
     - role: otel_collector
     - role: beyla
     - role: datadog


### PR DESCRIPTION
Closes #7271.
Closes #4029.
Related to #7333.

We no longer need to mount the HR shares for bibdata, which is one of the systems that has been connecting to an obsolete Samba server that OIT wants to retire.

This PR:
- removes the BIBDATA_ACCESS_DIRECTORY variables from the group vars for all three bibdata environments
- removes the hr_share role from the bibdata playbook
- asks in a comment whether we still need to send `bibdata_access` logs to our logging service - if we do not, we can remove those variable as well