### PR TITLE
[proxmox] credentials for proxmox are baked into tower

### DIFF
--- a/playbooks/utils/create_proxmox_vm.yml
+++ b/playbooks/utils/create_proxmox_vm.yml
@@ -1,4 +1,6 @@
 ---
+#  This playbook should only be run from ansible tower. No need for detailed instructions or examples here, because you should not run it here.
+#
 - name: Create a Proxmox VM from a cluster template
   hosts: localhost
   connection: local
@@ -8,16 +10,6 @@
     - community.proxmox
 
   vars:
-    proxmox_api_host: >-
-      {{ lookup('env', 'PROXMOX_HOST')
-         | default('lib-pxserv01a.princeton.edu', true) }}
-    proxmox_api_user: "{{ lookup('env', 'PROXMOX_USER') }}"
-    proxmox_api_token_id: "{{ lookup('env', 'PROXMOX_TOKEN_ID') }}"
-    proxmox_api_token_secret: "{{ lookup('env', 'PROXMOX_TOKEN_SECRET') }}"
-    proxmox_validate_certs: >-
-      {{ lookup('env', 'PROXMOX_VALIDATE_CERTS')
-         | default('false', true)
-         | bool }}
 
     # Required deployment variables. Supply these with -e or a vars file.
     # proxmox_template_vmid: 1002


### PR DESCRIPTION
we remove these credentials since the primary place this playbook will be run in on AAP