### PR TITLE
uses a different var for the CheckMK agent playbook

### DIFF
--- a/playbooks/utils/checkmk_agent.yml
+++ b/playbooks/utils/checkmk_agent.yml
@@ -9,10 +9,20 @@
 # checkmk folder names must be all lower case and should not begin with a slash
 # checkmk site names are: 'production', 'staging', 'aws', and 'gce'
 #
-# by default this playbook runs against inventory from the staging environment
-# to run against a production group or host, pass '-e runtime_env=production'
+# by default this playbook runs against the staging inventory group
+# to run against a production group or host, pass '-e inventory_group=production'
+#
+# Note:
+# 'inventory_group' can be 'ci', 'qa', 'staging', or 'production'
+# 'runtime_env' is often used for both inventory referecnes and
+# references to the VMware environment
+# in that context it can only be 'production' or 'staging'
+#
+# By using two variables, we can pass both when we rebuild a VM with the Tower workflow
+# even if two values are different (VMware environment and inventory group)
+#
 - name: Install CheckMk agent on host
-  hosts: "{{ runtime_env | default ('staging') }}"
+  hosts: "{{ inventory_group | default ('staging') }}"
   remote_user: pulsys
   become: true
 


### PR DESCRIPTION
Partially addresses #7219.

Traditionally we have used `runtime_env` to supply values for two different things:
- the VMware platform a VM runs on (options are  `staging` and `production`)
- the larger inventory group in which a VM can be found (originally `staging` and `production`, plus, more recently, `CI` and `QA`)

When we added files for CI and QA to the `by_environment` section of our inventory, we broke this connection, because QA and CI VMs run in our production VMware environment but they are not included in our production inventory group.

This PR uses a new variable in the CheckMK agent playbook. This allows us to include this playbook in the integrated workflow for replacing a VM - we can pass, for example, `production` as the value for `runtime_env` for VMware and `QA` as the value for `inventory_group` for the CheckMK playbook.

If we merge this PR, we must update the Survey questions in Tower for the CheckMK agent and replace-a-VM Templates so they provide the correct variable name and the correct set of choices. 