### PR TITLE
adds ci and qa to staging and production envs respectively; adds an ADR

### DIFF
--- a/architecture-decisions/0006-environtments.md
+++ b/architecture-decisions/0006-environtments.md
@@ -1,0 +1,30 @@
+# 1. Align inventory environments with infrastructure
+
+Date: 2026-07-27
+
+## Status
+
+Draft
+
+## Context
+
+We have two infrastructure environments: staging and production.
+
+We have four inventory environments: ci, qa, staging, and production. It's possible we could have more in future.
+
+We want to make automation simple and straightforward and limit the number of variables we need to pass for automation.
+
+## Decision
+
+We will maintain our inventory to reflect the basic division between the staging infrastructure and the production infrastructure.
+
+1. All `CI` VMs run on our `staging` infrastructure. 
+2. All `QA` VMs run on our `production` infrastructure.
+3. We will maintain `ci` and `qa` inventory groups so we can easily target similar VMs together.
+4. The `ci` inventory group will be a member of the `staging` group.
+5. The `qa` inventory group will  be a member of the `production` group.
+
+## Consequences
+
+* We can continue to use the `runtime_env` variable to pass a value for both the inventory group and the infrastructure environment.
+* We must maintain the correct assignment of VMs in our infrastructure and our inventory.

--- a/architecture-decisions/0006-environtments.md
+++ b/architecture-decisions/0006-environtments.md
@@ -18,11 +18,11 @@ We want to make automation simple and straightforward and limit the number of va
 
 We will maintain our inventory to reflect the basic division between the staging infrastructure and the production infrastructure.
 
-1. All `CI` VMs run on our `staging` infrastructure. 
-2. All `QA` VMs run on our `production` infrastructure.
-3. We will maintain `ci` and `qa` inventory groups so we can easily target similar VMs together.
-4. The `ci` inventory group will be a member of the `staging` group.
-5. The `qa` inventory group will  be a member of the `production` group.
+1. All `QA` VMs run on our `production` infrastructure.
+2. The `qa` inventory group will  be a member of the `production` group.
+3. All other non-production VMs, including `CI` run on our `staging` infrastructure. 
+4. The `ci` inventory group and any other inventory groups we create in future will be members of the `staging` group.
+5. We can create and maintain `ci` and `qa` and other top-level inventory groups under `inventory/by_environment` if we want to, so we can easily target similar VMs together.
 
 ## Consequences
 

--- a/inventory/by_environment/production.ini
+++ b/inventory/by_environment/production.ini
@@ -1,4 +1,7 @@
 [production:children]
+# QA resources run in our production VMware env
+# membership in the qa group is defined in by_environment/qa.ini
+qa
 allsearch_api_production
 allsearch_frontend_production
 ansible_tower

--- a/inventory/by_environment/staging.ini
+++ b/inventory/by_environment/staging.ini
@@ -1,4 +1,7 @@
 [staging:children]
+# CI resources run in our staging VMware env
+# membership in the ci group is defined in by_environment/ci.ini
+ci
 allsearch_api_staging
 allsearch_frontend_staging
 analyze_catalog


### PR DESCRIPTION
Closes #7219.

Supersedes #7347.

Amends our inventory so that every group is part of either `staging` or `production`, reflecing the underlying infrastructure. 

Adds an ADR about where CI and QA resources should run and why we are doing this. 