### PR TITLE
[mailcatcher] Refactor to enable OS upgrade and improve observability

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,7 @@ allow_broken_conditionals = True
 roles_path = external_roles
 pipelining = true
 local_tmp  = ~/.ansible/tmp
+remote_tmp = /tmp
 [connection]
 pipelining =True
 [inventory]

--- a/roles/mailcatcher/README.md
+++ b/roles/mailcatcher/README.md
@@ -12,7 +12,7 @@ Role Variables
 --------------
 
 * install_mailcatcher: defaults to false - you must specifically opt into mailcatcher
-* mailcatcher_install_location: location mailcatcher will be installed. defaults to /usr/local/bin/mailcatcher If you are utilizing RVM the installation location will change based on your current ruby (e.g. /usr/local/rvm/gems/ruby-2.4.6/bin/mailcatcher)
+* mailcatcher_install_location: location mailcatcher will be installed. defaults to /usr/local/bin/mailcatcher 
 
 Dependencies
 ------------

--- a/roles/mailcatcher/defaults/main.yml
+++ b/roles/mailcatcher/defaults/main.yml
@@ -1,7 +1,20 @@
 ---
 # defaults file for roles/mailcatcher
-install_mailcatcher: false
+
+# Make sure install_mailcatcher is set to false on any server where you
+# actually want to send email.
+install_mailcatcher: true
+mailcatcher_version: '0.10.0'
 mailcatcher_install_location: '/usr/local/bin/mailcatcher'
-mailcatcher_version: 0.10.0
-mailcatcher_user: root
-mailcatcher_group: root
+mailcatcher_user: mailcatcher
+mailcatcher_group: mailcatcher
+mailcatcher_http_listen_address: '0.0.0.0'
+mailcatcher_http_port: '1080'
+mailcatcher_listen_address: '0.0.0.0'
+mailcatcher_smtp_listen_address: '0.0.0.0'
+mailcatcher_smtp_port: '1025'
+mailcatcher_ubuntu_packages:
+  - 'build-essential'
+  - 'libsqlite3-dev'
+  - 'software-properties-common'
+

--- a/roles/mailcatcher/defaults/main.yml
+++ b/roles/mailcatcher/defaults/main.yml
@@ -15,6 +15,7 @@ mailcatcher_smtp_listen_address: '0.0.0.0'
 mailcatcher_smtp_port: '1025'
 mailcatcher_ubuntu_packages:
   - 'build-essential'
+  - 'pkg-config'
   - 'libsqlite3-dev'
   - 'software-properties-common'
 

--- a/roles/mailcatcher/defaults/main.yml
+++ b/roles/mailcatcher/defaults/main.yml
@@ -4,18 +4,20 @@
 # Make sure install_mailcatcher is set to false on any server where you
 # actually want to send email.
 install_mailcatcher: true
-mailcatcher_version: '0.10.0'
-mailcatcher_install_location: '/usr/local/bin/mailcatcher'
+mailcatcher_version: "0.10.0"
+mailcatcher_install_location: /usr/local/bin/mailcatcher
+mailcatcher_home: /var/lib/mailcatcher
 mailcatcher_user: mailcatcher
 mailcatcher_group: mailcatcher
-mailcatcher_http_listen_address: '0.0.0.0'
-mailcatcher_http_port: '1080'
-mailcatcher_listen_address: '0.0.0.0'
-mailcatcher_smtp_listen_address: '0.0.0.0'
-mailcatcher_smtp_port: '1025'
+mailcatcher_http_listen_address: 0.0.0.0
+mailcatcher_http_port: "1080"
+mailcatcher_listen_address: 0.0.0.0
+mailcatcher_smtp_listen_address: 0.0.0.0
+mailcatcher_smtp_port: "1025"
 mailcatcher_ubuntu_packages:
-  - 'build-essential'
-  - 'pkg-config'
-  - 'libsqlite3-dev'
-  - 'software-properties-common'
+  - build-essential
+  - libsqlite3-dev
+  - pkg-config
+  - ruby-dev
+  - software-properties-common
 

--- a/roles/mailcatcher/handlers/main.yml
+++ b/roles/mailcatcher/handlers/main.yml
@@ -1,8 +1,7 @@
 ---
 # handlers file for roles/mailcatcher
 - name: restart mailcatcher
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: mailcatcher
     daemon_reload: true
     state: restarted
-  when: running_on_server

--- a/roles/mailcatcher/meta/main.yml
+++ b/roles/mailcatcher/meta/main.yml
@@ -13,5 +13,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - jammy
+        - noble
 dependencies:
   - role: 'ruby_s'

--- a/roles/mailcatcher/molecule/default/converge.yml
+++ b/roles/mailcatcher/molecule/default/converge.yml
@@ -5,12 +5,12 @@
     running_on_server: false
     install_mailcatcher: true
   become: true
-  pre_tasks:
-    - name: update cache
-      ansible.builtin.apt:
-        update_cache: true
-        cache_valid_time: 600
-  tasks:
-    - name: "Include mailcatcher"
-      ansible.builtin.include_role:
-        name: mailcatcher
+  # pre_tasks:
+  #   - name: update cache
+  #     ansible.builtin.apt:
+  #       update_cache: true
+  #       cache_valid_time: 600
+  # tasks:
+  #   - name: "Include mailcatcher"
+  #     ansible.builtin.include_role:
+  #       name: mailcatcher

--- a/roles/mailcatcher/molecule/default/converge.yml
+++ b/roles/mailcatcher/molecule/default/converge.yml
@@ -1,16 +1,18 @@
 ---
 - name: Converge
   hosts: all
+  become: true
   vars:
     running_on_server: false
     install_mailcatcher: true
-  become: true
-  # pre_tasks:
-  #   - name: update cache
-  #     ansible.builtin.apt:
-  #       update_cache: true
-  #       cache_valid_time: 600
-  # tasks:
-  #   - name: "Include mailcatcher"
-  #     ansible.builtin.include_role:
-  #       name: mailcatcher
+    mailcatcher_http_port: 1080
+    mailcatcher_smtp_port: 1025
+  pre_tasks:
+    - name: update cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 600
+  tasks:
+    - name: "Include mailcatcher"
+      ansible.builtin.include_role:
+        name: mailcatcher

--- a/roles/mailcatcher/molecule/default/verify.yml
+++ b/roles/mailcatcher/molecule/default/verify.yml
@@ -2,17 +2,20 @@
 - name: Verify
   hosts: all
   gather_facts: true
+  vars:
+    mailcatcher_http_port: 1080
+    mailcatcher_smtp_port: 1025
   tasks:
     - name: Check if mailcatcher binary exists
       ansible.builtin.stat:
         path: /usr/local/bin/mailcatcher
-      register: bin_check
+      register: mailcatcher_binary
 
     - name: Assert binary is present
       ansible.builtin.assert:
         that:
-          - bin_check.stat.exists
-          - bin_check.stat.executable
+          - mailcatcher_binary.stat.exists
+          - mailcatcher_binary.stat.executable
 
     - name: Check if mailcatcher service is running
       ansible.builtin.service_facts:
@@ -28,9 +31,15 @@
 
     - name: Verify network ports (HTTP and SMTP)
       ansible.builtin.wait_for:
+        host: 127.0.0.1
         port: "{{ item }}"
-        timeout: 5
+        timeout: 30
       loop:
-        - 1080
-        - 1025
+        - "{{ mailcatcher_http_port }}"
+        - "{{ mailcatcher_smtp_port }}"
       when: hostvars[inventory_hostname]['running_on_server'] | default(false)
+
+    - name: Check Mailcatcher HTTP endpoint
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ mailcatcher_http_port }}/"
+        status_code: 200

--- a/roles/mailcatcher/tasks/config.yml
+++ b/roles/mailcatcher/tasks/config.yml
@@ -5,28 +5,30 @@
     state: directory
     owner: "{{ mailcatcher_user }}"
     group: "{{ mailcatcher_group }}"
+    mode: "0755"
 
 - name: mailcatcher | configuring mailcatcher init service
   template:
-    src: "templates/mailcatcher.service.j2"
-    dest: "/etc/systemd/system/mailcatcher.service"
+    src: mailcatcher.service.j2
+    dest: /etc/systemd/system/mailcatcher.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - restart mailcatcher
 
 - name: mailcatcher | ensuring mailcatcher starts on boot
   ansible.builtin.systemd:
     name: "mailcatcher"
-    enabled: yes
+    enabled: true
 
 - name: mailcatcher | daemon-reload systemd
   ansible.builtin.systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: mailcatcher | restart mailcatcher
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     name: mailcatcher
-    state: restarted
-    enabled: yes
+    enabled: true
+    daemon_reload: true
+    state: started

--- a/roles/mailcatcher/tasks/config.yml
+++ b/roles/mailcatcher/tasks/config.yml
@@ -1,12 +1,12 @@
 ---
-- name: config | create mailcatcher log directory
+- name: mailcatcher | create mailcatcher log directory
   ansible.builtin.file:
     path: /var/log/mailcatcher
     state: directory
     owner: "{{ mailcatcher_user }}"
     group: "{{ mailcatcher_group }}"
 
-- name: config | configuring mailcatcher init service
+- name: mailcatcher | configuring mailcatcher init service
   template:
     src: "templates/mailcatcher.service.j2"
     dest: "/etc/systemd/system/mailcatcher.service"
@@ -16,7 +16,17 @@
   notify:
     - restart mailcatcher
 
-- name: config | ensuring mailcatcher starts on boot
+- name: mailcatcher | ensuring mailcatcher starts on boot
   ansible.builtin.systemd:
     name: "mailcatcher"
+    enabled: yes
+
+- name: mailcatcher | daemon-reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: mailcatcher | restart mailcatcher
+  ansible.builtin.systemd:
+    name: mailcatcher
+    state: restarted
     enabled: yes

--- a/roles/mailcatcher/tasks/config.yml
+++ b/roles/mailcatcher/tasks/config.yml
@@ -1,0 +1,22 @@
+---
+- name: config | create mailcatcher log directory
+  ansible.builtin.file:
+    path: /var/log/mailcatcher
+    state: directory
+    owner: "{{ mailcatcher_user }}"
+    group: "{{ mailcatcher_group }}"
+
+- name: config | configuring mailcatcher init service
+  template:
+    src: "templates/mailcatcher.service.j2"
+    dest: "/etc/systemd/system/mailcatcher.service"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart mailcatcher
+
+- name: config | ensuring mailcatcher starts on boot
+  ansible.builtin.systemd:
+    name: "mailcatcher"
+    enabled: yes

--- a/roles/mailcatcher/tasks/create_user.yml
+++ b/roles/mailcatcher/tasks/create_user.yml
@@ -1,10 +1,15 @@
 ---
 - name: mailcatcher | creating mailcatcher group
-  group:
+  ansible.builtin.group:
     name: "mailcatcher"
 
-- name: mailcatcher | creating mailcatcher user
-  user:
-    name: "mailcatcher"
-    comment: "Mailcatcher Service Account"
-    group: "mailcatcher"
+- name: Mailcatcher | Create service user
+  ansible.builtin.user:
+    name: "{{ mailcatcher_user }}"
+    comment: Mailcatcher Service Account
+    group: "{{ mailcatcher_group }}"
+    home: "{{ mailcatcher_home }}"
+    create_home: true
+    shell: /usr/sbin/nologin
+    system: true
+    state: present

--- a/roles/mailcatcher/tasks/create_user.yml
+++ b/roles/mailcatcher/tasks/create_user.yml
@@ -1,0 +1,10 @@
+---
+- name: mailcatcher | creating mailcatcher group
+  group:
+    name: "mailcatcher"
+
+- name: mailcatcher | creating mailcatcher user
+  user:
+    name: "mailcatcher"
+    comment: "Mailcatcher Service Account"
+    group: "mailcatcher"

--- a/roles/mailcatcher/tasks/install.yml
+++ b/roles/mailcatcher/tasks/install.yml
@@ -1,0 +1,6 @@
+---
+- name: mailcatcher | installing mailcatcher
+  ansible.builtin.command: gem install mailcatcher -v {{ mailcatcher_version }}
+  register: gem_install
+  args:
+    creates: "{{ mailcatcher_install_location }}"

--- a/roles/mailcatcher/tasks/install.yml
+++ b/roles/mailcatcher/tasks/install.yml
@@ -1,6 +1,13 @@
 ---
-- name: mailcatcher | installing mailcatcher
-  ansible.builtin.command: gem install mailcatcher -v {{ mailcatcher_version }}
-  register: gem_install
-  args:
+- name: Mailcatcher | Install requested gem version
+  ansible.builtin.command:
+    argv:
+      - gem
+      - install
+      - mailcatcher
+      - --version
+      - "{{ mailcatcher_version }}"
+      - --no-document
+      - --bindir
+      - "{{ mailcatcher_install_location | dirname }}"
     creates: "{{ mailcatcher_install_location }}"

--- a/roles/mailcatcher/tasks/main.yml
+++ b/roles/mailcatcher/tasks/main.yml
@@ -6,15 +6,26 @@
     state: present
   with_items: '{{ mailcatcher_ubuntu_packages }}'
   when: running_on_server 
+- name: Mailcatcher | Install and configure Mailcatcher
+  when:
+    - install_mailcatcher | bool
+    - running_on_server | default(true) | bool
+  block:
+    - name: Mailcatcher | Install prerequisites
+      ansible.builtin.apt:
+        name: "{{ mailcatcher_ubuntu_packages }}"
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
 
 # Then, create the mailcatcher user and group. 
-# - import_tasks: create_user.yml
+- import_tasks: create_user.yml
 
 # # Next, install mailcatcher at /usr/local/bin/mailcatcher
-# - import_tasks: install.yml
+- import_tasks: install.yml
 
 # # Finally, configure mailcatcher to run as a service.
-# - import_tasks: config.yml
+- import_tasks: config.yml
 
 # You can test that it is running with the command: curl http://localhost:1080 or
 # sudo service mailcatcher status

--- a/roles/mailcatcher/tasks/main.yml
+++ b/roles/mailcatcher/tasks/main.yml
@@ -1,21 +1,20 @@
 ---
-# tasks file for roles/mailcatcher
+# First, install the pre-requisites. Find these in the defaults/main.yml file. 
 - name: mailcatcher | installing pre-reqs
   apt:
     name: "{{ item }}"
     state: present
   with_items: '{{ mailcatcher_ubuntu_packages }}'
+  when: running_on_server 
 
-- import_tasks: create_user.yml
-- import_tasks: install.yml
-- import_tasks: config.yml
+# Then, create the mailcatcher user and group. 
+# - import_tasks: create_user.yml
 
-- name: mailcatcher | daemon-reload systemd
-  ansible.builtin.systemd:
-    daemon_reload: yes
+# # Next, install mailcatcher at /usr/local/bin/mailcatcher
+# - import_tasks: install.yml
 
-- name: mailcatcher | restart mailcatcher
-  ansible.builtin.systemd:
-    name: mailcatcher
-    state: restarted
-    enabled: yes
+# # Finally, configure mailcatcher to run as a service.
+# - import_tasks: config.yml
+
+# You can test that it is running with the command: curl http://localhost:1080 or
+# sudo service mailcatcher status

--- a/roles/mailcatcher/tasks/main.yml
+++ b/roles/mailcatcher/tasks/main.yml
@@ -1,56 +1,21 @@
 ---
 # tasks file for roles/mailcatcher
-- name: mailcatcher | Install dependencies
-  ansible.builtin.apt:
-    pkg:
-    - libsqlite3-dev
-    - pkg-config
+- name: mailcatcher | installing pre-reqs
+  apt:
+    name: "{{ item }}"
     state: present
-  tags: mailcatcher
+  with_items: '{{ mailcatcher_ubuntu_packages }}'
 
-- name: mailcatcher | install global mail catcher
-  ansible.builtin.command: gem install mailcatcher -v {{ mailcatcher_version }}
-  register: gem_install
-  args:
-    creates: "{{ mailcatcher_install_location }}"
-  tags: mailcatcher
+- import_tasks: create_user.yml
+- import_tasks: install.yml
+- import_tasks: config.yml
 
-- name: mailcatcher | Install startup script for mailcatcher
-  ansible.builtin.template:
-    src: mailcatcher.service.j2
-    dest: /lib/systemd/system/mailcatcher.service
-    mode: 0644
-  when: running_on_server and install_mailcatcher
-  notify: restart mailcatcher
-  tags: mailcatcher
+- name: mailcatcher | daemon-reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
 
-- name: mailcatcher | Keep mailcatcher running
-  ansible.builtin.service:
+- name: mailcatcher | restart mailcatcher
+  ansible.builtin.systemd:
     name: mailcatcher
-    enabled: true
-    state: started
-  when: running_on_server and install_mailcatcher
-  tags: mailcatcher
-
-# In case it was previously installed and is no longer needed, remove it
-- name: mailcatcher | Remove mailcatcher gem if not needed
-  ansible.builtin.command: gem uninstall mailcatcher -v {{ mailcatcher_version }} -a -x
-  args:
-    removes: "{{ mailcatcher_install_location }}"
-  when: running_on_server and not install_mailcatcher
-  tags: mailcatcher
-  
-- name: mailcatcher | Remove mailcatcher service if not needed
-  ansible.builtin.service:
-    name: mailcatcher
-    enabled: false
-    state: stopped
-  when: running_on_server and not install_mailcatcher
-  tags: mailcatcher
-
-- name: mailcatcher | Remove mailcatcher startup script if not needed
-  ansible.builtin.file:
-    path: /lib/systemd/system/mailcatcher.service
-    state: absent
-  when: running_on_server and not install_mailcatcher
-  tags: mailcatcher
+    state: restarted
+    enabled: yes

--- a/roles/mailcatcher/templates/mailcatcher.service.j2
+++ b/roles/mailcatcher/templates/mailcatcher.service.j2
@@ -5,13 +5,10 @@ After=syslog.target network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/{{ mailcatcher_user }}
-ExecStart=/bin/bash --login -c "{{ mailcatcher_install_location }} --foreground"
+ExecStart=/bin/bash --login -c "{{ mailcatcher_install_location }} -f -v --ip={{ mailcatcher_listen_address }} --smtp-ip={{ mailcatcher_smtp_listen_address }} --smtp-port={{ mailcatcher_smtp_port }} --http-ip={{ mailcatcher_http_listen_address }} --http-port={{ mailcatcher_http_port }} &>>/var/log/mailcatcher/mailcatcher.log"
 User={{ mailcatcher_user }}
 Group={{ mailcatcher_group }}
 UMask=0002
-
-StandardOutput=journal
-StandardError=journal
 
 # if we crash, restart
 RestartSec=1

--- a/roles/mailcatcher/templates/mailcatcher.service.j2
+++ b/roles/mailcatcher/templates/mailcatcher.service.j2
@@ -1,20 +1,20 @@
 [Unit]
 Description=Mailcatcher
-After=syslog.target network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/{{ mailcatcher_user }}
-ExecStart=/bin/bash --login -c "{{ mailcatcher_install_location }} -f -v --ip={{ mailcatcher_listen_address }} --smtp-ip={{ mailcatcher_smtp_listen_address }} --smtp-port={{ mailcatcher_smtp_port }} --http-ip={{ mailcatcher_http_listen_address }} --http-port={{ mailcatcher_http_port }} &>>/var/log/mailcatcher/mailcatcher.log"
 User={{ mailcatcher_user }}
 Group={{ mailcatcher_group }}
 UMask=0002
-
-# if we crash, restart
+WorkingDirectory={{ mailcatcher_home }}
+Environment=HOME={{ mailcatcher_home }}
+ExecStart=/bin/bash -c 'exec {{ mailcatcher_install_location }} -f -v --ip={{ mailcatcher_listen_address }} --smtp-ip={{ mailcatcher_smtp_listen_address }} --smtp-port={{ mailcatcher_smtp_port }} --http-ip={{ mailcatcher_http_listen_address }} --http-port={{ mailcatcher_http_port }} >>/var/log/mailcatcher/mailcatcher.log 2>&1'
 RestartSec=1
+
 Restart=on-failure
 
-# This will default to "bundler" if we don't specify it
 SyslogIdentifier=mailcatcher
 
 [Install]


### PR DESCRIPTION
Advances https://github.com/pulibrary/princeton_ansible/issues/7330

related #7353 


* Now runs as `mailcatcher` instead of `root`
* Logging to `/var/log/mailcatcher` 
* Easier to see what ports everything is running on (see screenshot)

<img width="1660" height="302" alt="Screenshot 2026-07-28 at 2 27 39 PM" src="https://github.com/user-attachments/assets/5f872a7d-8631-484a-93e9-07facd8b05e2" />
