### PR TITLE
[mailcatcher] Fix mailcatcher service account management

### DIFF
--- a/group_vars/dss/staging.yml
+++ b/group_vars/dss/staging.yml
@@ -23,9 +23,10 @@ solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/dss-staging"
 dss_honeybadger_key: '{{ vault_dss_honeybadger_key }}'
 honeybadger_env: 'staging'
 install_mailcatcher: true
-mailcatcher_user: "pulsys"
-mailcatcher_group: "pulsys"
+mailcatcher_user: "mailcatcher"
+mailcatcher_group: "mailcatcher"
 mailcatcher_version: 0.10.0
+mailcatcher_home: /var/lib/mailcatcher
 mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.3.0/gems/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
 # beyla
 beyla_enabled: true

--- a/group_vars/lib_jobs/staging.yml
+++ b/group_vars/lib_jobs/staging.yml
@@ -18,8 +18,9 @@ app_oit_client_key: '{{ vault_oit_prod_client_key }}'
 app_oit_client_secret: '{{ vault_oit_prod_client_secret }}'
 # Mailcatcher
 install_mailcatcher: true
-mailcatcher_group: 'pulsys'
-mailcatcher_user: 'pulsys'
+mailcatcher_group: 'mailcatcher'
+mailcatcher_user: 'mailcatcher'
+mailcatcher_home: /var/lib/mailcatcher
 # lib-sftp
 app_sftp_host: 'lib-sftp-staging1.princeton.edu'
 # Database / Postgres

--- a/group_vars/lockers_and_study_spaces/staging.yml
+++ b/group_vars/lockers_and_study_spaces/staging.yml
@@ -27,8 +27,9 @@ app_host_name: 'lockers_and_study_spaces_staging.princeton.edu'
 application_host_protocol: 'https'
 running_on_server: true
 install_mailcatcher: true
-mailcatcher_user: 'pulsys'
-mailcatcher_group: 'pulsys'
+mailcatcher_user: 'mailcatcher'
+mailcatcher_group: 'mailcatcher'
+mailcatcher_home: /var/lib/mailcatcher
 lockers_honeybadger_key: '{{ vault_lockers_and_study_spaces_honeybadger_key }}'
 # beyla
 beyla_enabled: true

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -1,9 +1,10 @@
 ---
 alma_read_write_key: "{{ vault_alma_sandbox_read_write_key }}"
 install_mailcatcher: true
-mailcatcher_user: "pulsys"
-mailcatcher_group: "pulsys"
+mailcatcher_user: "mailcatcher"
+mailcatcher_group: "mailcatcher"
 mailcatcher_version: 0.10.0
+mailcatcher_home: /var/lib/mailcatcher
 mailcatcher_install_location: "{{ global_gems_directory }}/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
 ol_smtp_host: 'localhost'
 ol_smtp_port: 1025

--- a/group_vars/pas/staging.yml
+++ b/group_vars/pas/staging.yml
@@ -28,8 +28,9 @@ mysql_users:
 
 install_ruby_from_source: true
 install_mailcatcher: true
-mailcatcher_user: "pulsys"
-mailcatcher_group: "pulsys"
+mailcatcher_user: "mailcatcher"
+mailcatcher_group: "mailcatcher"
+mailcatcher_home: /var/lib/mailcatcher
 
 # beyla
 beyla_enabled: true

--- a/roles/mailcatcher/defaults/main.yml
+++ b/roles/mailcatcher/defaults/main.yml
@@ -4,6 +4,7 @@
 # Make sure install_mailcatcher is set to false on any server where you
 # actually want to send email.
 install_mailcatcher: true
+mailcatcher_manage_user: true
 mailcatcher_version: "0.10.0"
 mailcatcher_install_location: /usr/local/bin/mailcatcher
 mailcatcher_home: /var/lib/mailcatcher

--- a/roles/mailcatcher/tasks/create_user.yml
+++ b/roles/mailcatcher/tasks/create_user.yml
@@ -1,7 +1,9 @@
 ---
-- name: mailcatcher | creating mailcatcher group
+- name: Mailcatcher | Create service group
   ansible.builtin.group:
-    name: "mailcatcher"
+    name: "{{ mailcatcher_group }}"
+    system: "{{ mailcatcher_manage_user | bool }}"
+    state: present
 
 - name: Mailcatcher | Create service user
   ansible.builtin.user:
@@ -13,3 +15,19 @@
     shell: /usr/sbin/nologin
     system: true
     state: present
+  when: mailcatcher_manage_user | bool
+
+- name: Mailcatcher | Look up existing service user
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ mailcatcher_user }}"
+    fail_key: true
+  when: not mailcatcher_manage_user | bool
+
+- name: Mailcatcher | Create application home
+  ansible.builtin.file:
+    path: "{{ mailcatcher_home }}"
+    state: directory
+    owner: "{{ mailcatcher_user }}"
+    group: "{{ mailcatcher_group }}"
+    mode: "0755"


### PR DESCRIPTION
Using a dedicated service account avoids modifying an active interactive user, prevents Ansible from attempting to change pulsys into a system account, and limits Mailcatcher’s filesystem access and privileges to only what the service
requires.

closes #7353 