### PR TITLE
[nginxplus] add Beyla to NGINX Plus

### DIFF
--- a/group_vars/nginxplus/production.yml
+++ b/group_vars/nginxplus/production.yml
@@ -1,6 +1,7 @@
 ---
 adc_domain: "lib-adc"
-# modules to install
+
+# Modules to install
 nginx_modules:
   waf: false
   geoip: true
@@ -11,13 +12,16 @@ nginx_modules:
   otel: true
   xslt: true
   dos: false
-# app_protect logs
+
+# App Protect logs
 app_protect_dir: "/var/log/app_protect/*.log"
-# external sites
+
+# External sites
 sites:
   - domain: cicognara.org
     cert_dst: /etc/nginx/conf.d/ssl/certs/cicognara_org_chained.pem
     key_dst: /etc/nginx/conf.d/ssl/private/cicognara_org_priv.key
+
   - domain: pcdm.org
     cert_dst: /etc/nginx/conf.d/ssl/certs/pcdm_org_chained.pem
     key_dst: /etc/nginx/conf.d/ssl/private/pcdm_org_priv.key
@@ -25,7 +29,26 @@ sites:
 nginxplus_otel_enabled: true
 nginxplus_otel_stub_status_port: 18080
 
-# signoz / otel collector for nginxplus load balancers
+# Grafana Beyla
+#
+beyla_enabled: true
+beyla_service_name: nginxplus-lb
+beyla_environment: production
+
+beyla_otlp_endpoint: http://127.0.0.1:4318
+beyla_otlp_protocol: http/protobuf
+
+beyla_open_ports:
+  - 80
+  - 443
+
+# Propagate W3C trace context using HTTP headers.
+beyla_bpf_context_propagation: headers
+
+# Beyla requires elevated eBPF and process-inspection privileges.
+beyla_privileged: true
+
+# SigNoz / OpenTelemetry Collector for NGINX Plus load balancers
 otel_default_resource_attributes:
   host.name: "{{ inventory_hostname }}"
   service.name: nginxplus-lb
@@ -34,6 +57,7 @@ otel_default_resource_attributes:
   deployment.environment: production
 
 otel_receivers:
+  # Receives native NGINX OpenTelemetry traces and Beyla telemetry.
   otlp:
     protocols:
       grpc:
@@ -176,10 +200,11 @@ otel_service_pipelines:
       - batch
     exporters:
       - loadbalancing
-      - debug
 
   metrics:
     receivers:
+      # Required to receive Beyla RED metrics over OTLP/HTTP.
+      - otlp
       - nginx
       - hostmetrics
     processors:
@@ -187,7 +212,6 @@ otel_service_pipelines:
       - batch
     exporters:
       - loadbalancing
-      - debug
 
   traces:
     receivers:
@@ -197,4 +221,3 @@ otel_service_pipelines:
       - batch
     exporters:
       - loadbalancing
-      - debug

--- a/group_vars/nginxplus/staging.yml
+++ b/group_vars/nginxplus/staging.yml
@@ -3,7 +3,7 @@ adc_domain: "adc-dev.lib.princeton.edu"
 nginx_http_upload_src: conf/http/dev/*.conf
 nginx_template_upload_src: conf/http/dev/templates/*.conf
 
-# modules to install
+# Modules to install
 nginx_modules:
   waf: false
   geoip: true
@@ -15,11 +15,33 @@ nginx_modules:
   xslt: true
 
 # dos: true
-# app_protect logs
+
+# App Protect logs
 app_protect_dir: "/var/log/app_protect/*.log"
+
 sites: []
 
-# signoz / otel collector for nginxplus load balancers
+# Grafana Beyla
+#
+beyla_enabled: true
+beyla_service_name: nginxplus-lb
+beyla_environment: staging
+
+beyla_otlp_endpoint: http://127.0.0.1:4318
+beyla_otlp_protocol: http/protobuf
+
+beyla_open_ports:
+  - 80
+  - 443
+
+# Propagate W3C trace context through normal HTTP headers without enabling
+# Beyla's IP-option/TC propagation mechanism.
+beyla_bpf_context_propagation: headers
+
+# Beyla requires elevated eBPF and process-inspection privileges.
+beyla_privileged: true
+
+# SigNoz / OpenTelemetry Collector for NGINX Plus load balancers
 otel_default_resource_attributes:
   host.name: "{{ inventory_hostname }}"
   service.name: nginxplus-lb
@@ -28,6 +50,7 @@ otel_default_resource_attributes:
   deployment.environment: staging
 
 otel_receivers:
+  # Receives:
   otlp:
     protocols:
       grpc:
@@ -170,10 +193,11 @@ otel_service_pipelines:
       - batch
     exporters:
       - loadbalancing
-      - debug
 
   metrics:
     receivers:
+      # Required for Beyla RED metrics.
+      - otlp
       - nginx
       - hostmetrics
     processors:
@@ -181,7 +205,6 @@ otel_service_pipelines:
       - batch
     exporters:
       - loadbalancing
-      - debug
 
   traces:
     receivers:
@@ -191,4 +214,3 @@ otel_service_pipelines:
       - batch
     exporters:
       - loadbalancing
-      - debug

--- a/playbooks/nginxplus.yml
+++ b/playbooks/nginxplus.yml
@@ -44,6 +44,7 @@
   roles:
     - role: ../roles/nginxplus
     - role: otel_collector
+    - role: beyla
     - role: datadog
       when: runtime_env | default('staging') == "production"
 


### PR DESCRIPTION
Enable Grafana Beyla on the staging and production NGINX Plus load balancers to collect application traces and RED metrics from ports 80 and 443.

Send Beyla telemetry to the local OpenTelemetry Collector over OTLP/HTTP and add the OTLP receiver to the metrics pipeline so Beyla metrics are forwarded to SigNoz.

Use header-based trace context propagation and identify the service as nginxplus-lb in the appropriate deployment environment.

related #7197