### PR TITLE
Standardize how we run mailcatcher

### DIFF
--- a/group_vars/approvals/sandbox.yml
+++ b/group_vars/approvals/sandbox.yml
@@ -18,8 +18,8 @@ app_host_name: 'approvals-px-sandbox.princeton.edu'
 application_host_protocol: 'https'
 running_on_server: true
 install_mailcatcher: true
-mailcatcher_user: 'pulsys'
-mailcatcher_group: 'pulsys'
+mailcatcher_user: 'mailcatcher'
+mailcatcher_group: 'mailcatcher'
 
 postgres_host: "sandbox-postgresql1.lib.princeton.edu"
 postgres_version: 18

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -1,8 +1,8 @@
 ---
 alma_read_write_key: "{{ vault_alma_read_write_key }}"
 install_mailcatcher: true
-mailcatcher_user: "pulsys"
-mailcatcher_group: "pulsys"
+mailcatcher_user: "mailcatcher"
+mailcatcher_group: "mailcatcher"
 mailcatcher_version: 0.10.0
 mailcatcher_install_location: "{{ global_gems_directory }}/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
 ol_smtp_host: 'localhost'

--- a/group_vars/pdc_describe/main.yml
+++ b/group_vars/pdc_describe/main.yml
@@ -35,11 +35,6 @@ project_db_host: '{{postgres_host}}'
 install_ruby_from_source: true
 ruby_version_override: "ruby-3.4.8"
 
-mailcatcher_user: "pulsys"
-mailcatcher_group: "pulsys"
-mailcatcher_version: 0.10.0
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.4.0/gems/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
-
 bundler_version: "2.5.14"
 passenger_extra_http_config:
   - "passenger_preload_bundler on;"

--- a/group_vars/repec/staging.yml
+++ b/group_vars/repec/staging.yml
@@ -23,8 +23,8 @@ application_dbuser_role_attr_flags: 'CREATEDB'
 app_host_name: 'repec-staging.princeton.edu'
 application_host_protocol: 'https'
 install_mailcatcher: true
-mailcatcher_user: 'pulsys'
-mailcatcher_group: 'pulsys'
+mailcatcher_user: 'mailcatcher'
+mailcatcher_group: 'mailcatcher'
 passenger_extra_config: "rewrite ^/econlib/RePEc/pri(.*)$ /$1;"
 # beyla
 beyla_enabled: true


### PR DESCRIPTION
I'd like to try keeping the defaults for mailcatcher whenever possible. Let's not override anything we don't have to, so we keep our config files easier to understand.

<img width="1372" height="342" alt="Screenshot 2026-07-29 at 3 19 49 PM" src="https://github.com/user-attachments/assets/3efa41b3-c25b-459e-8c4a-2baaa8480566" />
