### PR TITLE
Remove mailcatcher role from pdc_discovery playbook

### DIFF
--- a/playbooks/pdc_discovery.yml
+++ b/playbooks/pdc_discovery.yml
@@ -17,7 +17,6 @@
       - run a cap deploy for pdc_discovery: https://github.com/pulibrary/pdc_discovery
 
   roles:
-    - role: mailcatcher
     - role: ruby_app
     - role: otel_collector
     - role: beyla


### PR DESCRIPTION
We believe mail is not sent from Discovery