### PR TITLE
[pdc_discovery] Remove unused config options

### DIFF
--- a/group_vars/pdc_discovery/staging.yml
+++ b/group_vars/pdc_discovery/staging.yml
@@ -17,12 +17,6 @@ rails_app_env: "staging"
 pdc_discovery_host_name: 'pdc-discovery-staging.princeton.edu'
 pdc_discovery_honeybadger_key: '{{vault_pdc_discovery_honeybadger_key}}'
 
-install_mailcatcher: true
-mailcatcher_user: "pulsys"
-mailcatcher_group: "pulsys"
-mailcatcher_version: 0.10.0
-mailcatcher_install_location: "/usr/local/lib/ruby/gems/3.3.0/gems/mailcatcher-{{ mailcatcher_version }}/bin/mailcatcher"
-
 solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/pdc-discovery-staging"
 
 secret_key_base: '{{ vault_pdc_discovery_staging_secret_key }}'


### PR DESCRIPTION
Mailcatcher isn't running on PDC Discovery