### PR TITLE
[hr_share] replace IP with alias for the dms sambaserver

### DIFF
--- a/inventory/by_environment/production.ini
+++ b/inventory/by_environment/production.ini
@@ -59,6 +59,7 @@ static_tables_production
 studio_processors
 tigerdata_production
 tigerdata_training
+tower_26
 towerdeploy
 utilities
 whichiso_production

--- a/roles/hr_share/tasks/main.yml
+++ b/roles/hr_share/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Check mount for hr shared files
   ansible.posix.mount:
     path: '/mnt/dms-smbserve/bi-library-hr'
-    src: '//10.6.49.226/bi-library-hr'  # Use IP, //dms-smbserve isn't routable.
+    src: '//dms-smbserve.princeton.edu/bi-library-hr'  # Use IP, //dms-smbserve isn't routable.
     fstype: cifs
     opts: 'defaults,uid=33,gid={{ deploy_user_uid }},credentials=/etc/hr_share.smb.credentials'
     state: present
@@ -27,7 +27,7 @@
 - name: Create mount for hr shared files
   ansible.posix.mount:
     path: '/mnt/dms-smbserve/bi-library-hr'
-    src: '//10.6.49.226/bi-library-hr'  # Use IP, //dms-smbserve isn't routable.
+    src: '//dms-smbserve.princeton.edu/bi-library-hr'  # Use IP, //dms-smbserve isn't routable.
     fstype: cifs
     opts: 'defaults,uid=33,gid={{ deploy_user_uid }},credentials=/etc/hr_share.smb.credentials'
     state: mounted

--- a/roles/hr_share/tasks/main.yml
+++ b/roles/hr_share/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Check mount for hr shared files
   ansible.posix.mount:
     path: '/mnt/dms-smbserve/bi-library-hr'
-    src: '//dms-smbserve.princeton.edu/bi-library-hr'  # Use IP, //dms-smbserve isn't routable.
+    src: '//dms-smbserve.princeton.edu/bi-library-hr'
     fstype: cifs
     opts: 'defaults,uid=33,gid={{ deploy_user_uid }},credentials=/etc/hr_share.smb.credentials'
     state: present
@@ -27,7 +27,7 @@
 - name: Create mount for hr shared files
   ansible.posix.mount:
     path: '/mnt/dms-smbserve/bi-library-hr'
-    src: '//dms-smbserve.princeton.edu/bi-library-hr'  # Use IP, //dms-smbserve isn't routable.
+    src: '//dms-smbserve.princeton.edu/bi-library-hr'
     fstype: cifs
     opts: 'defaults,uid=33,gid={{ deploy_user_uid }},credentials=/etc/hr_share.smb.credentials'
     state: mounted

--- a/roles/lib_jobs/defaults/main.yml
+++ b/roles/lib_jobs/defaults/main.yml
@@ -24,7 +24,7 @@ app_lib_jobs_aspace_password: change_me
 lib_jobs_honeybadger_key: change_me
 onbase_samba_server: 172.19.70.71
 onbase_samba_directory: obqadrop/Scheduler/KeywordUpdate/LIB/Alma
-peoplesoft_samba_server: 10.6.49.226
+peoplesoft_samba_server: 'dms-smbserve.princeton.edu'
 peoplesoft_samba_directory: lbvchr-q
 peoplesoft_bursar_samba_directory: sf_library
 peoplesoft_bursar_output_dir: /mnt/dms-smbserve/bursar/test

--- a/roles/lib_jobs/tasks/main.yml
+++ b/roles/lib_jobs/tasks/main.yml
@@ -16,7 +16,7 @@
     owner: root
     group: root
   loop: "{{ lib_jobs_logrotate_rules }}"
-  when: 
+  when:
     - lib_jobs_logrotate_rules is defined
     - lib_jobs_logrotate_rules | length > 0
 
@@ -98,7 +98,7 @@
 - name: lib_jobs | Create mount for peoplesoft shared files
   ansible.posix.mount:
     path: '/mnt/dms-smbserve/peoplesoft'
-    src: '//{{ peoplesoft_samba_server }}/{{ peoplesoft_samba_directory }}'  # Use IP, //dms-smbserve isn't routable.
+    src: '//{{ peoplesoft_samba_server }}/{{ peoplesoft_samba_directory }}'
     fstype: cifs
     opts: 'defaults,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }},credentials=/etc/peoplesoft.smb.credentials,file_mode=0777'
     state: mounted
@@ -108,7 +108,7 @@
 - name: lib_jobs | Create mount for peoplesoft bursar shared files
   ansible.posix.mount:
     path: '/mnt/dms-smbserve/bursar'
-    src: '//{{ peoplesoft_samba_server }}/{{ peoplesoft_bursar_samba_directory }}'  # Use IP, //dms-smbserve isn't routable.
+    src: '//{{ peoplesoft_samba_server }}/{{ peoplesoft_bursar_samba_directory }}'
     fstype: cifs
     opts: 'defaults,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }},credentials=/etc/peoplesoft.smb.credentials,file_mode=0777'
     state: mounted
@@ -127,7 +127,7 @@
 - name: lib_jobs | Create mount for onbase shared files
   ansible.posix.mount:
     path: '/mnt/oby14qa/onbase'
-    src: '//{{ onbase_samba_server }}/{{ onbase_samba_directory }}'  # Use IP, //dms-smbserve isn't routable.
+    src: '//{{ onbase_samba_server }}/{{ onbase_samba_directory }}'
     fstype: cifs
     opts: 'defaults,uid={{ deploy_user_uid }},gid={{ deploy_user_uid }},credentials=/etc/onbase.smb.credentials'
     state: mounted


### PR DESCRIPTION
Partially addresses #7333.

Since the Alma migration we have used a hardcoded IP to mount shares on the central Samba server for sharing data with other departments. The server using that IP is obsolete and needs to be replaced. 

This PR substitutes an alias, so future changes to the IP or to the underlying hardware for this service will not interrupt the mounts for library services.


