### PR TITLE
[Traefik Wall] Reduce the RAM used to store challenges, increase RAM.

### DIFF
--- a/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-production.tpl.yml
@@ -18,7 +18,6 @@ http:
           siteKey: "{{ .TURNSTILE_SITE_KEY }}"
           secretKey: "{{ .TURNSTILE_SECRET_KEY }}"
           goodBots: apple.com,archive.org,duckduckgo.com,facebook.com,google.com,googlebot.com,googleusercontent.com,instagram.com,kagibot.org,linkedin.com,msn.com,openalex.org,twitter.com,x.com,commoncrawl.org
-          persistentStateFile: /tmp/state.json
           ipForwardedHeader: X-Forwarded-For
           rateLimit: {{ env "rate_limit" }}
           ipv4subnetMask: {{ env "subnet_mask" }}

--- a/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
+++ b/nomad/traefik-wall/deploy/bot-plugin-staging.tpl.yml
@@ -18,7 +18,6 @@ http:
           siteKey: "{{ .TURNSTILE_SITE_KEY }}"
           secretKey: "{{ .TURNSTILE_SECRET_KEY }}"
           goodBots: apple.com,archive.org,duckduckgo.com,facebook.com,google.com,googlebot.com,googleusercontent.com,instagram.com,kagibot.org,linkedin.com,msn.com,openalex.org,twitter.com,x.com,commoncrawl.org
-          persistentStateFile: /tmp/state.json
           ipForwardedHeader: X-Forwarded-For
           rateLimit: {{ env "rate_limit" }}
           ipv4subnetMask: {{ env "subnet_mask" }}

--- a/nomad/traefik-wall/deploy/production.hcl
+++ b/nomad/traefik-wall/deploy/production.hcl
@@ -120,7 +120,7 @@ job "traefik-wall-production" {
 
       resources {
         cpu    = 1000
-        memory = 1024
+        memory = 3072
       }
     }
   }

--- a/nomad/traefik-wall/deploy/production.hcl
+++ b/nomad/traefik-wall/deploy/production.hcl
@@ -119,7 +119,7 @@ job "traefik-wall-production" {
       }
 
       resources {
-        cpu    = 1000
+        cpu    = 4000
         memory = 3072
       }
     }

--- a/nomad/traefik-wall/deploy/sites/sites-production.yml
+++ b/nomad/traefik-wall/deploy/sites/sites-production.yml
@@ -8,147 +8,100 @@ http:
       middlewares:
         - metricAuth
 
-    catalog-production-skip-all-mw:
-      service: catalog-production
-      rule: "Header(`X-Forwarded-Host`, `catalog.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
+    protected-sites:
+      rule: "Header(`X-Forwarded-Host`, `catalog.princeton.edu`) || Header(`X-Forwarded-Host`, `datacommons.princeton.edu`) || Header(`X-Forwarded-Host`, `dpul.princeton.edu`) || Header(`X-Forwarded-Host`, `dss.princeton.edu`) || Header(`X-Forwarded-Host`, `figgy.princeton.edu`) || Header(`X-Forwarded-Host`, `findingaids.princeton.edu`) || Header(`X-Forwarded-Host`, `findingaids-qa.princeton.edu`) || Header(`X-Forwarded-Host`, `lae.princeton.edu`) || Header(`X-Forwarded-Host`, `maps.princeton.edu`)"
       entrypoints:
         - http
-      priority: 11
-    catalog-production-apply-mw:
+
+    # Skip the bot wall on ajax requests.
+    skip-bot-wall:
+      rule: "Header(`Sec-Fetch-Dest`, `empty`)"
+      parentRefs:
+        - protected-sites
+
+    apply-bot-wall:
+      rule: "!Header(`Sec-Fetch-Dest`, `empty`)"
+      middlewares:
+        - captcha-protect
+      parentRefs:
+        - protected-sites
+
+    catalog-production:
       service: catalog-production
       rule: "Header(`X-Forwarded-Host`, `catalog.princeton.edu`)"
-      entrypoints:
-        - http
       middlewares:
-        - captcha-protect
         - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    datacommons-production-skip-all-mw:
+    datacommons-production:
       service: datacommons-production
-      rule: "Header(`X-Forwarded-Host`, `datacommons.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    datacommons-production-apply-mw:
-      service: datacommons-production
-      rule: Header(`X-Forwarded-Host`, `datacommons.princeton.edu`)
-      entrypoints:
-        - http
+      rule: "Header(`X-Forwarded-Host`, `datacommons.princeton.edu`)"
       middlewares:
-        - captcha-protect
         - append-discovery-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    dpul-production-skip-all-mw:
-      service: dpul-production
-      rule: "Header(`X-Forwarded-Host`, `dpul.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    dpul-production-apply-mw:
+    dpul-production:
       service: dpul-production
       rule: "Header(`X-Forwarded-Host`, `dpul.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    dss-production-skip-all-mw:
+    dss-production:
       service: dss-production
-      rule: "Header(`X-Forwarded-Host`, `dss.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    dss-production-apply-mw:
-      service: dss-production
-      rule: Header(`X-Forwarded-Host`, `dss.princeton.edu`)
-      entrypoints:
-        - http
+      rule: "Header(`X-Forwarded-Host`, `dss.princeton.edu`)"
       middlewares:
-        - captcha-protect
         - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    figgy-production-skip-all-mw:
-      service: figgy-production
-      rule: "Header(`X-Forwarded-Host`, `figgy.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    figgy-production-apply-mw:
+    figgy-production:
       service: figgy-production
       rule: "Header(`X-Forwarded-Host`, `figgy.princeton.edu`)"
-      entrypoints:
-        - http
       middlewares:
-        - captcha-protect
         - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    findingaids-production-skip-all-mw:
-      service: findingaids-production
-      rule: "Header(`X-Forwarded-Host`, `findingaids.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    findingaids-production-apply-mw:
+    findingaids-production:
       service: findingaids-production
       rule: "Header(`X-Forwarded-Host`, `findingaids.princeton.edu`)"
-      entrypoints:
-        - http
       middlewares:
-        - captcha-protect
         - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    findingaids-qa-skip-all-mw:
-      service: findingaids-qa
-      rule: "Header(`X-Forwarded-Host`, `findingaids-qa.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    findingaids-qa-apply-mw:
+    findingaids-qa:
       service: findingaids-qa
       rule: "Header(`X-Forwarded-Host`, `findingaids-qa.princeton.edu`)"
-      entrypoints:
-        - http
       middlewares:
-        - captcha-protect
         - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    lae-production-skip-all-mw:
-      service: lae-production
-      rule: "Header(`X-Forwarded-Host`, `lae.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    lae-production-apply-mw:
+    lae-production:
       service: lae-production
       rule: "Header(`X-Forwarded-Host`, `lae.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
-    maps-production-skip-all-mw:
-      service: maps-production
-      rule: "Header(`X-Forwarded-Host`, `maps.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    maps-production-apply-mw:
+    maps-production:
       service: maps-production
       rule: "Header(`X-Forwarded-Host`, `maps.princeton.edu`)"
-      entrypoints:
-        - http
       middlewares:
-        - captcha-protect
         - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
   services:
     catalog-production:

--- a/nomad/traefik-wall/deploy/sites/sites-staging.yml
+++ b/nomad/traefik-wall/deploy/sites/sites-staging.yml
@@ -8,68 +8,91 @@ http:
       middlewares: 
         - metricAuth
 
-    # Don't protect the path if it's an ajax request.
-    protected-sites-skip-mw:
-      rule: "Header(`Sec-Fetch-Dest`, `empty`)"
+    protected-sites:
+      rule: "Header(`X-Forwarded-Host`, `catalog-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `dpul-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `dss-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `figgy-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `findingaids-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `lae-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `pulfalight-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `maps-staging.princeton.edu`)"
       entrypoints:
         - http
 
-    protected-sites:
-      rule: "!Header(`Sec-Fetch-Dest`, `empty`) && (Header(`X-Forwarded-Host`, `catalog-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `dpul-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `dss-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `figgy-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `findingaids-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `lae-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `pulfalight-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `maps-staging.princeton.edu`))"
-      entrypoints:
-        - http
+    # Skip the bot wall on ajax requests.
+    skip-bot-wall:
+      rule: "Header(`Sec-Fetch-Dest`, `empty`)"
+      parentRefs:
+        - protected-sites
+
+    apply-bot-wall:
+      rule: "!Header(`Sec-Fetch-Dest`, `empty`)"
       middlewares:
         - captcha-protect
-        - append-catalog-regex
+      parentRefs:
+        - protected-sites
 
     catalog-staging:
       service: catalog-staging
       rule: "Header(`X-Forwarded-Host`, `catalog-staging.princeton.edu`)"
+      middlewares:
+        - append-catalog-regex
       parentRefs:
-        - protected-sites-skip-mw
-        - protected-sites
+        - apply-bot-wall
+        - skip-bot-wall
+
+    dpul-staging:
+      service: dpul-staging
+      rule: "Header(`X-Forwarded-Host`, `dpul-staging.princeton.edu`)"
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
 
     dss-staging:
       service: dss-staging
       rule: "Header(`X-Forwarded-Host`, `dss-staging.princeton.edu`)"
+      middlewares:
+        - append-catalog-regex
       parentRefs:
-        - protected-sites-skip-mw
-        - protected-sites
+        - apply-bot-wall
+        - skip-bot-wall
 
     figgy-staging:
       service: figgy-staging
       rule: "Header(`X-Forwarded-Host`, `figgy-staging.princeton.edu`)"
+      middlewares:
+        - append-catalog-regex
       parentRefs:
-        - protected-sites-skip-mw
-        - protected-sites
+        - apply-bot-wall
+        - skip-bot-wall
 
     findingaids-staging:
       service: findingaids-staging
       rule: "Header(`X-Forwarded-Host`, `findingaids-staging.princeton.edu`)"
+      middlewares:
+        - append-catalog-regex
       parentRefs:
-        - protected-sites-skip-mw
-        - protected-sites
+        - apply-bot-wall
+        - skip-bot-wall
 
     lae-staging:
       service: lae-staging
       rule: "Header(`X-Forwarded-Host`, `lae-staging.princeton.edu`)"
       parentRefs:
-        - protected-sites-skip-mw
-        - protected-sites
+        - apply-bot-wall
+        - skip-bot-wall
 
     pulfalight-staging:
       service: findingaids-staging
       rule: "Header(`X-Forwarded-Host`, `pulfalight-staging.princeton.edu`)"
+      middlewares:
+        - append-catalog-regex
       parentRefs:
-        - protected-sites-skip-mw
-        - protected-sites
+        - apply-bot-wall
+        - skip-bot-wall
 
     pulmap-staging:
       service: pulmap-staging
       rule: "Header(`X-Forwarded-Host`, `maps-staging.princeton.edu`)"
       middlewares:
-        - captcha-protect
         - append-catalog-regex
+      parentRefs:
+        - apply-bot-wall
+        - skip-bot-wall
   services:
     catalog-staging:
       loadBalancer:

--- a/nomad/traefik-wall/deploy/sites/sites-staging.yml
+++ b/nomad/traefik-wall/deploy/sites/sites-staging.yml
@@ -8,130 +8,68 @@ http:
       middlewares: 
         - metricAuth
 
-    catalog-staging-skip-all-mw:
-      service: catalog-staging
-      rule: "Header(`X-Forwarded-Host`, `catalog-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
+    # Don't protect the path if it's an ajax request.
+    protected-sites-skip-mw:
+      rule: "Header(`Sec-Fetch-Dest`, `empty`)"
       entrypoints:
         - http
-      priority: 11
-    catalog-staging-apply-mw:
+
+    protected-sites:
+      rule: "!Header(`Sec-Fetch-Dest`, `empty`) && (Header(`X-Forwarded-Host`, `catalog-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `dpul-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `dss-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `figgy-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `findingaids-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `lae-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `pulfalight-staging.princeton.edu`) || Header(`X-Forwarded-Host`, `maps-staging.princeton.edu`))"
+      entrypoints:
+        - http
+      middlewares:
+        - captcha-protect
+        - append-catalog-regex
+
+    catalog-staging:
       service: catalog-staging
       rule: "Header(`X-Forwarded-Host`, `catalog-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-        - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - protected-sites-skip-mw
+        - protected-sites
 
-    dpul-staging-skip-all-mw:
-      service: dpul-staging
-      rule: "Header(`X-Forwarded-Host`, `dpul-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    dpul-staging-apply-mw:
-      service: dpul-staging
-      rule: "Header(`X-Forwarded-Host`, `dpul-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-      priority: 10
-
-    dss-staging-skip-all-mw:
-      service: dss-staging
-      rule: "Header(`X-Forwarded-Host`, `dss-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    dss-staging-apply-mw:
+    dss-staging:
       service: dss-staging
       rule: "Header(`X-Forwarded-Host`, `dss-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-        - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - protected-sites-skip-mw
+        - protected-sites
 
-    figgy-staging-skip-all-mw:
-      service: figgy-staging
-      rule: "Header(`X-Forwarded-Host`, `figgy-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    figgy-staging-apply-mw:
+    figgy-staging:
       service: figgy-staging
       rule: "Header(`X-Forwarded-Host`, `figgy-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-        - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - protected-sites-skip-mw
+        - protected-sites
 
-    findingaids-staging-skip-all-mw:
-      service: findingaids-staging
-      rule: "Header(`X-Forwarded-Host`, `findingaids-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    findingaids-staging-apply-mw:
+    findingaids-staging:
       service: findingaids-staging
       rule: "Header(`X-Forwarded-Host`, `findingaids-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-        - append-catalog-regex
-      priority: 10
+      parentRefs:
+        - protected-sites-skip-mw
+        - protected-sites
 
-    lae-staging-skip-all-mw:
-      service: lae-staging
-      rule: "Header(`X-Forwarded-Host`, `lae-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    lae-staging-apply-mw:
+    lae-staging:
       service: lae-staging
       rule: "Header(`X-Forwarded-Host`, `lae-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      middlewares:
-        - captcha-protect
-      priority: 10
+      parentRefs:
+        - protected-sites-skip-mw
+        - protected-sites
 
-    pulfalight-staging-skip-all-mw:
-      service: findingaids-staging
-      rule: "Header(`X-Forwarded-Host`, `pulfalight-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    # Pulfalight-staging redirects to findingaids-staging.
-    pulfalight-staging-apply-mw:
+    pulfalight-staging:
       service: findingaids-staging
       rule: "Header(`X-Forwarded-Host`, `pulfalight-staging.princeton.edu`)"
-      entrypoints:
-        - http
-      priority: 10
+      parentRefs:
+        - protected-sites-skip-mw
+        - protected-sites
 
-    pulmap-staging-skip-all-mw:
-      service: pulmap-staging
-      rule: "Header(`X-Forwarded-Host`, `maps-staging.princeton.edu`) && Header(`Sec-Fetch-Dest`, `empty`)"
-      entrypoints:
-        - http
-      priority: 11
-    pulmap-staging-apply-mw:
+    pulmap-staging:
       service: pulmap-staging
       rule: "Header(`X-Forwarded-Host`, `maps-staging.princeton.edu`)"
-      entrypoints:
-        - http
       middlewares:
         - captcha-protect
         - append-catalog-regex
-      priority: 10
-
   services:
     catalog-staging:
       loadBalancer:


### PR DESCRIPTION
This reduces the amount of ram needed for challenges by having a single router for most sites. It also increases the amount of allowed provisioned memory for this container.

We should see a few improvements from this:

1. No downtime from OOM.
2. Succeeding in the challenge on one site should count as a success for another site.
3. A little easier to read the config files.

Closes #7383 