### PR TITLE
[rapid7] Ensure Rapid7 Scan Assistant config directory exists

### DIFF
--- a/playbooks/utils/security_install.yml
+++ b/playbooks/utils/security_install.yml
@@ -148,6 +148,14 @@
         - ansible_distribution != "FreeBSD"
         # add condition here so we don't re-install Rapid7 on every machine every week
       block:
+        - name: Create Rapid7 Scan Assistant configuration directory
+          ansible.builtin.file:
+            path: /etc/rapid7/ScanAssistant
+            state: directory
+            owner: root
+            group: root
+            mode: "0755"
+
         - name: Download the Rapid7 deb file (Ubuntu)
           ansible.builtin.get_url:
             url: "https://us.storage.endpoint.ingress.rapid7.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/rapid7_insight_agent_x64.deb"


### PR DESCRIPTION
Create /etc/rapid7/ScanAssistant before copying the trusted PEM file to prevent fresh installations from failing when the directory is absent.

closes #7391 