### PR TITLE
[proxmox] feat(nginx): add redirect to port 8006 for lib-px-staging

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/lib_px_staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/lib_px_staging.conf
@@ -14,6 +14,30 @@ upstream lib-px-staging {
         samesite=lax;
 }
 
+# Redirect HTTP (port 80) → HTTPS on port 8006
+server {
+    listen 80;
+    server_name lib-px-staging.lib.princeton.edu;
+    return 301 https://$server_name:8006$request_uri;
+}
+
+# Redirect HTTPS (port 443) → HTTPS on port 8006
+server {
+    listen 443 ssl;
+    server_name lib-px-staging.lib.princeton.edu;
+
+    # Use the same certificate files as your existing block
+    ssl_certificate     /etc/letsencrypt/live/lib-px-staging.lib/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/lib-px-staging.lib/privkey.pem;
+
+    # Optional: keep SSL settings consistent
+    ssl_session_cache shared:lib_px_staging_SSL_redirect:10m;
+    ssl_session_timeout 1d;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    return 301 https://$server_name:8006$request_uri;
+}
+
 server {
     listen 8006 ssl;
     server_name lib-px-staging.lib.princeton.edu;


### PR DESCRIPTION
Adds two server blocks:
- listen 80 → return 301 to https://$server_name:8006
- listen 443 → return 301 to https://$server_name:8006

Allows users to reach the service without manually specifying the port.