### PR TITLE
[solr9prod] make max_fail=0

### DIFF
--- a/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
@@ -5,9 +5,9 @@ proxy_cache_path /var/cache/nginx/lib-solr9-prod/ keys_zone=lib-solr9-prodcache:
 upstream lib-solr9-prod {
     least_time header 'inflight';
     zone lib-solr9-prod 128k;
-    server lib-solr-prod1.princeton.edu:8983 resolve;
-    server lib-solr-prod2.princeton.edu:8983 resolve;
-    server lib-solr-prod3.princeton.edu:8983 resolve;
+    server lib-solr-prod1.princeton.edu:8983 resolve max_fails=0;
+    server lib-solr-prod2.princeton.edu:8983 resolve max_fails=0;
+    server lib-solr-prod3.princeton.edu:8983 resolve max_fails=0;
     sticky learn
           create=$upstream_cookie_lib-solr9-prodcookie
           lookup=$cookie_lib-solr9-prodcookie


### PR DESCRIPTION
this allows solr's health to persist longer than the default for nginx before it screams I'm done