### PR TITLE
adds quotes to handle multi-value tags field

### DIFF
--- a/playbooks/utils/gitlab-api-RW.yml
+++ b/playbooks/utils/gitlab-api-RW.yml
@@ -11,7 +11,7 @@
     - name: write selected output to CSV for team handbook
       ansible.builtin.lineinfile:
         dest: /opt/gitlab_issues/team_handbook_issues.csv
-        line: GitLab,"{{ GLissue.title }}",{{ GLissue.iid }},{{ GLissue.state }},{{ GLissue.assignee.name | default('') }},{{ GLissue.created_at }},{{ GLissue.labels | default('') }},{{ GLissue.web_url }}
+        line: GitLab,"{{ GLissue.title }}",{{ GLissue.iid }},{{ GLissue.state }},{{ GLissue.assignee.name | default('') }},{{ GLissue.created_at }},"{{ GLissue.labels | default('') }}",{{ GLissue.web_url }}
         insertafter: EOF
         state: present
       loop: "{{ current_page | community.general.json_query('json[*]') }}"


### PR DESCRIPTION
Our CSV transfer of ticket data to Airtable failed when we created a ticket with multiple tags assigned to it. Adding quotes to the lineinfile task makes the CSV creation work correctly.