### PR TITLE
[otel_collector] Fix format of extensions config

### DIFF
--- a/roles/otel_collector/defaults/main.yml
+++ b/roles/otel_collector/defaults/main.yml
@@ -29,7 +29,7 @@ otel_receivers: {}
 otel_processors: {}
 otel_exporters: {}
 otel_service_pipelines: {}
-otel_extensions: []
+otel_extensions: {}
 
 # Default resource attributes to merge into processors.resource.
 otel_default_resource_attributes: {}

--- a/roles/otel_collector/templates/config.yaml.j2
+++ b/roles/otel_collector/templates/config.yaml.j2
@@ -6,7 +6,7 @@
 # - otel_exporters (dict)
 # - otel_service_pipelines (dict)
 # - otel_service_telemetry (dict, optional)
-# - otel_extensions (list)
+# - otel_extensions (dict)
 #
 # Optionally add otel_default_resource_attributes (dict) to merge into
 # processors.resource.
@@ -107,4 +107,4 @@ service:
 {{ (merged_service_pipelines | default({})) | to_nice_yaml(indent=2) | indent(4, true) }}
 
 extensions:
-{{ (otel_extensions | default([])) | to_nice_yaml(indent=2) | indent(4, true) }}
+{{ (otel_extensions | default({})) | to_nice_yaml(indent=2) | indent(4, true) }}


### PR DESCRIPTION
Before this change, we got the following error which prevented the solr playbooks from running:

```
$ /opt/otelcol/otelcol-contrib validate --config /opt/otelcol/config.yaml
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

'extensions' expected a map or struct, got "slice"
```