### PR TITLE
[Signoz] SigNoz ClickHouse memory request to prevent OOM

### DIFF
--- a/group_vars/signoz/production.yml
+++ b/group_vars/signoz/production.yml
@@ -3,6 +3,12 @@ signoz_ingress_enabled: true
 signoz_ingress_host: signoz.lib.princeton.edu
 signoz_ingress_class_name: public
 signoz_clickhouse_memory_request: "32Gi"
+# Checkmk monitoring
+signoz_checkmk_ingestion_enabled: true
+signoz_checkmk_monitor_host: "k8s-prod1.lib.princeton.edu"
+signoz_checkmk_ingestion_warn_seconds: 60
+signoz_checkmk_ingestion_crit_seconds: 300
+signoz_checkmk_collector_log_window: "5m"
 
 signoz_global_storage_class: k8s-fs-nfs
 

--- a/group_vars/signoz/production.yml
+++ b/group_vars/signoz/production.yml
@@ -2,6 +2,7 @@
 signoz_ingress_enabled: true
 signoz_ingress_host: signoz.lib.princeton.edu
 signoz_ingress_class_name: public
+signoz_clickhouse_memory_request: "32Gi"
 
 signoz_global_storage_class: k8s-fs-nfs
 

--- a/roles/signoz_k8s/defaults/main.yml
+++ b/roles/signoz_k8s/defaults/main.yml
@@ -7,6 +7,8 @@ signoz_chart_repo_url: https://charts.signoz.io
 signoz_chart_ref: signoz/signoz
 signoz_chart_version: ""
 signoz_clickhousetraces_timeout: "10s"
+signoz_clickhouse_cpu_request: "100m"
+signoz_clickhouse_memory_request: "200Mi"
 
 signoz_ingress_enabled: false
 signoz_ingress_name: signoz

--- a/roles/signoz_k8s/defaults/main.yml
+++ b/roles/signoz_k8s/defaults/main.yml
@@ -6,6 +6,7 @@ signoz_chart_repo_name: signoz
 signoz_chart_repo_url: https://charts.signoz.io
 signoz_chart_ref: signoz/signoz
 signoz_chart_version: ""
+signoz_clickhousetraces_timeout: "10s"
 
 signoz_ingress_enabled: false
 signoz_ingress_name: signoz

--- a/roles/signoz_k8s/defaults/main.yml
+++ b/roles/signoz_k8s/defaults/main.yml
@@ -9,6 +9,12 @@ signoz_chart_version: ""
 signoz_clickhousetraces_timeout: "10s"
 signoz_clickhouse_cpu_request: "100m"
 signoz_clickhouse_memory_request: "200Mi"
+# Checkmk SigNoz ingestion monitoring
+signoz_checkmk_ingestion_enabled: false
+signoz_checkmk_monitor_host: ""
+signoz_checkmk_ingestion_warn_seconds: 60
+signoz_checkmk_ingestion_crit_seconds: 300
+signoz_checkmk_collector_log_window: "5m"
 
 signoz_ingress_enabled: false
 signoz_ingress_name: signoz

--- a/roles/signoz_k8s/tasks/checkmk.yml
+++ b/roles/signoz_k8s/tasks/checkmk.yml
@@ -1,0 +1,41 @@
+---
+- name: SigNoz | Ensure Checkmk local check directory exists
+  ansible.builtin.file:
+    path: /usr/lib/check_mk_agent/local
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - signoz_checkmk_ingestion_enabled | default(false) | bool
+    - inventory_hostname == signoz_checkmk_monitor_host
+
+- name: SigNoz | Install Checkmk ingestion local check
+  ansible.builtin.template:
+    src: check_signoz_ingestion.sh.j2
+    dest: /usr/lib/check_mk_agent/local/check_signoz_ingestion.sh
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - signoz_checkmk_ingestion_enabled | default(false) | bool
+    - inventory_hostname == signoz_checkmk_monitor_host
+
+- name: SigNoz | Verify Checkmk ingestion local check
+  ansible.builtin.command:
+    cmd: /usr/lib/check_mk_agent/local/check_signoz_ingestion.sh
+  register: signoz_checkmk_ingestion_result
+  changed_when: false
+  failed_when: false
+  when:
+    - signoz_checkmk_ingestion_enabled | default(false) | bool
+    - inventory_hostname == signoz_checkmk_monitor_host
+    - checkmk_verify_local | default(false) | bool
+
+- name: SigNoz | Show Checkmk ingestion local check result
+  ansible.builtin.debug:
+    var: signoz_checkmk_ingestion_result.stdout
+  when:
+    - signoz_checkmk_ingestion_enabled | default(false) | bool
+    - inventory_hostname == signoz_checkmk_monitor_host
+    - checkmk_verify_local | default(false) | bool

--- a/roles/signoz_k8s/tasks/main.yml
+++ b/roles/signoz_k8s/tasks/main.yml
@@ -328,3 +328,6 @@
 - name: Show SigNoz pods and PVCs
   ansible.builtin.debug:
     var: signoz_pods.stdout_lines
+
+- name: Add checkmk monitor
+  ansible.builtin.import_tasks: checkmk.yml

--- a/roles/signoz_k8s/templates/check_signoz_ingestion.sh.j2
+++ b/roles/signoz_k8s/templates/check_signoz_ingestion.sh.j2
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -u
+
+MICROK8S="/snap/bin/microk8s"
+NAMESPACE="{{ signoz_namespace }}"
+CLICKHOUSE_POD="chi-signoz-clickhouse-cluster-0-0-0"
+WARN_SECONDS={{ signoz_checkmk_ingestion_warn_seconds }}
+CRIT_SECONDS={{ signoz_checkmk_ingestion_crit_seconds }}
+COLLECTOR_LOG_WINDOW="{{ signoz_checkmk_collector_log_window }}"
+
+SERVICE_NAME="SigNoz log ingestion"
+
+clickhouse_lag="$(
+  "${MICROK8S}" kubectl -n "${NAMESPACE}" exec \
+    "${CLICKHOUSE_POD}" \
+    -c clickhouse -- \
+    clickhouse-client \
+      --format TSVRaw \
+      -q "
+        SELECT dateDiff(
+          'second',
+          toDateTime(intDiv(max(timestamp), 1000000000)),
+          now()
+        )
+        FROM signoz_logs.logs_v2
+      " 2>/dev/null
+)"
+
+if [[ $? -ne 0 || ! "${clickhouse_lag}" =~ ^[0-9]+$ ]]; then
+  echo "2 \"${SERVICE_NAME}\" - Unable to query newest log timestamp from ClickHouse"
+  exit 0
+fi
+
+collector_pod="$(
+  "${MICROK8S}" kubectl -n "${NAMESPACE}" get pods \
+    -l app.kubernetes.io/component=otel-collector \
+    -o jsonpath='{.items[0].metadata.name}' \
+    2>/dev/null
+)"
+
+if [[ -z "${collector_pod}" ]]; then
+  echo "2 \"${SERVICE_NAME}\" lag_seconds=${clickhouse_lag};${WARN_SECONDS};${CRIT_SECONDS} No SigNoz OTel collector pod found"
+  exit 0
+fi
+
+collector_errors="$(
+  "${MICROK8S}" kubectl -n "${NAMESPACE}" logs \
+    "${collector_pod}" \
+    -c collector \
+    --since="${COLLECTOR_LOG_WINDOW}" \
+    2>/dev/null |
+  grep -Eic \
+    'sending queue is full|PrepareBatch.*context deadline exceeded|Rejecting data' \
+  || true
+)"
+
+if (( collector_errors > 0 )); then
+  echo "2 \"${SERVICE_NAME}\" lag_seconds=${clickhouse_lag};${WARN_SECONDS};${CRIT_SECONDS}|collector_errors=${collector_errors} Collector exporter failure detected: ${collector_errors} matching errors in last ${COLLECTOR_LOG_WINDOW}"
+  exit 0
+fi
+
+if (( clickhouse_lag >= CRIT_SECONDS )); then
+  echo "2 \"${SERVICE_NAME}\" lag_seconds=${clickhouse_lag};${WARN_SECONDS};${CRIT_SECONDS}|collector_errors=${collector_errors} Log ingestion is ${clickhouse_lag}s behind"
+  exit 0
+fi
+
+if (( clickhouse_lag >= WARN_SECONDS )); then
+  echo "1 \"${SERVICE_NAME}\" lag_seconds=${clickhouse_lag};${WARN_SECONDS};${CRIT_SECONDS}|collector_errors=${collector_errors} Log ingestion is ${clickhouse_lag}s behind"
+  exit 0
+fi
+
+echo "0 \"${SERVICE_NAME}\" lag_seconds=${clickhouse_lag};${WARN_SECONDS};${CRIT_SECONDS}|collector_errors=${collector_errors} Log ingestion healthy: ${clickhouse_lag}s behind"

--- a/roles/signoz_k8s/templates/signoz-values.yaml.j2
+++ b/roles/signoz_k8s/templates/signoz-values.yaml.j2
@@ -3,6 +3,10 @@ global:
 
 clickhouse:
   installCustomStorageClass: false
+  resources:
+    requests:
+      cpu: "{{ signoz_clickhouse_cpu_request }}"
+      memory: "{{ signoz_clickhouse_memory_request }}"
 
 signoz:
   service:

--- a/roles/signoz_k8s/templates/signoz-values.yaml.j2
+++ b/roles/signoz_k8s/templates/signoz-values.yaml.j2
@@ -9,30 +9,34 @@ signoz:
     type: {{ signoz_service_type }}
     port: 8080
     nodePort: {{ signoz_http_node_port }}
-
   env:
     # Alertmanager email alerts
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__FROM: "signoz@princeton.edu"
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__HELLO: "signoz.lib.princeton.edu"
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__SMARTHOST: "lib-ponyexpr-prod.princeton.edu:25"
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__REQUIRE__TLS: "false"
-     # Alertmanager links back to SigNoz UI
+    # Alertmanager links back to SigNoz UI
     signoz_alertmanager_signoz_external__url: "https://{{ signoz_ingress_host }}"
     SIGNOZ_TOKENIZER_JWT_SECRET: "{{ signoz_tokenizer_jwt_secret }}"
 
 otelCollector:
+  config:
+    exporters:
+      clickhousetraces:
+        timeout: "{{ signoz_clickhousetraces_timeout }}"
+
   service:
     type: NodePort
-  ports:
-    otlp:
-      enabled: true
-      servicePort: 4317
-      containerPort: 4317
-      nodePort: {{ signoz_otel_grpc_node_port }}
-      protocol: TCP
-    otlp-http:
-      enabled: true
-      servicePort: 4318
-      containerPort: 4318
-      nodePort: {{ signoz_otel_http_node_port }}
-      protocol: TCP
+    ports:
+      otlp:
+        enabled: true
+        servicePort: 4317
+        containerPort: 4317
+        nodePort: {{ signoz_otel_grpc_node_port }}
+        protocol: TCP
+      otlp-http:
+        enabled: true
+        servicePort: 4318
+        containerPort: 4318
+        nodePort: {{ signoz_otel_http_node_port }}
+        protocol: TCP


### PR DESCRIPTION
- add configurable ClickHouse CPU and memory requests
- set production ClickHouse memory request to 32Gi
- keep the production VM at 64Gi RAM for additional headroom
- prevent ClickHouse from being treated as a 200Mi Burstable workload under memory pressure
- add a local Checkmk check for end-to-end log ingestion lag
- alert when ClickHouse log timestamps fall behind
- detect SigNoz collector queue saturation and rejected logs
- report healthy ingestion with configurable warning and critical thresholds

closes #7430 