### PR TITLE
Updates the systemd file descriptor limits for Redis and Sidekiq workers

### DIFF
--- a/roles/redis/README.md
+++ b/roles/redis/README.md
@@ -56,6 +56,9 @@ Requirements
 Role Variables
 --------------
 
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `redis_limit_nofile` | `65536` | `nofile` in `limits.d` for the redis user and systemd `LimitNOFILE` for `redis-server` |
 
 Dependencies
 ------------

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -6,6 +6,8 @@ redis_apt_repository: "deb [signed-by={{ redis_keyring_path }}] https://packages
 
 redis__user: "redis"
 redis__group: "redis"
+# File descriptor limit for Redis (limits.d for the redis user and systemd unit descriptor)
+redis_limit_nofile: 65536
 redis__domain: "{{ ansible_domain if ansible_domain else ansible_hostname }}"
 redis__server_bind: "0.0.0.0"
 redis__auth_password: "{{ vault_redis__auth_password | default('change_me') }}"
@@ -17,9 +19,9 @@ redis__server_save_enabled: true
 # List of ``SAVE`` snapshots to configure. See http://redis.io/commands/save
 # for more details.
 redis__server_save:
-  - '900 1'
-  - '300 10'
-  - '60 10000'
+  - "900 1"
+  - "300 10"
+  - "60 10000"
 # Specify Redis Server log level. Available levels: ``debug``, ``verbose``,
 # ``notice``, ``warning``.
 redis__server_loglevel: "notice"
@@ -34,7 +36,7 @@ redis__server_maxmemory_limit: "0.8"
 #
 # Maximum amount of system memory available for Redis Server in bytes.
 redis__server_maxmemory: "{{ ((ansible_memtotal_mb|int * 1024 * 1024) *
-                              redis__server_maxmemory_limit|float) | round | int }}"
+  redis__server_maxmemory_limit|float) | round | int }}"
 # Specify the policy used by Redis Server for key expiration.
 redis__server_maxmemory_policy: "volatile-lru"
 # Enable or disable vm.overcommit_memory. If disabled and background save is
@@ -64,16 +66,16 @@ redis__server_configuration: {}
 redis__server_group_configuration: {}
 
 redis__server_combined_configuration: "{{ redis__server_default_configuration
-                                          | combine(redis__server_configuration)
-                                          | combine(redis__server_group_configuration)
-                                          | combine(redis__server_host_configuration) }}"
+  | combine(redis__server_configuration)
+  | combine(redis__server_group_configuration)
+  | combine(redis__server_host_configuration) }}"
 
 # versions and above. This YAML dictionary defines what parameters can be used
 # when certain Redis version is installed.
 redis__server_version_config_map:
-  tcp-backlog: '2.8.5'
-  hll-sparse-max-bytes: '2.8.9'
-  latency-monitor-threshold: '2.8.13'
+  tcp-backlog: "2.8.5"
+  hll-sparse-max-bytes: "2.8.9"
+  latency-monitor-threshold: "2.8.13"
 # service needs to be restarted (role will do that automatically).
 redis__server_static_options:
   - "activerehashing"

--- a/roles/redis/handlers/main.yml
+++ b/roles/redis/handlers/main.yml
@@ -1,8 +1,14 @@
 ---
 # handlers file for roles/redis
+- name: reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  become: true
+
 - name: restart redis
   ansible.builtin.service:
     name: "redis-server"
     state: restarted
   when:
     - not ansible_check_mode
+    - running_on_server | default(true)

--- a/roles/redis/molecule/default/verify.yml
+++ b/roles/redis/molecule/default/verify.yml
@@ -25,3 +25,11 @@
     changed_when: false
     failed_when:
       - process | length == 0
+
+  - name: redis limits.d sets nofile
+    ansible.builtin.command: grep -E 'nofile {{ redis_limit_nofile | default(65536) }}' /etc/security/limits.d/redis.conf
+    changed_when: false
+
+  - name: redis-server systemd drop-in sets LimitNOFILE
+    ansible.builtin.command: grep -E '^LimitNOFILE={{ redis_limit_nofile | default(65536) }}$' /etc/systemd/system/redis-server.service.d/limits.conf
+    changed_when: false

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.get_url:
     url: "{{ redis_apt_key_url }}"
     dest: /tmp/redis.gpg.key
-    mode: '0644'
+    mode: "0644"
 
 - name: Redis | De-armor Redis GPG key to binary keyring
   ansible.builtin.shell: "gpg --dearmor < /tmp/redis.gpg.key > {{ redis_keyring_path }}"
@@ -14,7 +14,7 @@
 - name: Redis | Ensure keyring permissions
   ansible.builtin.file:
     path: "{{ redis_keyring_path }}"
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root
     state: file
@@ -44,7 +44,7 @@
     dest: /etc/redis/redis.conf
     owner: redis
     group: redis
-    mode: '0644'
+    mode: "0644"
   notify:
     - restart redis
 
@@ -52,7 +52,27 @@
   ansible.builtin.template:
     src: redis_ulimit.conf.j2
     dest: /etc/security/limits.d/redis.conf
-    mode: '0644'
+    mode: "0644"
+
+# because systemd services do not inherit limits.d the LimitNOFILE must be set on the unit.
+- name: Redis | Create redis-server systemd drop-in directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/redis-server.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Redis | Set LimitNOFILE for redis-server
+  ansible.builtin.template:
+    src: redis-server-limits.conf.j2
+    dest: /etc/systemd/system/redis-server.service.d/limits.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart redis
 
 - name: Redis | Set vm.overcommit
   ansible.posix.sysctl:

--- a/roles/redis/templates/redis-server-limits.conf.j2
+++ b/roles/redis/templates/redis-server-limits.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed | comment }}
+# systemd applies RLIMIT_NOFILE for redis-server; limits.d alone is not enough.
+[Service]
+LimitNOFILE={{ redis_limit_nofile }}

--- a/roles/redis/templates/redis_ulimit.conf.j2
+++ b/roles/redis/templates/redis_ulimit.conf.j2
@@ -1,3 +1,3 @@
 # {{ ansible_managed | comment }}
-redis soft nofile 65535
-redis hard nofile 65535
+{{ redis__user }} soft nofile {{ redis_limit_nofile }}
+{{ redis__user }} hard nofile {{ redis_limit_nofile }}

--- a/roles/sidekiq_worker/README.md
+++ b/roles/sidekiq_worker/README.md
@@ -11,7 +11,14 @@ This role expects the `rails_app`
 Role Variables
 --------------
 
-Variables in `defaults/main.yml`
+Variables in `defaults/main.yml`, including:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `sidekiq_worker_name` | `sidekiq-workers` | systemd unit name |
+| `sidekiq_worker_threads` | `5` | Sidekiq concurrency (`-c`) |
+| `sidekiq_worker_queues` | high, mailers, default, low, super_low | Queues |
+| `sidekiq_worker_limit_nofile` | `65536` | systemd `LimitNOFILE` for the worker unit |
 
 Dependencies
 ------------

--- a/roles/sidekiq_worker/defaults/main.yml
+++ b/roles/sidekiq_worker/defaults/main.yml
@@ -9,6 +9,8 @@ sidekiq_worker_queues:
   - low
   - super_low
 sidekiq_worker_name: "sidekiq-workers"
+# systemd LimitNOFILE for Sidekiq (avoids EMFILE / "Too many open files - getaddrinfo")
+sidekiq_worker_limit_nofile: 65536
 # postgres test VM settings
 postgres_port: 5432
 postgres_version: 15

--- a/roles/sidekiq_worker/molecule/default/verify.yml
+++ b/roles/sidekiq_worker/molecule/default/verify.yml
@@ -16,3 +16,7 @@
     register: present
     failed_when:
       - present is changed
+
+  - name: sidekiq unit sets LimitNOFILE
+    ansible.builtin.command: grep -E '^LimitNOFILE=65536$' /etc/systemd/system/sidekiq-workers.service
+    changed_when: false


### PR DESCRIPTION
Resolves #7406 
Systemd units/services do not inherit limitations set in limits.d or limits.conf. This proposes changes to configure systemd LimitNOFILE settings to ensure Redis and Sidekiq processes are allocated sufficient file descriptor limits (65,536 by default) to prevent 'Too many open files' (EMFILE / getaddrinfo) errors.

Changes include:
- Redis:
  - Added `redis_limit_nofile` default variable.
  - Formulated a systemd drop-in configuration template (`redis-server-limits.conf.j2`) applying `LimitNOFILE` to `redis-server.service.d/limits.conf`.
  - Added a 'reload systemd' handler and integrated it with drop-in tasks.
  - Dynamically configured `redis_ulimit.conf.j2` using `redis__user` and `redis_limit_nofile`.
  - Added molecule verification tasks to confirm `limits.d` and systemd limits are correctly configured.
- Sidekiq:
  - Added `sidekiq_worker_limit_nofile` default variable.
  - Included `LimitNOFILE` directive within the systemd service template `derivatives.service`.
  - Added molecule verification tasks checking `LimitNOFILE` settings in `/etc/systemd/system/sidekiq-workers.service`.
- Documentation:
  - Updated respective roles README files to document the new configuration variables.
