### PR TITLE
[Security] reject commits with unencrypted files called '*priv.key'

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@
 # https://www.reinteractive.net/posts/167-ansible-real-life-good-practices
 #
 # File should be .git/hooks/pre-commit and executable
-FILES_PATTERN='.*vault.*\.*$|digital_ocean\.ini|do_env\.sh'
+FILES_PATTERN='.*vault.*\.*$|.*priv.key|digital_ocean\.ini|do_env\.sh'
 REQUIRED='ANSIBLE_VAULT'
 
 EXIT_STATUS=0


### PR DESCRIPTION
We accidentally exposed an obsolete private key in this repo. This time the key was useless, but we should guard against exposing our keys. This experience showed us that our precommit hook would allow you to check in a file called `*priv.key` without encrypting it.

This PR adds `*priv.key` to the search pattern for file names that must be encrypted.

Updated script in action shown below. It rejected a commit with an unencrypted file called `fake_priv.key`. After encrypting the fake private key, the script allowed the commit to complete.

```
(devbox) princeton_ansible % git commit -m "try to add fake key that isn't encrypted"
# COMMIT REJECTED
# Looks like unencrypted ansible-vault files are part of the commit:
#
-e #	unencrypted:   keys/fake_priv.key
#
# Please encrypt them with 'ansible-vault encrypt <file>'
#   (or force the commit with '--no-verify').
(devbox) princeton_ansible % ansible-vault encrypt keys/fake_priv.key --encrypt-vault-id pul
Encryption successful
(devbox) princeton_ansible % ansible-vault view keys/fake_priv.key 
(devbox) princeton_ansible % git commit -m "try to add fake key after encrypting it"        
[private_is_private e53c049e4] try to add fake key after encrypting it
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 keys/fake_priv.key
```