### PR TITLE
Only BSD machines should report that they are running BSD

### DIFF
--- a/playbooks/utils/security_audit.yml
+++ b/playbooks/utils/security_audit.yml
@@ -44,4 +44,4 @@
     ansible.builtin.debug:
       msg: "{{ inventory_hostname }} runs FreeBSD and cannot run these tools"
     when:
-      - ansible_distribution != "FreeBSD"
+      - ansible_distribution == "FreeBSD"


### PR DESCRIPTION
Copy-pasta meant that our security audit playbook was not correctly checking for BSD as an OS.

This PR corrects the logic on our BSD task for the security audit.