### PR TITLE
Reduce volume of logs sent to signoz

### DIFF
--- a/group_vars/checkmk/production.yml
+++ b/group_vars/checkmk/production.yml
@@ -19,8 +19,6 @@ checkmk_agent_server_protocol: http
 #   - path: /linux/sandboxes
 #     title: Sandboxes
 
-
-
 checkmk_observability_hosts:
   pulmonitor-prod1.lib.princeton.edu:
     site_name: production
@@ -53,7 +51,6 @@ otel_signoz_backends: >-
     checkmk_observability_hosts[inventory_hostname]['otlp_backends']
   }}
 
-
 otel_service_name: otelcol-contrib
 otel_service_user: root
 otel_service_group: root
@@ -73,7 +70,6 @@ otel_default_resource_attributes:
       else 'remote'
     }}
 
-
 otel_receivers:
   otlp/beyla:
     protocols:
@@ -83,24 +79,48 @@ otel_receivers:
       http:
         endpoint: 127.0.0.1:4318
 
-  # Checkmk/OMD logs for the site assigned to this host.
+  # Checkmk logs which use Python-style numeric severity levels.
+  #
+  # Observed examples:
+  #   [15] debug-ish / verbose
+  #   [20] info
+  #   [40] error
+  #
+  # Only WARN (30) and above will reach SigNoz because this receiver
+  # passes through filter/warn_and_above in the logs pipeline.
   filelog/checkmk:
     include:
       - "/omd/sites/{{ checkmk_site_name }}/var/log/*.log"
-      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/access_log"
-      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/error_log"
 
     exclude:
+      # CMC uses a different numeric logging/verbosity scale and is
+      # handled by its own receiver and pipeline below.
+      - "/omd/sites/{{ checkmk_site_name }}/var/log/cmc.log"
+
+      # Ignore rotated logs.
       - "/omd/sites/{{ checkmk_site_name }}/var/log/*.gz"
       - "/omd/sites/{{ checkmk_site_name }}/var/log/*.[0-9]"
-      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/*.gz"
-      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/*.[0-9]"
 
     start_at: end
     include_file_name: true
     include_file_path: true
 
     operators:
+      - type: regex_parser
+        regex: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:,\d{3})? \[(?P<severity>[0-9]+)\]'
+        severity:
+          parse_from: attributes.severity
+          preset: none
+          mapping:
+            debug:
+              - 10
+              - 15
+            info: 20
+            warn: 30
+            error: 40
+            fatal: 50
+          overwrite_text: true
+
       - type: add
         field: attributes["log.source"]
         value: checkmk
@@ -109,18 +129,95 @@ otel_receivers:
         field: attributes["checkmk.site.name"]
         value: "{{ checkmk_site_name }}"
 
-  filelog/system:
+  # CMC does not use the same numeric severity scale as the other
+  # Checkmk logs. For example, observed "[4]" records can contain
+  # actual errors. Keep CMC logs unfiltered rather than risk dropping
+  # operationally useful errors.
+  # https://docs.checkmk.com/latest/en/notifications.html
+  filelog/checkmk-cmc:
     include:
-      - /var/log/syslog
-      - /var/log/auth.log
+      - "/omd/sites/{{ checkmk_site_name }}/var/log/cmc.log"
 
     exclude:
-      - /var/log/*.gz
-      - /var/log/*.[0-9]
+      - "/omd/sites/{{ checkmk_site_name }}/var/log/cmc.log.*"
 
     start_at: end
     include_file_name: true
     include_file_path: true
+
+    operators:
+      - type: add
+        field: attributes["log.source"]
+        value: checkmk-cmc
+
+      - type: add
+        field: attributes["checkmk.site.name"]
+        value: "{{ checkmk_site_name }}"
+
+  # Apache error log only.
+  #
+  # access_log is intentionally not collected because HTTP access
+  # records do not have WARN/ERROR severity semantics.
+  filelog/checkmk-apache-error:
+    include:
+      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/error_log"
+
+    exclude:
+      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/*.gz"
+      - "/omd/sites/{{ checkmk_site_name }}/var/log/apache/*.[0-9]"
+
+    start_at: end
+    include_file_name: true
+    include_file_path: true
+
+    operators:
+      - type: regex_parser
+        regex: '^\[[^\]]+\] \[[^:\]]+:(?P<severity>[^\]]+)\]'
+        severity:
+          parse_from: attributes.severity
+          preset: none
+          mapping:
+            debug:
+              - debug
+              - trace1
+              - trace2
+              - trace3
+              - trace4
+              - trace5
+              - trace6
+              - trace7
+              - trace8
+            info:
+              - info
+              - notice
+            warn: warn
+            error: error
+            fatal:
+              - crit
+              - alert
+              - emerg
+          overwrite_text: true
+
+      - type: add
+        field: attributes["log.source"]
+        value: checkmk-apache
+
+      - type: add
+        field: attributes["checkmk.site.name"]
+        value: "{{ checkmk_site_name }}"
+
+  # System logs at warning severity and above.
+  #
+  # This replaces direct file tailing of:
+  #   /var/log/syslog
+  #   /var/log/auth.log
+  #
+  # journald performs the priority filtering before sending records
+  # into the Collector pipeline.
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/journaldreceiver/README.md
+  journald/system:
+    start_at: end
+    priority: warning
 
     operators:
       - type: add
@@ -178,6 +275,16 @@ otel_processors:
     limit_mib: 512
     spike_limit_mib: 128
 
+  # Drop any parsed log record below WARN.
+  #
+  # This applies to the normal Checkmk logs, Apache error logs,
+  # and journald/system. CMC logs intentionally use a separate
+  # pipeline without this processor.
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
   batch:
     timeout: 10s
     send_batch_size: 8192
@@ -209,14 +316,30 @@ otel_exporters:
       static:
         hostnames: "{{ otel_signoz_backends }}"
 
-otel_extensions: []
-
+otel_extensions: {}
 
 otel_service_pipelines:
+  # WARN and above only.
   logs:
     receivers:
       - filelog/checkmk
-      - filelog/system
+      - filelog/checkmk-apache-error
+      - journald/system
+
+    processors:
+      - memory_limiter
+      - resource
+      - filter/warn_and_above
+      - batch
+
+    exporters:
+      - loadbalancing
+
+  # CMC uses a different logging level scheme, so do not apply
+  # the generic WARN severity filter.
+  logs/cmc:
+    receivers:
+      - filelog/checkmk-cmc
 
     processors:
       - memory_limiter

--- a/group_vars/mysql/production.yml
+++ b/group_vars/mysql/production.yml
@@ -69,6 +69,51 @@ otel_receivers:
       http:
         endpoint: 127.0.0.1:4318
 
+  filelog/mysql-error:
+    include:
+      - /var/log/mysql/mysql_error.log
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: regex_parser
+        id: parse_mysql_error
+        regex: '^\S+(?:\s+\S+)?\s+\d+\s+\[(?P<level>[^\]]+)\]\s+(?P<message>[\s\S]*)$'
+        parse_from: body
+        on_error: send
+
+      - type: severity_parser
+        id: parse_mysql_severity
+        parse_from: attributes.level
+        mapping:
+          debug:
+            - Debug
+          info:
+            - Note
+            - Info
+          warn:
+            - Warning
+          error:
+            - Error
+          fatal:
+            - Critical
+            - Fatal
+        on_error: send
+
+      - type: move
+        id: move_mysql_message_to_body
+        from: attributes.message
+        to: body
+        on_error: send
+
+      - type: add
+        field: attributes.log_type
+        value: mysql_error
+
+      - type: add
+        field: attributes.service_name
+        value: mysql
+
   hostmetrics:
     collection_interval: 30s
     scrapers:
@@ -80,6 +125,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -113,6 +163,17 @@ otel_exporters:
     verbosity: basic
 
 otel_service_pipelines:
+  logs:
+    receivers:
+      - filelog/mysql-error
+    processors:
+      - resource
+      - filter/warn_and_above
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
   metrics:
     receivers:
       - otlp

--- a/group_vars/mysql/staging.yml
+++ b/group_vars/mysql/staging.yml
@@ -31,6 +31,51 @@ otel_receivers:
       http:
         endpoint: 127.0.0.1:4318
 
+  filelog/mysql-error:
+    include:
+      - /var/log/mysql/mysql_error.log
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: regex_parser
+        id: parse_mysql_error
+        regex: '^\S+(?:\s+\S+)?\s+\d+\s+\[(?P<level>[^\]]+)\]\s+(?P<message>[\s\S]*)$'
+        parse_from: body
+        on_error: send
+
+      - type: severity_parser
+        id: parse_mysql_severity
+        parse_from: attributes.level
+        mapping:
+          debug:
+            - Debug
+          info:
+            - Note
+            - Info
+          warn:
+            - Warning
+          error:
+            - Error
+          fatal:
+            - Critical
+            - Fatal
+        on_error: send
+
+      - type: move
+        id: move_mysql_message_to_body
+        from: attributes.message
+        to: body
+        on_error: send
+
+      - type: add
+        field: attributes.log_type
+        value: mysql_error
+
+      - type: add
+        field: attributes.service_name
+        value: mysql
+
   hostmetrics:
     collection_interval: 30s
     scrapers:
@@ -42,6 +87,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -75,6 +125,17 @@ otel_exporters:
     verbosity: basic
 
 otel_service_pipelines:
+  logs:
+    receivers:
+      - filelog/mysql-error
+    processors:
+      - resource
+      - filter/warn_and_above
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
   metrics:
     receivers:
       - otlp
@@ -95,4 +156,3 @@ otel_service_pipelines:
     exporters:
       - loadbalancing
       - debug
-

--- a/group_vars/nginxplus/production.yml
+++ b/group_vars/nginxplus/production.yml
@@ -158,6 +158,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -197,6 +202,7 @@ otel_service_pipelines:
       - filelog/nginxplus-error
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/nginxplus/staging.yml
+++ b/group_vars/nginxplus/staging.yml
@@ -151,6 +151,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -190,6 +195,7 @@ otel_service_pipelines:
       - filelog/nginxplus-error
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/postfix/production.yml
+++ b/group_vars/postfix/production.yml
@@ -96,6 +96,11 @@ otel_processors:
         value: production
         action: upsert
 
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
   batch:
     timeout: 10s
     send_batch_size: 8192
@@ -131,6 +136,7 @@ otel_service_pipelines:
     processors:
       - memory_limiter
       - resource
+      - filter/warn_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/postfix/staging.yml
+++ b/group_vars/postfix/staging.yml
@@ -8,3 +8,158 @@ proofpoint_username: "{{ vault_proofpoint_staging_username }}"
 proofpoint_password: "{{ vault_proofpoint_staging_password }}"
 proofpoint_host: "{{ vault_proofpoint_host }}"
 proofpoint_port: "587"
+
+# SigNoz / OpenTelemetry Collector for ponyexpr Postfix logs
+otel_default_resource_attributes:
+  host.name: "{{ inventory_hostname }}"
+  service.name: ponyexpr-postfix
+  service.namespace: mail
+  service.version: staging
+  environment: staging
+  deployment.environment: staging
+
+otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
+  filelog/postfix:
+    include:
+      - /var/log/mail.log
+    exclude:
+      - /var/log/mail.log.*
+      - /var/log/*.gz
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: syslog_parser
+        id: parse_syslog_rfc3164
+        protocol: rfc3164
+
+      - type: regex_parser
+        id: parse_postfix_client
+        parse_from: body
+        regex: '^connect from (?P<client_hostname>[^\[]+)\[(?P<client_ip>[^\]]+)\]$'
+        if: 'body matches "^connect from .*\\[[^\\]]+\\]$"'
+
+      - type: regex_parser
+        id: parse_postfix_disconnect
+        parse_from: body
+        regex: '^disconnect from (?P<client_hostname>[^\[]+)\[(?P<client_ip>[^\]]+)\](?: (?P<postfix_disconnect_stats>.*))?$'
+        if: 'body matches "^disconnect from .*\\[[^\\]]+\\]"'
+
+      - type: regex_parser
+        id: parse_postfix_lost_connection
+        parse_from: body
+        regex: '^lost connection after (?P<smtp_stage>[A-Z]+) from (?P<client_hostname>[^\[]+)\[(?P<client_ip>[^\]]+)\]$'
+        if: 'body matches "^lost connection after [A-Z]+ from .*\\[[^\\]]+\\]$"'
+
+      - type: add
+        field: attributes.log_type
+        value: postfix
+
+      - type: add
+        field: attributes.service.name
+        value: ponyexpr-postfix
+
+      - type: add
+        field: attributes.deployment.environment
+        value: staging
+
+otel_processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+
+  resource:
+    attributes:
+      - key: host.name
+        value: "{{ inventory_hostname }}"
+        action: upsert
+      - key: service.name
+        value: ponyexpr-postfix
+        action: upsert
+      - key: service.namespace
+        value: mail
+        action: upsert
+      - key: service.version
+        value: staging
+        action: upsert
+      - key: deployment.environment
+        value: staging
+        action: upsert
+      - key: environment
+        value: staging
+        action: upsert
+
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
+  batch:
+    timeout: 10s
+    send_batch_size: 8192
+
+otel_exporters:
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    resolver:
+      static:
+        hostnames:
+          - k8s-staging1.lib.princeton.edu:32317
+          - k8s-staging2.lib.princeton.edu:32317
+          - k8s-staging3.lib.princeton.edu:32317
+
+otel_service_pipelines:
+  logs:
+    receivers:
+      - filelog/postfix
+    processors:
+      - memory_limiter
+      - resource
+      - filter/warn_and_above
+      - batch
+    exporters:
+      - loadbalancing
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - memory_limiter
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+
+  metrics:
+    receivers:
+      - otlp
+    processors:
+      - memory_limiter
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+
+otel_extensions: []

--- a/group_vars/postgresql/production.yml
+++ b/group_vars/postgresql/production.yml
@@ -182,6 +182,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -220,6 +225,7 @@ otel_service_pipelines:
       - filelog/postgresql-json
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/postgresql/qa.yml
+++ b/group_vars/postgresql/qa.yml
@@ -22,6 +22,7 @@ postgresadmin: "postgres"
 postgres_admin_password: '{{ vault_postgres_admin_password }}'
 postgres_port: 5432
 postgres_admin_user: "{{ postgresadmin }}"
+postgresql_log_path: "/var/lib/postgresql/{{ postgres_version }}/main/pg_log/pg.json"
 
 postgresql_logrotate_rules:
   - name: "postgresql"
@@ -35,3 +36,185 @@ postgresql_logrotate_rules:
       create_group: postgres
       su_user: "{{ logrotate_global_defaults.su_user }}"
       su_group: "{{ logrotate_global_defaults.su_group }}"
+
+# Beyla
+beyla_enabled: true
+beyla_service_name: postgresql
+beyla_environment: qa
+beyla_otlp_endpoint: "http://127.0.0.1:4318"
+beyla_otlp_protocol: "http/protobuf"
+beyla_bpf_context_propagation: "all"
+
+beyla_open_ports:
+  - 5432
+
+# SigNoz / OpenTelemetry Collector for PostgreSQL
+otel_default_resource_attributes:
+  host.name: "{{ inventory_hostname }}"
+  service.name: postgresql
+  service.version: qa
+  environment: qa
+  deployment.environment: qa
+
+otel_receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
+  postgresql:
+    endpoint: 127.0.0.1:5432
+    transport: tcp
+    username: "{{ postgres_admin_user }}"
+    password: "{{ postgres_admin_password }}"
+    databases:
+      - postgres
+    collection_interval: 30s
+    metrics:
+      postgresql.database.locks:
+        enabled: true
+      postgresql.deadlocks:
+        enabled: true
+
+  filelog/postgresql-json:
+    include:
+      - /var/lib/postgresql/15/main/pg_log/pg.json
+      - /var/lib/postgresql/15/main/pg_log/pg.json-[0-9]*
+    exclude:
+      - /var/lib/postgresql/15/main/pg_log/*.gz
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: json_parser
+        id: parse_postgresql_json
+        parse_from: body
+        on_error: send
+
+      - type: time_parser
+        id: parse_postgresql_timestamp
+        parse_from: attributes.timestamp
+        layout_type: strptime
+        layout: '%Y-%m-%d %H:%M:%S.%L %Z'
+        on_error: send
+
+      - type: severity_parser
+        id: parse_postgresql_severity
+        parse_from: attributes.error_severity
+        mapping:
+          debug:
+            - DEBUG
+            - DEBUG1
+            - DEBUG2
+            - DEBUG3
+            - DEBUG4
+            - DEBUG5
+          info:
+            - LOG
+            - INFO
+            - NOTICE
+          warn:
+            - WARNING
+          error:
+            - ERROR
+          fatal:
+            - FATAL
+            - PANIC
+        on_error: send
+
+      - type: move
+        id: move_postgresql_message_to_body
+        from: attributes.message
+        to: body
+        on_error: send
+
+      - type: add
+        field: attributes.log_type
+        value: postgresql_json
+
+      - type: add
+        field: attributes.service_name
+        value: postgresql
+
+  hostmetrics:
+    collection_interval: 30s
+    scrapers:
+      cpu: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      memory: {}
+      network: {}
+
+otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
+  batch:
+    send_batch_max_size: 1024
+    send_batch_size: 512
+    timeout: 30s
+
+otel_exporters:
+  loadbalancing:
+    routing_key: service
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+    resolver:
+      static:
+        hostnames:
+          - k8s-prod1.lib.princeton.edu:32317
+          - k8s-prod2.lib.princeton.edu:32317
+          - k8s-prod3.lib.princeton.edu:32317
+
+  debug:
+    verbosity: basic
+
+otel_service_pipelines:
+  logs:
+    receivers:
+      - filelog/postgresql-json
+    processors:
+      - resource
+      - filter/info_and_above
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
+  metrics:
+    receivers:
+      - postgresql
+      - hostmetrics
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug
+
+  traces:
+    receivers:
+      - otlp
+    processors:
+      - resource
+      - batch
+    exporters:
+      - loadbalancing
+      - debug

--- a/group_vars/postgresql/sandbox.yml
+++ b/group_vars/postgresql/sandbox.yml
@@ -147,6 +147,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -185,6 +190,7 @@ otel_service_pipelines:
       - filelog/postgresql-json
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/postgresql/staging.yml
+++ b/group_vars/postgresql/staging.yml
@@ -147,6 +147,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -185,6 +190,7 @@ otel_service_pipelines:
       - filelog/postgresql-json
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/redis/production.yml
+++ b/group_vars/redis/production.yml
@@ -107,6 +107,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -145,6 +150,7 @@ otel_service_pipelines:
       - filelog/redis-server
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/redis/staging.yml
+++ b/group_vars/redis/staging.yml
@@ -92,6 +92,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -130,6 +135,7 @@ otel_service_pipelines:
       - filelog/redis-server
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/solr9cloud/production.yml
+++ b/group_vars/solr9cloud/production.yml
@@ -208,10 +208,10 @@ otel_receivers:
       network: {}
 
 otel_processors:
-  filter/warn_and_above:
+  filter/info_and_above:
     error_mode: ignore
     log_conditions:
-      - log.severity_number < SEVERITY_NUMBER_WARN
+      - log.severity_number < SEVERITY_NUMBER_INFO
 
   batch:
     send_batch_max_size: 1024
@@ -254,7 +254,7 @@ otel_service_pipelines:
       - filelog/solr-slow-requests
     processors:
       - resource
-      - filter/warn_and_above
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/solr9cloud/production.yml
+++ b/group_vars/solr9cloud/production.yml
@@ -208,6 +208,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -249,6 +254,7 @@ otel_service_pipelines:
       - filelog/solr-slow-requests
     processors:
       - resource
+      - filter/warn_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/solr9cloud/staging.yml
+++ b/group_vars/solr9cloud/staging.yml
@@ -216,6 +216,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/warn_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_WARN
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -257,6 +262,7 @@ otel_service_pipelines:
       - filelog/solr-slow-requests
     processors:
       - resource
+      - filter/warn_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/solr9cloud/staging.yml
+++ b/group_vars/solr9cloud/staging.yml
@@ -216,10 +216,10 @@ otel_receivers:
       network: {}
 
 otel_processors:
-  filter/warn_and_above:
+  filter/info_and_above:
     error_mode: ignore
     log_conditions:
-      - log.severity_number < SEVERITY_NUMBER_WARN
+      - log.severity_number < SEVERITY_NUMBER_INFO
 
   batch:
     send_batch_max_size: 1024
@@ -262,7 +262,7 @@ otel_service_pipelines:
       - filelog/solr-slow-requests
     processors:
       - resource
-      - filter/warn_and_above
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/zookeeper/production.yml
+++ b/group_vars/zookeeper/production.yml
@@ -55,6 +55,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -93,6 +98,7 @@ otel_service_pipelines:
       - journald/zookeeper
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/group_vars/zookeeper/staging.yml
+++ b/group_vars/zookeeper/staging.yml
@@ -32,6 +32,11 @@ otel_receivers:
       network: {}
 
 otel_processors:
+  filter/info_and_above:
+    error_mode: ignore
+    log_conditions:
+      - log.severity_number < SEVERITY_NUMBER_INFO
+
   batch:
     send_batch_max_size: 1024
     send_batch_size: 512
@@ -70,6 +75,7 @@ otel_service_pipelines:
       - journald/zookeeper
     processors:
       - resource
+      - filter/info_and_above
       - batch
     exporters:
       - loadbalancing

--- a/roles/k8s_nfs_provisioner/tasks/main.yml
+++ b/roles/k8s_nfs_provisioner/tasks/main.yml
@@ -49,9 +49,11 @@
   ansible.builtin.command: "microk8s kubectl get storageclass {{ k8s_nfs_storage_class }}"
   changed_when: false
 
-- name: Verify NFS provisioner pod is running
-  ansible.builtin.command: >-
-    microk8s kubectl -n {{ k8s_nfs_namespace }}
-    rollout status deployment/{{ k8s_nfs_release_name }}
-    --timeout=5m
+- name: Verify NFS provisioner deployment is available
+  ansible.builtin.command: >
+    microk8s kubectl -n platform
+    get deployment nfs-subdir-external-provisioner
+    -o jsonpath={.status.availableReplicas}
+  register: nfs_provisioner_available
   changed_when: false
+  failed_when: nfs_provisioner_available.stdout | int < 1

--- a/roles/signoz_k8s/tasks/main.yml
+++ b/roles/signoz_k8s/tasks/main.yml
@@ -289,13 +289,24 @@
   until: signoz_clickhouse_pvc_bound.stdout == "Bound," ~ signoz_clickhouse_local_pv_name
   when: signoz_clickhouse_local_storage_enabled | default(false) | bool
 
-- name: SigNoz | Wait for ClickHouse pod readiness
-  ansible.builtin.command: >
-    microk8s kubectl -n {{ signoz_namespace }}
-    wait --for=condition=Ready pod/chi-signoz-clickhouse-cluster-0-0-0
-    --timeout=600s
+- name: SigNoz | Check ClickHouse pod readiness
+  ansible.builtin.command:
+    argv:
+      - microk8s
+      - kubectl
+      - --request-timeout=10s
+      - -n
+      - "{{ signoz_namespace }}"
+      - get
+      - pod
+      - chi-signoz-clickhouse-cluster-0-0-0
+      - -o
+      - 'jsonpath={.status.conditions[?(@.type=="Ready")].status}'
+  register: signoz_clickhouse_pod_ready
   changed_when: false
-  when: signoz_clickhouse_local_storage_enabled | default(false) | bool
+  retries: 60
+  delay: 10
+  until: signoz_clickhouse_pod_ready.stdout == "True"
 
 - name: Wait for SigNoz service
   ansible.builtin.command: "microk8s kubectl -n {{ signoz_namespace }} get svc {{ signoz_release_name }}"


### PR DESCRIPTION
Log levels were increased during a previous event. This PR reduces logs shipped to signoz to reduce noise and storage demand.

clean up from staging storage cluster. While attempting to recover from storage saturation the following improvements allowed the k8s cluster to come up