### PR TITLE
[CircleCI/Nomad] Reduce deployer resources.

### DIFF
--- a/nomad/circleci_deployer/deploy/production.hcl
+++ b/nomad/circleci_deployer/deploy/production.hcl
@@ -68,8 +68,8 @@ job "circleci-runner" {
         EOF
       }
       resources {
-        cpu    = 4000
-        memory = 8192
+        cpu    = 2000
+        memory = 2048
       }
     }
   }


### PR DESCRIPTION
Not as required since Tigerdata has its own workers now.
