### PR TITLE
[Nomad/DaviesProject/Milberg/Cicognara] Host all the static sites from a single job. 

### DIFF
--- a/nomad/static-sites/README.md
+++ b/nomad/static-sites/README.md
@@ -1,0 +1,25 @@
+# Static Sites
+
+We have a few static sites that we host on Nomad. This repository deploys a job which fetches those static sites from Github and makes them available to the load balancer.
+
+It pulls the latest nginx image on re-deploy, and since all of our boxes restart every week for security patches, forcing a re-deploy, those images should get continuously updated.
+
+## Sites Hosted
+
+### Davies Project
+
+Github: https://github.com/pulibrary/davies_project
+Staging: https://daviesproject-staging.lib.princeton.edu
+Production: https://daviesproject.princeton.edu
+
+### Players & Painted Stage Milberg Exhibit Archive
+
+Github: https://github.com/pulibrary/milberg_exhibit_archive
+Staging: https://milberg-staging.lib.princeton.edu
+Production: https://milberg.princeton.edu
+
+### Digital Cicognara Library
+
+Github: https://github.com/pulibrary/digital-cicognara-library
+Staging: https://cicognara-staging.lib.princeton.edu
+Production: https://cicognara.org

--- a/nomad/static-sites/deploy/production.hcl
+++ b/nomad/static-sites/deploy/production.hcl
@@ -1,0 +1,151 @@
+variable "branch_or_sha" {
+  type    = string
+  default = "main"
+}
+
+job "static-sites-production" {
+  region      = "global"
+  datacenters = ["dc1"]
+  type        = "service"
+  node_pool   = "production"
+
+  group "web" {
+    count = 2
+
+    network {
+      port "http" { to = 8080 }
+    }
+
+    # milberg
+    service {
+      name = "milberg-production-web"
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+        header {
+          X-Forwarded-Host = ["milberg.lib.princeton.edu"]
+        }
+      }
+    }
+    # daviesproject
+    service {
+      name = "daviesproject-production-web"
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+        header {
+          X-Forwarded-Host = ["daviesproject.princeton.edu"]
+        }
+      }
+    }
+    # cicognara
+    service {
+      name = "cicognara-production-web"
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+        header {
+          X-Forwarded-Host = ["cicognara.org"]
+        }
+      }
+    }
+
+    task "nginx" {
+      driver = "docker"
+
+      user = "101:101"
+
+      # Pull from github.
+      artifact {
+        source      = "git::https://github.com/pulibrary/milberg_exhibit_archive//_site"
+        destination = "local/sites/milberg"
+      }
+      artifact {
+        source      = "git::https://github.com/pulibrary/davies_project//_site"
+        destination = "local/sites/daviesproject"
+      }
+      artifact {
+        source      = "git::https://github.com/pulibrary/digital-cicognara-library//apps/cicognara-static/_site"
+        destination = "local/sites/cicognara"
+      }
+
+      config {
+        image = "docker.io/nginxinc/nginx-unprivileged:stable"
+        # Force Docker to re-pull the image when the job re-deploys, which should be every week when the boxes reboot.
+        # Should keep us auto-updated.
+        force_pull = true
+
+        ports = ["http"]
+
+        volumes = [
+          "local/sites:/srv/sites:ro",
+          "local/nginx/sites.conf:/etc/nginx/conf.d/default.conf:ro",
+        ]
+
+        readonly_rootfs = true
+        cap_drop        = ["ALL"]
+        security_opt    = ["no-new-privileges"]
+        mount {
+          type = "tmpfs"
+          target = "/tmp"
+        }
+        mount {
+          type = "tmpfs"
+          target = "/var/cache/nginx"
+        }
+        mount {
+          type = "tmpfs"
+          target = "/var/run"
+        }
+      }
+
+      template {
+        destination = "local/nginx/sites.conf"
+        change_mode = "restart"
+        data        = <<EOF
+map $http_x_forwarded_host $site_root {
+    hostnames;
+    default                              /srv/sites/none;
+    # milberg
+    milberg.lib.princeton.edu    /srv/sites/milberg;
+    # davies_project
+    daviesproject.princeton.edu    /srv/sites/daviesproject;
+    daviesproject.lib.princeton.edu    /srv/sites/daviesproject;
+    # cicognara
+    cicognara.org    /srv/sites/cicognara;
+}
+
+server {
+    listen 8080 default_server;
+    root   $site_root;
+    index  index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+EOF
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/nomad/static-sites/deploy/production.hcl
+++ b/nomad/static-sites/deploy/production.hcl
@@ -143,8 +143,8 @@ EOF
       }
 
       resources {
-        cpu    = 200
-        memory = 256
+        cpu    = 1000
+        memory = 1024
       }
     }
   }

--- a/nomad/static-sites/deploy/staging.hcl
+++ b/nomad/static-sites/deploy/staging.hcl
@@ -115,7 +115,10 @@ map $http_x_forwarded_host $site_root {
     # cicognara
     cicognara-staging.lib.princeton.edu    /srv/sites/cicognara;
 }
-
+set_real_ip_from 172.20.80.13;
+set_real_ip_from 172.20.80.14;
+real_ip_header   X-Real-IP;
+real_ip_recursive on;
 server {
     listen 8080 default_server;
     root   $site_root;

--- a/nomad/static-sites/deploy/staging.hcl
+++ b/nomad/static-sites/deploy/staging.hcl
@@ -1,0 +1,150 @@
+variable "branch_or_sha" {
+  type    = string
+  default = "main"
+}
+
+job "static-sites-staging" {
+  region      = "global"
+  datacenters = ["dc1"]
+  type        = "service"
+  node_pool   = "staging"
+
+  group "web" {
+    count = 2
+
+    network {
+      port "http" { to = 8080 }
+    }
+
+    # milberg
+    service {
+      name = "milberg-staging-web"
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+        header {
+          X-Forwarded-Host = ["milberg-staging.lib.princeton.edu"]
+        }
+      }
+    }
+    # daviesproject
+    service {
+      name = "daviesproject-staging-web"
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+        header {
+          X-Forwarded-Host = ["daviesproject-staging.lib.princeton.edu"]
+        }
+      }
+    }
+    # cicognara
+    service {
+      name = "cicognara-staging-web"
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+        header {
+          X-Forwarded-Host = ["cicognara-staging.lib.princeton.edu"]
+        }
+      }
+    }
+
+    task "nginx" {
+      driver = "docker"
+
+      user = "101:101"
+
+      # Pull from github.
+      artifact {
+        source      = "git::https://github.com/pulibrary/milberg_exhibit_archive//_site"
+        destination = "local/sites/milberg"
+      }
+      artifact {
+        source      = "git::https://github.com/pulibrary/davies_project//_site"
+        destination = "local/sites/daviesproject"
+      }
+      artifact {
+        source      = "git::https://github.com/pulibrary/digital-cicognara-library//apps/cicognara-static/_site"
+        destination = "local/sites/cicognara"
+      }
+
+      config {
+        image = "docker.io/nginxinc/nginx-unprivileged:stable"
+        # Force Docker to re-pull the image when the job re-deploys, which should be every week when the boxes reboot.
+        # Should keep us auto-updated.
+        force_pull = true
+
+        ports = ["http"]
+
+        volumes = [
+          "local/sites:/srv/sites:ro",
+          "local/nginx/sites.conf:/etc/nginx/conf.d/default.conf:ro",
+        ]
+
+        readonly_rootfs = true
+        cap_drop        = ["ALL"]
+        security_opt    = ["no-new-privileges"]
+        mount {
+          type = "tmpfs"
+          target = "/tmp"
+        }
+        mount {
+          type = "tmpfs"
+          target = "/var/cache/nginx"
+        }
+        mount {
+          type = "tmpfs"
+          target = "/var/run"
+        }
+      }
+
+      template {
+        destination = "local/nginx/sites.conf"
+        change_mode = "restart"
+        data        = <<EOF
+map $http_x_forwarded_host $site_root {
+    hostnames;
+    default                              /srv/sites/none;
+    # milberg
+    milberg-staging.lib.princeton.edu    /srv/sites/milberg;
+    # davies_project
+    daviesproject-staging.lib.princeton.edu    /srv/sites/daviesproject;
+    # cicognara
+    cicognara-staging.lib.princeton.edu    /srv/sites/cicognara;
+}
+
+server {
+    listen 8080 default_server;
+    root   $site_root;
+    index  index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+EOF
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/nomad/static-sites/deploy/staging.hcl
+++ b/nomad/static-sites/deploy/staging.hcl
@@ -16,11 +16,9 @@ job "static-sites-staging" {
       port "http" { to = 8080 }
     }
 
-    # milberg
     service {
-      name = "milberg-staging-web"
       port = "http"
-
+      tags = ["logging"]
       check {
         type     = "http"
         port     = "http"
@@ -32,37 +30,21 @@ job "static-sites-staging" {
         }
       }
     }
+
+    # milberg
+    service {
+      name = "milberg-staging-web"
+      port = "http"
+    }
     # daviesproject
     service {
       name = "daviesproject-staging-web"
       port = "http"
-
-      check {
-        type     = "http"
-        port     = "http"
-        path     = "/"
-        interval = "10s"
-        timeout  = "2s"
-        header {
-          X-Forwarded-Host = ["daviesproject-staging.lib.princeton.edu"]
-        }
-      }
     }
     # cicognara
     service {
       name = "cicognara-staging-web"
       port = "http"
-
-      check {
-        type     = "http"
-        port     = "http"
-        path     = "/"
-        interval = "10s"
-        timeout  = "2s"
-        header {
-          X-Forwarded-Host = ["cicognara-staging.lib.princeton.edu"]
-        }
-      }
     }
 
     task "nginx" {
@@ -118,6 +100,11 @@ job "static-sites-staging" {
         destination = "local/nginx/sites.conf"
         change_mode = "restart"
         data        = <<EOF
+log_format json_combined escape=json
+  '{"time":"$time_iso8601","remote_addr":"$remote_addr",'
+  '"request":"$request","status":$status,'
+  '"bytes":$body_bytes_sent,"user_agent":"$http_user_agent",'
+  '"host":"$http_x_forwarded_host"}';
 map $http_x_forwarded_host $site_root {
     hostnames;
     default                              /srv/sites/none;
@@ -133,6 +120,7 @@ server {
     listen 8080 default_server;
     root   $site_root;
     index  index.html index.htm;
+    access_log /dev/stdout json_combined;
 
     location / {
         try_files $uri $uri/ =404;


### PR DESCRIPTION
This simultaneously migrates all the Nomad static sites to Docker (instead of podman), updates nginx for all of them, makes it so we don't have to build Docker images for them, and moves management of it to princeton_ansible instead of their code repository. It also locks the containers up - its root user is a nonsense user on the host, the user it runs as is non-root, the root file system is read-only, and it's not allowed to mess with CAP privileges.

The job registers the same services that nginxplus was looking for, so no nginx config changes necessary.