### PR TITLE
Secure Docker w/ UFW

### DIFF
--- a/roles/pul_nomad/handlers/main.yml
+++ b/roles/pul_nomad/handlers/main.yml
@@ -38,3 +38,7 @@
   ansible.builtin.service:
     name: docker
     state: restarted
+- name: reload ufw
+  become: true
+  community.general.ufw:
+    state: reloaded

--- a/roles/pul_nomad/tasks/nomad/docker.yml
+++ b/roles/pul_nomad/tasks/nomad/docker.yml
@@ -189,3 +189,42 @@
     - tcp
   when: running_on_server
   become: true
+
+# UFW doesn't apply to docker ports without this block.
+# See
+# https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw
+# and https://github.com/chaifeng/ufw-docker#solving-ufw-and-docker-issues
+- name: 'pul_nomad | nomad | docker | Ensure containers are blocked by UFW'
+  ansible.builtin.blockinfile:
+    path: /etc/ufw/after.rules
+    marker: "# {mark} UFW AND DOCKER"
+    insertafter: EOF
+    block: |
+      *filter
+      :ufw-user-forward - [0:0]
+      :ufw-docker-logging-deny - [0:0]
+      :DOCKER-USER - [0:0]
+      -A DOCKER-USER -j ufw-user-forward
+
+      -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+      -A DOCKER-USER -m conntrack --ctstate INVALID -j DROP
+      -A DOCKER-USER -i docker0 -o docker0 -j ACCEPT
+
+      # Traffic leaving containers (egress, -i docker0) may go anywhere.
+      -A DOCKER-USER -i docker0 -j RETURN
+
+      # Only allow private IP range and load balancers
+      -A DOCKER-USER -o docker0 -s 172.20.80.0/22 -j RETURN
+      -A DOCKER-USER -o docker0 -s 128.112.203.146/32 -j RETURN
+      -A DOCKER-USER -o docker0 -s 128.112.200.245/32 -j RETURN
+      -A DOCKER-USER -o docker0 -s 128.112.201.34/32 -j RETURN
+      -A DOCKER-USER -o docker0 -j ufw-docker-logging-deny
+      -A DOCKER-USER -o docker0 -j DROP
+
+      -A DOCKER-USER -j RETURN
+
+      -A ufw-docker-logging-deny -m limit --limit 3/min --limit-burst 10 -j LOG --log-prefix "[UFW DOCKER BLOCK] "
+      -A ufw-docker-logging-deny -j DROP
+
+      COMMIT
+  notify: reload ufw

--- a/roles/pul_nomad/tasks/nomad/docker.yml
+++ b/roles/pul_nomad/tasks/nomad/docker.yml
@@ -227,4 +227,5 @@
       -A ufw-docker-logging-deny -j DROP
 
       COMMIT
+  when: running_on_server
   notify: reload ufw

--- a/roles/pul_nomad/tasks/nomad/docker.yml
+++ b/roles/pul_nomad/tasks/nomad/docker.yml
@@ -190,6 +190,18 @@
   when: running_on_server
   become: true
 
+- name: 'pul_nomad | nomad | docker | Allow containers to talk to containers'
+  community.general.ufw:
+    rule: allow
+    direction: in
+    interface: docker0
+    # These are the internal docker IPs.
+    from_ip: 172.17.0.0/16
+    proto: "tcp"
+    comment: Allow containers to talk to other containers by host IP
+  when: running_on_server
+  become: true
+
 # UFW doesn't apply to docker ports without this block.
 # See
 # https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw


### PR DESCRIPTION
Unfortunately Docker punches through UFW without this: https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-5a-be-careful-when-mapping-container-ports-to-the-host-with-firewalls-like-ufw

Before this change I could query the port from my computer while on VPN, after this change I no longer can.