### PR TITLE
[Orangelight] Remove Hector from common.yml

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -14,7 +14,6 @@ ol_admin_netids:
   - kl37
   - ka1125
   - vk4273
-  - hc8719
   - bs3097
   - bg1162
   - rl3667


### PR DESCRIPTION
Removed 'hc8719' from the list of group variables.