### PR TITLE
[nginxplus] migrate nomad to the production loadbalancer

### DIFF
--- a/roles/nginxplus/files/conf/http/nomad.conf
+++ b/roles/nginxplus/files/conf/http/nomad.conf
@@ -33,7 +33,6 @@ server {
     ssl_prefer_server_ciphers  on;
 
     location / {
-        # app_protect_enable off;
         proxy_pass http://nomad;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -43,13 +42,5 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Origin "${scheme}://${proxy_host}";
-        # allow princeton network
-        # include /etc/nginx/conf.d/templates/restrict.conf;
-        # block all IPs outside the princeton network
-        # deny all;
     }
-    #
-    # yes it is okay to be visible outside VPN
-    #
-    # include /etc/nginx/conf.d/templates/staging-maintenance.conf;
 }


### PR DESCRIPTION
DNS for nomad.lib.princeton.edu has moved to the production loadbalancers