### PR TITLE
[Allsearch api] ship application logs to signoz

### DIFF
--- a/group_vars/allsearch_api/production.yml
+++ b/group_vars/allsearch_api/production.yml
@@ -103,6 +103,17 @@ otel_receivers:
         field: attributes.service_name
         value: "allsearch_api"
 
+  filelog/allsearch-app-log:
+    include: ["/opt/allsearch_api/current/log/*"]
+    start_at: end
+    operators:
+      - type: add
+        field: attributes.log_type
+        value: "allsearch_api_app_log"
+      - type: add
+        field: attributes.service_name
+        value: "allsearch_api"
+
   hostmetrics:
     collection_interval: 30s
     scrapers:
@@ -151,6 +162,7 @@ otel_service_pipelines:
     receivers:
       - filelog/nginx-access
       - filelog/nginx-error
+      - filelog/allsearch-app-log
     processors:
       - resource
       - batch


### PR DESCRIPTION
We previously were shipping only the nginx logs.

I ran this today on allsearch-api-prod2.princeton.edu, and its app logs are displaying.  They are not yet displaying for allsearch-api-prod1.princeton.edu, which I have not run this on.

It could be nice to filter these so we only ship logs with severity WARN and above to signoz, but I don't know how to do that yet!