### PR TITLE
automate dependency updates with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,163 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Dependency updates are opened by the Mend-hosted Renovate GitHub App
+  // (https://github.com/apps/renovate) after it is installed on this repo.
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommitsDisabled",
+    "security:openssf-scorecard",
+  ],
+
+  timezone: "America/New_York",
+  // One batch of update PRs per week keeps review load predictable.
+  schedule: ["before 7am on monday"],
+  prConcurrentLimit: 6,
+  prHourlyLimit: 2,
+  labels: ["dependencies"],
+  // Match the existing "[scope] message" commit convention in this repo.
+  commitMessagePrefix: "[deps]",
+  rebaseWhen: "conflicted",
+  configMigration: true,
+  dependencyDashboardTitle: "Dependency Dashboard",
+
+  // Generated, vendored, or templated trees that contain manifests Renovate
+  // would otherwise try to update. The Molecule Dockerfiles are Jinja
+  // templates whose image names are filled in at test time,
+  // roles/ansible-consul only carries a leftover pin list from an upstream
+  // role we no longer build from, and the SigNoz Nomad deployment is being
+  // retired, so upgrading its images would be wasted review effort.
+  ignorePaths: [
+    ".venv/**",
+    ".devbox/**",
+    "**/node_modules/**",
+    "**/molecule/**",
+    "roles/ansible-consul/**",
+    "nomad/signoz/**",
+  ],
+
+  // Security fixes should never wait for the weekly window.
+  vulnerabilityAlerts: {
+    enabled: true,
+    schedule: ["at any time"],
+    labels: ["dependencies", "security"],
+    minimumReleaseAge: null,
+  },
+  osvVulnerabilityAlerts: true,
+
+  // Let a release settle before proposing it, so we skip versions that are
+  // yanked or immediately superseded.
+  minimumReleaseAge: "3 days",
+
+  packageRules: [
+    {
+      description: "Ansible and Molecule tooling changes can break every role, so keep them in their own reviewable PR.",
+      matchManagers: ["pip_requirements"],
+      matchPackageNames: [
+        "ansible",
+        "ansible-builder",
+        "ansible-compat",
+        "ansible-core",
+        "ansible-creator",
+        "ansible-lint",
+        "molecule",
+        "molecule-plugins",
+      ],
+      groupName: "ansible tooling",
+      addLabels: ["ansible"],
+    },
+    {
+      description: "Everything else in requirements.txt is transitive pinning; one combined PR avoids dozens of trivial ones.",
+      matchManagers: ["pip_requirements"],
+      groupName: "python dependencies",
+    },
+    {
+      description: "Ansible Galaxy collections used by the playbooks.",
+      matchManagers: ["ansible-galaxy"],
+      groupName: "ansible collections",
+      addLabels: ["ansible"],
+    },
+    {
+      description: "Workflow actions rarely need individual review.",
+      matchManagers: ["github-actions"],
+      groupName: "github actions",
+    },
+    {
+      description: "Developer toolchain pinned in devbox.json.",
+      matchManagers: ["devbox"],
+      groupName: "devbox packages",
+    },
+    {
+      description: "Ruby is pinned in both the devbox environment and the runner images; bump them together to avoid drift.",
+      matchPackageNames: ["ruby"],
+      groupName: "ruby version",
+    },
+    {
+      description: "Container images deployed to Nomad are reviewed per service, since each one is a production rollout.",
+      matchManagers: ["custom.regex"],
+      matchFileNames: ["nomad/**/*.hcl"],
+      addLabels: ["nomad"],
+      minimumReleaseAge: "7 days",
+    },
+    {
+      description: "Floating tags cannot be updated meaningfully.",
+      matchCurrentValue: "latest",
+      enabled: false,
+    },
+  ],
+
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Container images pinned inline in Nomad job specs.",
+      managerFilePatterns: ["nomad/**/*.hcl"],
+      // Skips images whose tag is an HCL variable, e.g. "${var.signoz_version}".
+      matchStrings: [
+        "image\\s*=\\s*\"(?<depName>[^\"$:]+?):(?<currentValue>[^\"$\\s]+)\"",
+      ],
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker",
+    },
+    {
+      customType: "regex",
+      description: "Image tags held in Nomad HCL variable defaults, annotated with a renovate comment.",
+      managerFilePatterns: ["nomad/**/*.hcl"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?[\\s\\S]*?default\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
+    },
+    {
+      customType: "regex",
+      description: "Versions pinned in Ansible variables, opted in with a renovate comment.",
+      managerFilePatterns: [
+        "group_vars/**/*.yml",
+        "group_vars/**/*.yaml",
+        "host_vars/**/*.yml",
+        "host_vars/**/*.yaml",
+        "playbooks/**/*.yml",
+        "playbooks/**/*.yaml",
+        "roles/**/*.yml",
+        "roles/**/*.yaml",
+        "site_vars.yml",
+      ],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*[\\w.]+:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+    {
+      customType: "regex",
+      description: "Ruby pinned in the CircleCI runner images and the devbox environment.",
+      managerFilePatterns: ["nomad/**/Dockerfile", "devbox.json"],
+      matchStrings: [
+        "ARG RUBY_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "\"RUBY_VERSION\":\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+      ],
+      depNameTemplate: "ruby",
+      datasourceTemplate: "ruby-version",
+      versioningTemplate: "ruby",
+    },
+  ],
+}

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -1,0 +1,31 @@
+---
+name: Renovate Config
+permissions:
+  contents: read
+
+# A malformed Renovate config silently stops dependency updates, so check it
+# whenever the config or the manifests it reads change.
+on:
+  push:
+    paths:
+      - .github/renovate.json5
+      - .github/workflows/renovate-config.yml
+  pull_request:
+    paths:
+      - .github/renovate.json5
+      - .github/workflows/renovate-config.yml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Validate Renovate configuration
+        run: npx --yes --package renovate -- renovate-config-validator --strict

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Inside the Devbox shell, you can run:
 |---------|-------------|
 | `devbox run init` | Initialize Python environment and dependencies |
 | `devbox run update-deps` | Update Python dependencies from requirements.txt |
+| `devbox run renovate-validate` | Check the Renovate config before pushing it |
 | `devbox run clean` | Remove virtual environment and Devbox cache |
 | `devbox run test` | Verify Ansible tools installation |
 | `devbox run env-info` | Display current environment configuration |
@@ -355,6 +356,71 @@ Upgrading Ansible version
 4. Run the test suite to ensure compatibility
 5. Commit the updated `requirements.txt`
 
+Automated dependency updates (Renovate)
+---------------------------------------
+
+Dependency bumps are proposed automatically by
+[Renovate](https://docs.renovatebot.com/), run as the Mend-hosted GitHub App.
+Nobody has to watch upstream releases: Renovate opens pull requests, and the
+Molecule test suite gates them like any other change.
+
+### What is kept current
+
+| Where | What Renovate updates |
+|-------|-----------------------|
+| `requirements.txt` | Python packages; Ansible and Molecule get their own PR |
+| `requirements.yml` | Ansible Galaxy collections the playbooks depend on |
+| `.github/workflows/*.yml` | GitHub Actions used by CI |
+| `devbox.json` | Developer toolchain packages |
+| `nomad/*/Dockerfile` | Runner image base images and the pinned Ruby version |
+| `nomad/**/*.hcl` | Container image tags pinned in Nomad job specs |
+
+Updates arrive in one batch early Monday morning (America/New_York), except for
+security advisories, which are opened as soon as a fix is published. Everything
+Renovate is aware of, including anything it is waiting on, is listed in the
+repository's "Dependency Dashboard" issue.
+
+### Turning it on for the repository
+
+Renovate only runs once the app has access to this repo:
+
+1. Install the [Renovate GitHub App](https://github.com/apps/renovate) for the
+   `pulibrary` organization and grant it access to `princeton_ansible`.
+2. Merge the onboarding pull request Renovate opens. It uses the configuration
+   already committed at `.github/renovate.json5`, so no further setup is needed.
+
+### Changing the configuration
+
+A malformed config silently stops all updates, so validate before pushing:
+
+```bash
+devbox run renovate-validate
+```
+
+The same check runs in CI whenever `.github/renovate.json5` changes.
+
+### Tracking a version that lives in a variable
+
+Versions pinned in Ansible variables or Nomad HCL variables are invisible to
+Renovate unless you say what they point at. Add a comment directly above the
+value:
+
+```yaml
+# renovate: datasource=github-releases depName=apache/solr
+solr_version: "9.7.0"
+```
+
+```hcl
+# renovate: datasource=docker depName=docker.io/grafana/grafana
+variable "grafana_version" {
+  default = "11.3.0"
+}
+```
+
+Renovate will then propose upgrades for that value and leave everything else
+alone. Pick a `datasource` from the
+[Renovate datasource list](https://docs.renovatebot.com/modules/datasource/).
+
 Migration from Pipenv to Devbox
 -------------------------------
 
@@ -377,3 +443,4 @@ This project has been migrated from Pipenv to Devbox for better reproducibility 
 ### For CI/CD
 
 The `requirements.txt` file is maintained for CI/CD compatibility and contains all Python dependencies.
+Galaxy collections live in `requirements.yml`. Both files are kept current by Renovate.

--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,7 @@
     "python311",
     "python311Packages.pip",
     "python311Packages.virtualenv",
-    "nodejs_20",
+    "nodejs_22",
     "awscli2",
     "lastpass-cli",
     "git",
@@ -15,7 +15,7 @@
   "env": {
     "PYTHON_VERSION":              "3.11.1",
     "RUBY_VERSION":                "3.4.3",
-    "NODE_VERSION":                "20",
+    "NODE_VERSION":                "22",
     "LPASS_AGENT_TIMEOUT":         "32400",
     "PATH":                        "$DEVBOX_PROJECT_ROOT/.venv/bin:$PATH",
     "VIRTUAL_ENV":                 "$DEVBOX_PROJECT_ROOT/.venv",
@@ -37,7 +37,7 @@
         "./.venv/bin/python -m pip install -r requirements.txt",
         "touch .venv/.requirements_installed",
         "gem install --no-document lastpass-ansible",
-        "ansible-galaxy collection install prometheus.prometheus",
+        "ansible-galaxy collection install -r requirements.yml",
         "echo 'Setup complete!'"
       ],
       "setup": [
@@ -47,7 +47,11 @@
       "update-deps": [
         "./.venv/bin/python -m pip install --upgrade pip",
         "./.venv/bin/python -m pip install -r requirements.txt",
+        "ansible-galaxy collection install -r requirements.yml --force",
         "touch .venv/.requirements_installed"
+      ],
+      "renovate-validate": [
+        "npx --yes --package renovate -- renovate-config-validator --strict"
       ],
       "clean": [
         "rm -rf .venv",

--- a/devbox.lock
+++ b/devbox.lock
@@ -47,20 +47,10 @@
         }
       }
     },
-    "nodejs_20": {
+    "nodejs_22": {
       "plugin_version": "0.0.4",
-      "resolved": "github:NixOS/nixpkgs/32f313e49e42f715491e1ea7b306a87c16fe0388?narHash=sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj%2Fw%3D#nodejs_20",
-      "source": "nixpkg",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "path": "/nix/store/2xza7g9y47n717w43qdd1ikc0y10qh16-nodejs-20.19.4",
-              "default": true
-            }
-          ]
-        }
-      }
+      "resolved": "github:NixOS/nixpkgs/4d113fe1f7bb454435a5cabae6cd283e64191bb7#nodejs_22",
+      "source": "nixpkg"
     },
     "podman@latest": {
       "last_modified": "2025-12-31T03:27:36Z",

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+---
+# Ansible Galaxy collections this repo needs beyond the ones bundled with the
+# ansible package in requirements.txt.
+#
+# Installed by "devbox run init" and kept current by Renovate.
+collections:
+  - name: prometheus.prometheus
+    version: "0.27.4"


### PR DESCRIPTION
Upstream releases were tracked by dependabot, so Python, Ansible, Galaxy,   GitHub Actions, and container image versions drifted until someone   noticed. Renovate now proposes those upgrades as pull requests that   the existing test suite gates, with security fixes opened immediately   instead of waiting for the weekly batch.

Enabling this still requires installing the Renovate GitHub App on the   repository and merging its onboarding pull request.