### PR TITLE
adds IP range condition to the UFW playbook

### DIFF
--- a/playbooks/utils/ufw_firewall.yml
+++ b/playbooks/utils/ufw_firewall.yml
@@ -18,5 +18,11 @@
       when: ansible_limit is not defined
       run_once: true
 
+    - name: display IP addresses
+      ansible.builtin.debug:
+        var: ansible_default_ipv4.address
+
   roles:
     - role: roles/firewall
+      when: ansible_default_ipv4.address is match("172.20.80")
+      # do not install UFW on VMs with public-facing libnet IPs


### PR DESCRIPTION
We want UFW on machines in the ip4-library-servers network to control campus traffic. We do not need UFW on machines in libnet that have public-facing IPs. And we want to run the UFW playbook from Tower as part of our regular maintenance.

This PR adds a debug task that displays the IP for each machine the playbook runs against, then only runs the role against machines with IPs that start with `170.20.80`.

There's a WIP Tower template as well. Template [here](https://ansible-tower.princeton.edu/#/templates/job_template/107/details), first test run [here](https://ansible-tower.princeton.edu/#/jobs/playbook/57012/output).