### PR TITLE
[nginxplus] log upstream timing metrics as numbers for analysis

### DIFF
--- a/roles/nginxplus/templates/etc_nginx.conf.j2
+++ b/roles/nginxplus/templates/etc_nginx.conf.j2
@@ -53,6 +53,21 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    map $upstream_response_time $upstream_response_seconds {
+        default        "null";
+        "~([0-9.]+)$"  $1;
+    }
+
+    map $upstream_connect_time $upstream_connect_seconds {
+        default        "null";
+        "~([0-9.]+)$"  $1;
+    }
+
+    map $upstream_header_time $upstream_header_seconds {
+        default        "null";
+        "~([0-9.]+)$"  $1;
+    }
+
         log_format json_logs escape=json '{'
         '"remote_ip": "$remote_addr",'
         '"remote_user": "$remote_user",'
@@ -75,8 +90,13 @@ http {
 {% endif %}
         '"upstream_addr": "$upstream_addr",'
         '"upstream_status": "$upstream_status",'
+        '"upstream_cache_status": "$upstream_cache_status",'
         '"request_time": "$request_time",'
-        '"upstream_response_time": "$upstream_response_time"'
+        '"upstream_response_time": "$upstream_response_time",'
+        '"request_seconds": $request_time,'
+        '"upstream_response_seconds": $upstream_response_seconds,'
+        '"upstream_connect_seconds": $upstream_connect_seconds,'
+        '"upstream_header_seconds": $upstream_header_seconds'
     '}';
 
     access_log  /var/log/nginx/access.log json_logs;


### PR DESCRIPTION
allow our telemetry to display upstream response time

This PR adds values to our logs that we get from [the otel module](https://docs.nginx.com/nginx/admin-guide/dynamic-modules/opentelemetry/). Then it maps them to include the units in the variable names, so we know what we're looking at when they come through to signoz