### PR TITLE
[nginxplus] add solr upstream attributes to nginxplus tracing

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/lib-solr9-staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/lib-solr9-staging.conf
@@ -26,6 +26,11 @@ server {
         otel_trace on;
         otel_trace_context propagate;
 
+        otel_span_attr app.backend "solr";
+        otel_span_attr nginx.upstream.address "$upstream_addr";
+        otel_span_attr nginx.upstream.status "$upstream_status";
+        otel_span_attr nginx.upstream.response_time "$upstream_response_time";
+
         proxy_pass http://lib-solr9-staging;
         proxy_cache_methods POST;
         proxy_set_header Connection "";

--- a/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
@@ -24,6 +24,11 @@ server {
         otel_trace on;
         otel_trace_context propagate;
 
+        otel_span_attr app.backend "solr";
+        otel_span_attr nginx.upstream.address "$upstream_addr";
+        otel_span_attr nginx.upstream.status "$upstream_status";
+        otel_span_attr nginx.upstream.response_time "$upstream_response_time";
+
         proxy_pass http://lib-solr9-prod;
         proxy_cache_methods POST;
         proxy_set_header Connection "";


### PR DESCRIPTION
Expose the backend, upstream address, status, and response time on Solr NGINX Plus spans for filtering and correlation in SigNoz.

this https://github.com/pulibrary/princeton_ansible/pull/7502 did the initial work

closes #7578 