### PR TITLE
[signoz] add clickhouse fsgroupchangepolicy to signoz

### DIFF
--- a/roles/signoz_k8s/templates/signoz-values.yaml.j2
+++ b/roles/signoz_k8s/templates/signoz-values.yaml.j2
@@ -3,6 +3,14 @@ global:
 
 clickhouse:
   installCustomStorageClass: false
+
+  securityContext:
+    enabled: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+    fsGroupChangePolicy: OnRootMismatch
+
   resources:
     requests:
       cpu: "{{ signoz_clickhouse_cpu_request }}"
@@ -13,14 +21,17 @@ signoz:
     type: {{ signoz_service_type }}
     port: 8080
     nodePort: {{ signoz_http_node_port }}
+
   env:
     # Alertmanager email alerts
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__FROM: "signoz@princeton.edu"
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__HELLO: "signoz.lib.princeton.edu"
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__SMARTHOST: "lib-ponyexpr-prod.princeton.edu:25"
     SIGNOZ_ALERTMANAGER_SIGNOZ_GLOBAL_SMTP__REQUIRE__TLS: "false"
+
     # Alertmanager links back to SigNoz UI
     signoz_alertmanager_signoz_external__url: "https://{{ signoz_ingress_host }}"
+
     SIGNOZ_TOKENIZER_JWT_SECRET: "{{ signoz_tokenizer_jwt_secret }}"
 
 otelCollector:
@@ -38,6 +49,7 @@ otelCollector:
         containerPort: 4317
         nodePort: {{ signoz_otel_grpc_node_port }}
         protocol: TCP
+
       otlp-http:
         enabled: true
         servicePort: 4318


### PR DESCRIPTION
Configure ClickHouse with fsGroupChangePolicy=OnRootMismatch to avoid recursively resetting ownership across the large local ClickHouse volume during pod restarts and node maintenance.