### PR TITLE
fix molecule tests failing to find shared roles (unbreak main)

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -118,7 +118,6 @@ jobs:
       - name: Run tests
         env:
           MOLECULE_DOCKER_PLATFORM: linux/amd64
-          ANSIBLE_ROLES_PATH: ${{ github.workspace }}/roles
         run: |
           ROLE=${{ matrix.role }} uv run --frozen python run_molecule.py
 

--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Run tests
         env:
           MOLECULE_DOCKER_PLATFORM: linux/amd64
+          ANSIBLE_ROLES_PATH: ${{ github.workspace }}/roles
         run: |
           ROLE=${{ matrix.role }} uv run --frozen python run_molecule.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 # Ansible
 *.retry
 ansible.log
+external_roles/
 
 # IDE
 .vscode/

--- a/devbox.json
+++ b/devbox.json
@@ -21,7 +21,7 @@
     "UV_PROJECT_ENVIRONMENT":      "$DEVBOX_PROJECT_ROOT/.venv",
     "UV_PYTHON":                   "3.11",
     "UV_PYTHON_PREFERENCE":        "only-system",
-    "ANSIBLE_ROLES_PATH":          "$DEVBOX_PROJECT_ROOT/roles",
+    "ANSIBLE_ROLES_PATH":          "$DEVBOX_PROJECT_ROOT/external_roles:$DEVBOX_PROJECT_ROOT/roles",
     "ANSIBLE_VAULT_PASSWORD_FILE": "$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible",
     "ANSIBLE_VAULT_IDENTITY_LIST": "pul@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible,princeton@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible,ansible@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible,default@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible"
   },

--- a/devbox.json
+++ b/devbox.json
@@ -21,6 +21,7 @@
     "UV_PROJECT_ENVIRONMENT":      "$DEVBOX_PROJECT_ROOT/.venv",
     "UV_PYTHON":                   "3.11",
     "UV_PYTHON_PREFERENCE":        "only-system",
+    "ANSIBLE_ROLES_PATH":          "$DEVBOX_PROJECT_ROOT/roles",
     "ANSIBLE_VAULT_PASSWORD_FILE": "$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible",
     "ANSIBLE_VAULT_IDENTITY_LIST": "pul@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible,princeton@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible,ansible@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible,default@$DEVBOX_PROJECT_ROOT/bin/lastpass-ansible"
   },

--- a/run_molecule.py
+++ b/run_molecule.py
@@ -56,11 +56,11 @@ def roles_dependant_on_changed_roles():
 
 
 def roles_path():
-    repo_roles = os.path.abspath('./roles')
+    search_path = [os.path.abspath('./external_roles'), os.path.abspath('./roles')]
     existing = os.environ.get('ANSIBLE_ROLES_PATH')
-    if existing and repo_roles not in existing.split(':'):
-        return repo_roles + ':' + existing
-    return existing or repo_roles
+    if existing:
+        search_path.extend(p for p in existing.split(':') if p not in search_path)
+    return ':'.join(search_path)
 
 
 def run_test(role):

--- a/run_molecule.py
+++ b/run_molecule.py
@@ -55,7 +55,16 @@ def roles_dependant_on_changed_roles():
     return out_roles
 
 
+def roles_path():
+    repo_roles = os.path.abspath('./roles')
+    existing = os.environ.get('ANSIBLE_ROLES_PATH')
+    if existing and repo_roles not in existing.split(':'):
+        return repo_roles + ':' + existing
+    return existing or repo_roles
+
+
 def run_test(role):
+    os.environ['ANSIBLE_ROLES_PATH'] = roles_path()
     exit_code = os.system('cd  roles/' + role + ' && molecule test')
     if not exit_code == 0:
         raise Exception('Molecule tests failed')


### PR DESCRIPTION
Every role's test run broke because the newest Molecule (added by renovate) no longer adds the repository's shared roles directory to Ansible's role search path, so any test playbook referencing a sibling role failed its syntax check. Set the search path explicitly for CI, the test runner, and local shells.

https://github.com/ansible/molecule/issues/4391

closes #7604 