### PR TITLE
Fix: make role tests find shared roles again

### DIFF
--- a/roles/ad_join/molecule/default/molecule.yml
+++ b/roles/ad_join/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/apache2/molecule/default/molecule.yml
+++ b/roles/apache2/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/approvals/molecule/default/molecule.yml
+++ b/roles/approvals/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/bibdata/molecule/default/molecule.yml
+++ b/roles/bibdata/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/bibdata_sqs_poller/molecule/default/molecule.yml
+++ b/roles/bibdata_sqs_poller/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/bind9/molecule/default/molecule.yml
+++ b/roles/bind9/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/bitcurator/molecule/default/molecule.yml
+++ b/roles/bitcurator/molecule/default/molecule.yml
@@ -21,6 +21,10 @@ platforms:
       ansible_connection: docker
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   log: true
   playbooks:
     prepare: prepare.yml

--- a/roles/blacklight_app/molecule/default/molecule.yml
+++ b/roles/blacklight_app/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/capistrano/molecule/default/molecule.yml
+++ b/roles/capistrano/molecule/default/molecule.yml
@@ -29,6 +29,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/clamav/molecule/default/molecule.yml
+++ b/roles/clamav/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/composer/molecule/default/molecule.yml
+++ b/roles/composer/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/datadog/molecule/default/molecule.yml
+++ b/roles/datadog/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/deploy_user/molecule/default/molecule.yml
+++ b/roles/deploy_user/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/dpul/molecule/default/molecule.yml
+++ b/roles/dpul/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/dss/molecule/default/molecule.yml
+++ b/roles/dss/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/example/molecule/default/molecule.yml
+++ b/roles/example/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/extra_path/molecule/default/molecule.yml
+++ b/roles/extra_path/molecule/default/molecule.yml
@@ -29,6 +29,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/ezproxy/molecule/default/molecule.yml
+++ b/roles/ezproxy/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/ffmpeg_s/molecule/default/molecule.yml
+++ b/roles/ffmpeg_s/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/figgy/molecule/default/molecule.yml
+++ b/roles/figgy/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/figgy_filewatcher_worker/molecule/default/molecule.yml
+++ b/roles/figgy_filewatcher_worker/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/figgy_pubsub_worker/molecule/default/molecule.yml
+++ b/roles/figgy_pubsub_worker/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/firewall/molecule/default/molecule.yml
+++ b/roles/firewall/molecule/default/molecule.yml
@@ -29,6 +29,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/freetds/molecule/default/molecule.yml
+++ b/roles/freetds/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/gitlab/molecule/default/molecule.yml
+++ b/roles/gitlab/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/golang/molecule/default/molecule.yml
+++ b/roles/golang/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/himmelblau_entra_id/molecule/default/molecule.yml
+++ b/roles/himmelblau_entra_id/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/hr_share/molecule/default/molecule.yml
+++ b/roles/hr_share/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/iiif/molecule/default/molecule.yml
+++ b/roles/iiif/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/imagemagick/molecule/default/molecule.yml
+++ b/roles/imagemagick/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/lib_jobs/molecule/default/molecule.yml
+++ b/roles/lib_jobs/molecule/default/molecule.yml
@@ -52,6 +52,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/lib_sftp/molecule/default/molecule.yml
+++ b/roles/lib_sftp/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/libstatic/molecule/default/molecule.yml
+++ b/roles/libstatic/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/lockers_and_study_spaces/molecule/default/molecule.yml
+++ b/roles/lockers_and_study_spaces/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/mailcatcher/molecule/default/molecule.yml
+++ b/roles/mailcatcher/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/mediainfo/molecule/default/molecule.yml
+++ b/roles/mediainfo/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/memcached/molecule/default/molecule.yml
+++ b/roles/memcached/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/mirror_sync/molecule/default/molecule.yml
+++ b/roles/mirror_sync/molecule/default/molecule.yml
@@ -21,6 +21,10 @@ platforms:
       ansible_connection: docker
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   log: true
   playbooks:
     prepare: prepare.yml

--- a/roles/mysql/molecule/default/molecule.yml
+++ b/roles/mysql/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/nfsserver/molecule/default/molecule.yml
+++ b/roles/nfsserver/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/nginx/molecule/default/molecule.yml
+++ b/roles/nginx/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/nginxplus/molecule/default/molecule.yml
+++ b/roles/nginxplus/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/nodejs/molecule/default/molecule.yml
+++ b/roles/nodejs/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/nomad_app/molecule/default/molecule.yml
+++ b/roles/nomad_app/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/openjdk/molecule/default/molecule.yml
+++ b/roles/openjdk/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/openresty/molecule/default/molecule.yml
+++ b/roles/openresty/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/orangelight/molecule/default/molecule.yml
+++ b/roles/orangelight/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/otel_collector/molecule/default/molecule.yml
+++ b/roles/otel_collector/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/pas/molecule/default/molecule.yml
+++ b/roles/pas/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/passenger/molecule/default/molecule.yml
+++ b/roles/passenger/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/php/molecule/default/molecule.yml
+++ b/roles/php/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/postfix/molecule/default/molecule.yml
+++ b/roles/postfix/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/postgresql/molecule/default/molecule.yml
+++ b/roles/postgresql/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/psql-client/molecule/default/molecule.yml
+++ b/roles/psql-client/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/pulfalight/molecule/default/molecule.yml
+++ b/roles/pulfalight/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/pulmap/molecule/default/molecule.yml
+++ b/roles/pulmap/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/pulmirror/molecule/default/molecule.yml
+++ b/roles/pulmirror/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/redis/molecule/default/molecule.yml
+++ b/roles/redis/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/repec/molecule/default/molecule.yml
+++ b/roles/repec/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/resque_worker/molecule/default/molecule.yml
+++ b/roles/resque_worker/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/ruby/molecule/default/molecule.yml
+++ b/roles/ruby/molecule/default/molecule.yml
@@ -17,6 +17,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   log: true
 verifier:
   name: ansible

--- a/roles/ruby_app/molecule/default/molecule.yml
+++ b/roles/ruby_app/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/ruby_s/molecule/default/molecule.yml
+++ b/roles/ruby_s/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/rust/molecule/default/molecule.yml
+++ b/roles/rust/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/samba/molecule/default/molecule.yml
+++ b/roles/samba/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/shared_data/molecule/default/molecule.yml
+++ b/roles/shared_data/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/sidekiq_worker/molecule/default/molecule.yml
+++ b/roles/sidekiq_worker/molecule/default/molecule.yml
@@ -44,6 +44,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/sneakers_worker/molecule/default/molecule.yml
+++ b/roles/sneakers_worker/molecule/default/molecule.yml
@@ -56,6 +56,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     prepare: prepare.yml
     create: create.yml

--- a/roles/solr9cloud/molecule/default/molecule.yml
+++ b/roles/solr9cloud/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/studio_proc/molecule/default/molecule.yml
+++ b/roles/studio_proc/molecule/default/molecule.yml
@@ -29,6 +29,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/subversion/molecule/default/molecule.yml
+++ b/roles/subversion/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/timezone/molecule/default/molecule.yml
+++ b/roles/timezone/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/tippecanoe/molecule/default/molecule.yml
+++ b/roles/tippecanoe/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/tomcat9/molecule/default/molecule.yml
+++ b/roles/tomcat9/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/towerdeploy/molecule/default/molecule.yml
+++ b/roles/towerdeploy/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/vips/molecule/default/molecule.yml
+++ b/roles/vips/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/xrdp/molecule/default/molecule.yml
+++ b/roles/xrdp/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/zfs/molecule/default/molecule.yml
+++ b/roles/zfs/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml

--- a/roles/zookeeper/molecule/default/molecule.yml
+++ b/roles/zookeeper/molecule/default/molecule.yml
@@ -33,6 +33,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  # Molecule no longer puts the repository's roles directory on the role
+  # search path, so playbooks cannot find roles by name without this.
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
   playbooks:
     create: create.yml
     destroy: destroy.yml


### PR DESCRIPTION
Test runs for every role broke because the current Molecule release no longer adds the repository's shared roles directory to the search path Ansible uses to resolve roles by name, and it replaces the repository configuration with its own generated file

https://github.com/ansible/molecule/issues/4391

closes #7604 