### PR TITLE
[ezproxy] report ezproxy rule trips to Signoz

### DIFF
--- a/group_vars/ezproxy/common.yml
+++ b/group_vars/ezproxy/common.yml
@@ -10,7 +10,8 @@ ezproxy_directory: "/var/local/ezproxy/log"
 
 ezproxy_log_retention_days: 7
 
-ezproxy_logrotate_rules: []
+# Rotation of the security trip log is defined in the role's defaults, next to
+# the path it rotates, so the two cannot drift apart.
 
 # Catch a broken Collector configuration before restarting it, so a typo in the
 # log parsing rules cannot take log shipping down.

--- a/group_vars/ezproxy/production.yml
+++ b/group_vars/ezproxy/production.yml
@@ -276,6 +276,63 @@ otel_receivers:
         field: attributes.service_name
         value: ezproxy_audit
 
+  # Tripped EZproxy security rules.
+  #
+  # EZproxy stores these in a SQLite database and only shows them on its admin
+  # page. A cron script (see roles/ezproxy) copies each new trip here as JSON so
+  # they arrive in SigNoz, where an alert can fire on them. The rule that was
+  # tripped, who tripped it, the limit and the observed value all come through
+  # as fields.
+  filelog/ezproxy_security:
+    include:
+      - /var/local/ezproxy/log/security_trips.json
+    exclude:
+      - /var/local/ezproxy/log/*.gz
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: json_parser
+        id: parse_ezproxy_security_trip
+        parse_from: body
+        timestamp:
+          parse_from: attributes.triggered_at
+          layout_type: strptime
+          layout: '%Y-%m-%dT%H:%M:%SZ'
+        on_error: send
+
+      # EZproxy security rules either block the account or just record the
+      # breach, so a block is an error and a log entry is a warning. Anything
+      # else is passed through unclassified rather than dropped.
+      - type: severity_parser
+        id: parse_ezproxy_security_severity
+        parse_from: attributes.action
+        overwrite_text: true
+        mapping:
+          error:
+            - block
+          warn:
+            - log
+        on_error: send
+
+      - type: add
+        id: set_ezproxy_security_body
+        field: body
+        value: 'EXPR(attributes.rule_name + " " + attributes.action + " " + attributes.username)'
+
+      - type: remove
+        id: remove_ezproxy_security_triggered_at
+        if: 'attributes.triggered_at != nil'
+        field: attributes.triggered_at
+
+      - type: add
+        field: attributes.log_type
+        value: ezproxy_security_trip
+
+      - type: add
+        field: attributes.service_name
+        value: ezproxy_security
+
   hostmetrics:
     collection_interval: 30s
     scrapers:
@@ -325,6 +382,7 @@ otel_service_pipelines:
       - filelog/ezproxy_access
       - filelog/ezproxy_spu
       - filelog/ezproxy_audit
+      - filelog/ezproxy_security
     processors:
       - resource
       - batch

--- a/group_vars/ezproxy/production.yml
+++ b/group_vars/ezproxy/production.yml
@@ -288,7 +288,13 @@ otel_receivers:
       - /var/local/ezproxy/log/security_trips.json
     exclude:
       - /var/local/ezproxy/log/*.gz
-    start_at: end
+    # Unlike the request logs, this file does not exist until the very first
+    # rule trips, and trips are rare. Reading from the end would skip that
+    # first entry, which is exactly the one worth alerting on, so this reads
+    # from the beginning. The storage extension remembers how far it got, so a
+    # Collector restart does not replay old trips as fresh alerts.
+    start_at: beginning
+    storage: file_storage/otel
     include_file_path: true
     include_file_name: true
     operators:
@@ -348,6 +354,18 @@ otel_processors:
     send_batch_max_size: 1024
     send_batch_size: 512
     timeout: 30s
+
+# Remembers how far the Collector has read into each log file, so a restart
+# does not re-send what it already sent. create_directory saves needing a
+# separate Ansible task to make the directory.
+otel_extensions:
+  file_storage/otel:
+    directory: /var/lib/otelcol/file_storage
+    create_directory: true
+
+# An extension is only started if it is named here as well as defined above.
+otel_service_extensions:
+  - file_storage/otel
 
 otel_exporters:
   loadbalancing:

--- a/group_vars/ezproxy/testing.yml
+++ b/group_vars/ezproxy/testing.yml
@@ -290,7 +290,13 @@ otel_receivers:
       - /var/local/ezproxy/log/security_trips.json
     exclude:
       - /var/local/ezproxy/log/*.gz
-    start_at: end
+    # Unlike the request logs, this file does not exist until the very first
+    # rule trips, and trips are rare. Reading from the end would skip that
+    # first entry, which is exactly the one worth alerting on, so this reads
+    # from the beginning. The storage extension remembers how far it got, so a
+    # Collector restart does not replay old trips as fresh alerts.
+    start_at: beginning
+    storage: file_storage/otel
     include_file_path: true
     include_file_name: true
     operators:
@@ -350,6 +356,18 @@ otel_processors:
     send_batch_max_size: 1024
     send_batch_size: 512
     timeout: 30s
+
+# Remembers how far the Collector has read into each log file, so a restart
+# does not re-send what it already sent. create_directory saves needing a
+# separate Ansible task to make the directory.
+otel_extensions:
+  file_storage/otel:
+    directory: /var/lib/otelcol/file_storage
+    create_directory: true
+
+# An extension is only started if it is named here as well as defined above.
+otel_service_extensions:
+  - file_storage/otel
 
 otel_exporters:
   loadbalancing:

--- a/group_vars/ezproxy/testing.yml
+++ b/group_vars/ezproxy/testing.yml
@@ -278,6 +278,63 @@ otel_receivers:
         field: attributes.service_name
         value: ezproxy_audit
 
+  # Tripped EZproxy security rules.
+  #
+  # EZproxy stores these in a SQLite database and only shows them on its admin
+  # page. A cron script (see roles/ezproxy) copies each new trip here as JSON so
+  # they arrive in SigNoz, where an alert can fire on them. The rule that was
+  # tripped, who tripped it, the limit and the observed value all come through
+  # as fields.
+  filelog/ezproxy_security:
+    include:
+      - /var/local/ezproxy/log/security_trips.json
+    exclude:
+      - /var/local/ezproxy/log/*.gz
+    start_at: end
+    include_file_path: true
+    include_file_name: true
+    operators:
+      - type: json_parser
+        id: parse_ezproxy_security_trip
+        parse_from: body
+        timestamp:
+          parse_from: attributes.triggered_at
+          layout_type: strptime
+          layout: '%Y-%m-%dT%H:%M:%SZ'
+        on_error: send
+
+      # EZproxy security rules either block the account or just record the
+      # breach, so a block is an error and a log entry is a warning. Anything
+      # else is passed through unclassified rather than dropped.
+      - type: severity_parser
+        id: parse_ezproxy_security_severity
+        parse_from: attributes.action
+        overwrite_text: true
+        mapping:
+          error:
+            - block
+          warn:
+            - log
+        on_error: send
+
+      - type: add
+        id: set_ezproxy_security_body
+        field: body
+        value: 'EXPR(attributes.rule_name + " " + attributes.action + " " + attributes.username)'
+
+      - type: remove
+        id: remove_ezproxy_security_triggered_at
+        if: 'attributes.triggered_at != nil'
+        field: attributes.triggered_at
+
+      - type: add
+        field: attributes.log_type
+        value: ezproxy_security_trip
+
+      - type: add
+        field: attributes.service_name
+        value: ezproxy_security
+
   hostmetrics:
     collection_interval: 30s
     scrapers:
@@ -327,6 +384,7 @@ otel_service_pipelines:
       - filelog/ezproxy_access
       - filelog/ezproxy_spu
       - filelog/ezproxy_audit
+      - filelog/ezproxy_security
     processors:
       - resource
       - batch

--- a/roles/ezproxy/README.md
+++ b/roles/ezproxy/README.md
@@ -128,6 +128,17 @@ than in EZproxy.
 
 Points worth knowing:
 
+* **`security_trips.json` does not exist until the first rule trips.** That is
+  normal, not a sign the reporter is broken: the script appends only when it has
+  something new, so an absent file simply means nothing has tripped since the
+  servers were built. Use the `sqlite3` query above to confirm the database
+  agrees.
+* Because the file appears late, its receiver reads from the **beginning**,
+  unlike the request logs which read from the end. Reading from the end would
+  skip the first line of a newly created file, which here is the first trip ever
+  recorded and the one most worth alerting on. A storage extension remembers the
+  read position so a Collector restart does not re-send old trips. The same
+  applies each time logrotate starts a fresh file.
 * A rule whose action is `block` arrives as an **error**; `log` arrives as a
   **warning**. So a single SigNoz alert on error-severity records from
   `service.name = ezproxy` catches every blocked account.

--- a/roles/ezproxy/README.md
+++ b/roles/ezproxy/README.md
@@ -96,6 +96,51 @@ intruder lockouts show up as errors and blocked countries, usage limits and
 session address changes as warnings, without anyone having to memorise
 EZproxy's event names.
 
+## Security rules and alerting
+
+EZproxy enforces its own security rules (byte limits, login rates and so on)
+and records every rule it trips in a SQLite database at
+`/var/local/ezproxy/security/security_v1.db`. The `sqlite3` client is installed
+so this can be queried by hand:
+
+```sh
+sqlite3 -readonly -line /var/local/ezproxy/security/security_v1.db <<'SQL'
+SELECT t.id, datetime(t.at, 'unixepoch') AS triggered_utc, r.rulename,
+       t.user, r.criterion, r.boundary AS limit_value, t.value AS observed,
+       r.action, datetime(t.expires, 'unixepoch') AS expires_utc
+FROM tripped AS t JOIN rule AS r ON r.id = t.ruleid
+ORDER BY t.at DESC LIMIT 10;
+SQL
+```
+
+Always pass `-readonly`, since EZproxy is writing to this database while it
+runs.
+
+Waiting for someone to run that query is not alerting, though. EZproxy itself
+can only email a **daily** digest (admin page, Tripped Security Rules
+Notifications), which is too slow to catch an account being blocked mid-day.
+
+So `/usr/local/bin/ezproxy-security-trips` runs from cron every five minutes,
+finds trips it has not reported yet, and appends them to
+`log/security_trips.json`. The Collector tails that file like the other logs,
+so trips reach SigNoz within minutes and alerts are configured there rather
+than in EZproxy.
+
+Points worth knowing:
+
+* A rule whose action is `block` arrives as an **error**; `log` arrives as a
+  **warning**. So a single SigNoz alert on error-severity records from
+  `service.name = ezproxy` catches every blocked account.
+* Useful alert fields: `rule_name`, `username`, `criterion`, `limit_value`,
+  `observed_value`, `over_limit_by`, and `never_expires` (set when a block has
+  no expiry and so needs a human to clear it).
+* Progress is tracked in `/var/lib/ezproxy/security_trips.last_id`. On a first
+  run the script records where the table stands and reports nothing, so
+  existing history is not replayed as a flood of alerts. Delete that file to
+  deliberately re-report everything.
+* The high water mark only advances after trips are written, so a failure means
+  they are reported next run rather than silently lost.
+
 **The running servers get `config.txt` from the encrypted
 `files/{production,testing}_vault_config.txt`, not from `config.txt.j2`.** The
 template is only used for a greenfield build, so a log format change has to be

--- a/roles/ezproxy/defaults/main.yml
+++ b/roles/ezproxy/defaults/main.yml
@@ -22,3 +22,36 @@ domain_name: "ezproxy.example.edu"
 # that use them are given -strftime.
 ezproxy_access_log_pattern: "log/ezp%Y%m%d.json"
 ezproxy_spu_log_pattern: "log/spu%Y%m%d.json"
+
+# Security rule alerting.
+#
+# EZproxy records each security rule it trips in a SQLite database and shows
+# them on its admin page, but nothing pushes them anywhere. A companion script
+# copies new trips into the log directory as JSON so the OpenTelemetry Collector
+# picks them up and SigNoz can alert on them.
+ezproxy_security_db: "/var/local/ezproxy/security/security_v1.db"
+ezproxy_security_trips_log: "/var/local/ezproxy/log/security_trips.json"
+ezproxy_security_state_dir: "/var/lib/ezproxy"
+ezproxy_security_state_file: "/var/lib/ezproxy/security_trips.last_id"
+# How long to wait for EZproxy to release the write lock before giving up.
+ezproxy_security_query_timeout_ms: 10000
+# How often to look for new trips. Alerts are only ever this fresh.
+ezproxy_security_check_minute: "*/5"
+
+# The request logs are date stamped and aged out by a daily script, but the
+# security trip log is a single append-only file, so it needs rotating. Trips
+# are rare, so a long retention costs almost nothing and keeps the history
+# around for looking back at an incident. This lives here, next to the path it
+# rotates, so the two cannot drift apart.
+ezproxy_logrotate_rules:
+  - name: "ezproxy-security-trips"
+    paths:
+      - "{{ ezproxy_security_trips_log }}"
+    options:
+      rotate: "52"
+      maxsize: "10M"
+      create_mode: "0644"
+      create_owner: "root"
+      create_group: "root"
+      su_user: "root"
+      su_group: "root"

--- a/roles/ezproxy/tasks/main.yml
+++ b/roles/ezproxy/tasks/main.yml
@@ -21,6 +21,9 @@
     - libc6
     - libstdc++6
     - lsof
+    # EZproxy keeps its security rule history in a SQLite database. The client
+    # lets us query it by hand and lets the alerting script below read it.
+    - sqlite3
 
 - name: Ezproxy | install missing file replacements
   ansible.builtin.command: /var/local/ezproxy/ezproxy -m
@@ -160,6 +163,36 @@
     owner: root
     group: root
     mode: "0755"
+  when:
+    - running_on_server
+
+# Report tripped security rules so they can be alerted on, rather than waiting
+# for someone to open the admin page.
+- name: Ezproxy | create security alerting state directory
+  ansible.builtin.file:
+    path: "{{ ezproxy_security_state_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - running_on_server
+
+- name: Ezproxy | install security rule trip reporter
+  ansible.builtin.template:
+    src: ezproxy-security-trips.sh.j2
+    dest: /usr/local/bin/ezproxy-security-trips
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - running_on_server
+
+- name: Ezproxy | check for tripped security rules on a schedule
+  ansible.builtin.cron:
+    name: "report tripped ezproxy security rules"
+    minute: "{{ ezproxy_security_check_minute }}"
+    job: "/usr/local/bin/ezproxy-security-trips"
   when:
     - running_on_server
 

--- a/roles/ezproxy/templates/ezproxy-security-trips.sh.j2
+++ b/roles/ezproxy/templates/ezproxy-security-trips.sh.j2
@@ -1,0 +1,72 @@
+#!/bin/sh
+#
+# {{ ansible_managed }}
+#
+# EZproxy records every security rule it trips in a SQLite database, and shows
+# them on the admin page under Security. Nothing pushes them anywhere, so a
+# blocked account is only noticed if somebody thinks to look, or the next day
+# when EZproxy emails its digest.
+#
+# This turns each new trip into a line of JSON in the EZproxy log directory.
+# The OpenTelemetry Collector already tails that directory, so trips reach
+# SigNoz within a minute or two and can raise an alert there.
+
+set -eu
+
+security_db={{ ezproxy_security_db | quote }}
+state_file={{ ezproxy_security_state_file | quote }}
+output_log={{ ezproxy_security_trips_log | quote }}
+
+# The database only appears once EZproxy has loaded at least one security rule.
+[ -r "$security_db" ] || exit 0
+
+# -readonly guarantees we cannot disturb the database EZproxy is writing to,
+# and the timeout waits rather than failing if EZproxy holds the write lock.
+run_query() {
+  sqlite3 -readonly -noheader -batch -cmd ".timeout {{ ezproxy_security_query_timeout_ms }}" \
+    "$security_db" "$1"
+}
+
+if [ ! -s "$state_file" ]; then
+  # First run: note where the table currently stands and report nothing, so
+  # existing history is not replayed as a burst of new alerts.
+  run_query "SELECT IFNULL(MAX(id), 0) FROM tripped;" > "$state_file"
+  exit 0
+fi
+
+last_id="$(cat "$state_file")"
+
+# tripped.id is an autoincrementing key, so it only ever moves forward and is
+# never reused. That makes it a safe high water mark for "what has been seen".
+new_trips="$(run_query "
+  SELECT json_object(
+    'trip_id',        t.id,
+    'triggered_at',   strftime('%Y-%m-%dT%H:%M:%SZ', t.at, 'unixepoch'),
+    'rule_name',      r.rulename,
+    'username',       t.user,
+    'criterion',      r.criterion,
+    'limit_value',    r.boundary,
+    'observed_value', t.value,
+    'over_limit_by',  t.value - r.boundary,
+    'action',         r.action,
+    'period_seconds', r.period,
+    'evidence_table', r.facttable,
+    'expires_at',     CASE WHEN t.expires IN (0, 1) THEN NULL
+                           ELSE strftime('%Y-%m-%dT%H:%M:%SZ', t.expires, 'unixepoch') END,
+    'never_expires',  CASE WHEN t.expires >= 2147483647 THEN 1 ELSE 0 END,
+    'rule_source',    r.file || ':' || r.lineno
+  )
+  FROM tripped AS t
+  JOIN rule AS r ON r.id = t.ruleid
+  WHERE t.id > $last_id
+  ORDER BY t.id;
+")"
+
+[ -n "$new_trips" ] || exit 0
+
+printf '%s\n' "$new_trips" >> "$output_log"
+
+# Advance the mark only after the trips are safely written, so a failure here
+# means they are reported again next run rather than lost.
+printf '%s\n' "$new_trips" \
+  | sed -n '$s/.*"trip_id":\([0-9]*\).*/\1/p' > "$state_file"

--- a/roles/otel_collector/README.md
+++ b/roles/otel_collector/README.md
@@ -24,6 +24,7 @@ See `defaults/main.yml` for the full list. Key ones:
 - `otel_download_url`: Download URL (amd64)
 - `otel_validate_config`: If `true`, run a validation command after templating (default: `false`)
 - `otel_receivers`, `otel_processors`, `otel_exporters`, `otel_service_pipelines`, `otel_extensions`: Core config dicts/lists (default: empty)
+- `otel_service_extensions`: List naming which of `otel_extensions` to start (default: empty). An extension that is defined but not named here never starts, and a receiver referencing an unstarted extension makes the Collector fail on boot.
 - `otel_default_resource_attributes`: Map of resource attributes to **merge** into a `processors.resource` section (as *upsert* actions)
 
 ## How to use

--- a/roles/otel_collector/defaults/main.yml
+++ b/roles/otel_collector/defaults/main.yml
@@ -30,6 +30,9 @@ otel_processors: {}
 otel_exporters: {}
 otel_service_pipelines: {}
 otel_extensions: {}
+# Which of the extensions above to actually start. Defining an extension is not
+# enough on its own, it has to be named here too.
+otel_service_extensions: []
 
 # Default resource attributes to merge into processors.resource.
 otel_default_resource_attributes: {}

--- a/roles/otel_collector/templates/config.yaml.j2
+++ b/roles/otel_collector/templates/config.yaml.j2
@@ -103,6 +103,13 @@ service:
   telemetry:
 {{ otel_service_telemetry | to_nice_yaml(indent=2) | indent(4, true) }}
 {% endif %}
+{% if (otel_service_extensions | default([])) | length > 0 %}
+  # Extensions have to be listed here as well as defined below. A defined but
+  # unlisted extension is never started, and a receiver that asks for one that
+  # is not started makes the Collector fail on boot.
+  extensions:
+{{ otel_service_extensions | to_nice_yaml(indent=2) | indent(4, true) }}
+{% endif %}
   pipelines:
 {{ (merged_service_pipelines | default({})) | to_nice_yaml(indent=2) | indent(4, true) }}
 


### PR DESCRIPTION
- poll the EZproxy security database for newly tripped rules
- ship structured security events through the OpenTelemetry Collector
- map block and log actions to error and warning severities
- rotate the security trip log and document the alerting workflow