### PR TITLE
adds tip for deleting devbox and starting over

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ devbox run init
 If your DevBox environment is acting wonky, or you're unsure if it might be causing some weird behavior, delete the local virtual environment and start over:
 
 ```bash
+# Delete the old python venv if you still have one
+rm -rf .venv
 # Delete and recreate devbox shell
 rm -rf .devbox
 devbox shell

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ cd roles/common
 env -u ANSIBLE_VAULT_IDENTITY_LIST -u ANSIBLE_VAULT_PASSWORD_FILE molecule test
 ```
 
-Troubleshooting Setup
----------------------
+Troubleshooting
+---------------
 
 ### Ansible Command Not Found / Reinstall deps
 
@@ -89,6 +89,16 @@ devbox shell
 devbox run init
 ```
 
+### DevBox is borked
+
+If your DevBox environment is acting wonky, or you're unsure if it might be causing some weird behavior, delete the local virtual environment and start over:
+
+```bash
+# Delete and recreate devbox shell
+rm -rf .devbox
+devbox shell
+devbox run init
+```
 ### LastPass Authentication Issues
 
 If you get vault password errors when running playbooks:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ devbox run init
 If your DevBox environment is acting wonky, or you're unsure if it might be causing some weird behavior, delete the local virtual environment and start over:
 
 ```bash
-# Delete the old python venv if you still have one
+# Delete your python venv
 rm -rf .venv
 # Delete and recreate devbox shell
 rm -rf .devbox


### PR DESCRIPTION
We kept asking on slack "how do I delete devbox and start over?"

This PR changes a section title from "Troubleshooting Setup" to just "Troubleshooting" and adds a section with instructions for deleting devbox and starting over.

We may want this somewhere else instead, or in addition, but I wanted to get it out of my brain for now. 