### PR TITLE
[dacs] Parse severity from semantic logger log lines for signoz

### DIFF
--- a/group_vars/allsearch_api/production.yml
+++ b/group_vars/allsearch_api/production.yml
@@ -113,6 +113,10 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "allsearch_api"
+      - type: json_parser
+        parse_from: body
+        severity:
+          parse_from: attributes.level
 
   hostmetrics:
     collection_interval: 30s

--- a/group_vars/allsearch_api/staging.yml
+++ b/group_vars/allsearch_api/staging.yml
@@ -77,6 +77,10 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "allsearch_api"
+      - type: json_parser
+        parse_from: body
+        severity:
+          parse_from: attributes.level
 
   hostmetrics:
     collection_interval: 30s

--- a/group_vars/dss/production.yml
+++ b/group_vars/dss/production.yml
@@ -89,6 +89,10 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "dss"
+      - type: json_parser
+        parse_from: body
+        severity:
+          parse_from: attributes.level
 
   hostmetrics:
     collection_interval: 30s

--- a/group_vars/dss/staging.yml
+++ b/group_vars/dss/staging.yml
@@ -92,6 +92,10 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "dss"
+      - type: json_parser
+        parse_from: body
+        severity:
+          parse_from: attributes.level
 
   hostmetrics:
     collection_interval: 30s

--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -129,6 +129,10 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "orangelight"
+      - type: json_parser
+        parse_from: body
+        severity:
+          parse_from: attributes.level
 
   hostmetrics:
     collection_interval: 30s

--- a/group_vars/orangelight/staging.yml
+++ b/group_vars/orangelight/staging.yml
@@ -87,6 +87,10 @@ otel_receivers:
       - type: add
         field: attributes.service_name
         value: "orangelight"
+      - type: json_parser
+        parse_from: body
+        severity:
+          parse_from: attributes.level
 
   hostmetrics:
     collection_interval: 30s


### PR DESCRIPTION
Semantic logger includes the severity like so in its json:

```
{"level":"info"...
```

This adds this level to the otel severity fields, so that we can use it as a filter in signoz.

Copied more or less from the solr otelcol config