### PR TITLE
[Figgy] Move Memcached for Staging/Prod to Nomad

### DIFF
--- a/nomad/figgy-infrastructure/deploy/production.hcl
+++ b/nomad/figgy-infrastructure/deploy/production.hcl
@@ -9,6 +9,70 @@ job "figgy-infrastructure-production" {
   # Set a higher priority because this job only works on these boxes.
   priority = 60
 
+  group "memcached" {
+    count = 1
+    # Remove from consul, wait 10s, then shut down.
+    shutdown_delay = "10s"
+
+    update {
+      max_parallel = 1
+      health_check = "checks"
+      min_healthy_time = "30s"
+      healthy_deadline = "5m"
+      progress_deadline = "15m"
+      auto_revert = true
+    }
+
+    migrate {
+      max_parallel = 1
+      health_check = "checks"
+      min_healthy_time = "30s"
+    }
+
+    network {
+      port "memcached" {
+        to = 11211
+      }
+
+      dns {
+        servers = ["172.17.0.1", "128.112.129.209", "8.8.8.8", "8.8.4.4"]
+      }
+    }
+
+    service {
+      port = "memcached"
+      tags = ["logging"]
+
+      check {
+        type = "tcp"
+        port = "memcached"
+        interval = "10s"
+        timeout = "2s"
+      }
+    }
+
+    task "memcached" {
+      driver = "docker"
+
+      config {
+        image = "memcached:1.6-alpine"
+        ports = ["memcached"]
+        extra_hosts = ["host.containers.internal:host-gateway"]
+        args = [
+          # 512 MB of cache. It was 64 before, but y'know, we got ram.
+          "--memory-limit=512",
+          "--threads=4",
+          # 4MB largest single thing cached.
+          "--max-item-size=4M"
+        ]
+      }
+      resources {
+        cpu = 1000
+        memory = 1024
+      }
+    }
+  }
+
   group "rabbitmq" {
     count = 3
 

--- a/nomad/figgy-infrastructure/deploy/staging.hcl
+++ b/nomad/figgy-infrastructure/deploy/staging.hcl
@@ -9,6 +9,70 @@ job "figgy-infrastructure-staging" {
   # Set a higher priority because this job only works on these boxes.
   priority = 60
 
+  group "memcached" {
+    count = 1
+    # Remove from consul, wait 10s, then shut down.
+    shutdown_delay = "10s"
+
+    update {
+      max_parallel = 1
+      health_check = "checks"
+      min_healthy_time = "30s"
+      healthy_deadline = "5m"
+      progress_deadline = "15m"
+      auto_revert = true
+    }
+
+    migrate {
+      max_parallel = 1
+      health_check = "checks"
+      min_healthy_time = "30s"
+    }
+
+    network {
+      port "memcached" {
+        to = 11211
+      }
+
+      dns {
+        servers = ["172.17.0.1", "128.112.129.209", "8.8.8.8", "8.8.4.4"]
+      }
+    }
+
+    service {
+      port = "memcached"
+      tags = ["logging"]
+
+      check {
+        type = "tcp"
+        port = "memcached"
+        interval = "10s"
+        timeout = "2s"
+      }
+    }
+
+    task "memcached" {
+      driver = "docker"
+
+      config {
+        image = "memcached:1.6-alpine"
+        ports = ["memcached"]
+        extra_hosts = ["host.containers.internal:host-gateway"]
+        args = [
+          # 512 MB of cache. It was 64 before, but y'know, we got ram.
+          "--memory-limit=512",
+          "--threads=4",
+          # 4MB largest single thing cached.
+          "--max-item-size=4M"
+        ]
+      }
+      resources {
+        cpu = 1000
+        memory = 1024
+      }
+    }
+  }
+
   group "rabbitmq" {
     count = 3
 

--- a/playbooks/figgy_production.yml
+++ b/playbooks/figgy_production.yml
@@ -11,7 +11,6 @@
     - ../group_vars/figgy/common.yml
   roles:
     - role: roles/common
-    - {role: roles/memcached, when: inventory_hostname == 'figgy-web-prod1.princeton.edu'}
     - role: roles/figgy
     - role: otel_collector
       tags: otel

--- a/playbooks/figgy_staging.yml
+++ b/playbooks/figgy_staging.yml
@@ -11,7 +11,6 @@
     - ../group_vars/figgy/staging.yml
     - ../group_vars/figgy/common.yml    
   roles:
-    - {role: roles/memcached, when: inventory_hostname == 'figgy-web-staging1.princeton.edu'}
     - role: roles/sidekiq_worker
     - role: roles/sidekiq_worker
       sidekiq_worker_name: "figgy-realtime-workers"

--- a/roles/nginxplus/files/conf/stream/dev/nomad-proxy.conf
+++ b/roles/nginxplus/files/conf/stream/dev/nomad-proxy.conf
@@ -51,3 +51,20 @@ server {
     include /etc/nginx/conf.d/templates/restrict.conf;
     deny all;
 }
+
+upstream figgy-memcached-production {
+    resolver nomad-host-prod1.lib.princeton.edu:8600 nomad-host-prod2.lib.princeton.edu:8600 nomad-host-prod3.lib.princeton.edu:8600 valid=5s ipv6=off;
+    resolver_timeout 2s;
+    zone figgy-rabbitmq-production 64k;
+    server service.consul service=figgy-infrastructure-production-memcached resolve max_fails=0;
+}
+
+# Figgy Memcached Production - proxies for a cluster.
+server {
+    listen 10003;
+    proxy_pass figgy-memcached-production;
+    proxy_connect_timeout 3s;
+    proxy_timeout 1h;
+    include /etc/nginx/conf.d/templates/restrict.conf;
+    deny all;
+}

--- a/roles/nginxplus/files/conf/stream/dev/nomad-proxy.conf
+++ b/roles/nginxplus/files/conf/stream/dev/nomad-proxy.conf
@@ -34,3 +34,20 @@ server {
     include /etc/nginx/conf.d/templates/restrict.conf;
     deny all;
 }
+
+upstream figgy-memcached-staging {
+    resolver nomad-host-prod1.lib.princeton.edu:8600 nomad-host-prod2.lib.princeton.edu:8600 nomad-host-prod3.lib.princeton.edu:8600 valid=5s ipv6=off;
+    resolver_timeout 2s;
+    zone figgy-rabbitmq-production 64k;
+    server service.consul service=figgy-infrastructure-staging-memcached resolve max_fails=0;
+}
+
+# Figgy Memcached Staging - proxies for a cluster.
+server {
+    listen 10002;
+    proxy_pass figgy-memcached-staging;
+    proxy_connect_timeout 3s;
+    proxy_timeout 1h;
+    include /etc/nginx/conf.d/templates/restrict.conf;
+    deny all;
+}

--- a/roles/nginxplus/files/conf/stream/dev/nomad-proxy.conf
+++ b/roles/nginxplus/files/conf/stream/dev/nomad-proxy.conf
@@ -48,8 +48,6 @@ server {
     proxy_pass figgy-memcached-staging;
     proxy_connect_timeout 3s;
     proxy_timeout 1h;
-    include /etc/nginx/conf.d/templates/restrict.conf;
-    deny all;
 }
 
 upstream figgy-memcached-production {
@@ -65,6 +63,4 @@ server {
     proxy_pass figgy-memcached-production;
     proxy_connect_timeout 3s;
     proxy_timeout 1h;
-    include /etc/nginx/conf.d/templates/restrict.conf;
-    deny all;
 }


### PR DESCRIPTION
This updates memcached, runs it on Nomad, and makes it available for staging boxes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>