### PR TITLE
Set the connect timeout to the ceiling, it's more explicit

### DIFF
--- a/roles/nginxplus/files/conf/http/dev/lib-solr9-staging.conf
+++ b/roles/nginxplus/files/conf/http/dev/lib-solr9-staging.conf
@@ -35,9 +35,9 @@ server {
         proxy_cache_methods POST;
         proxy_set_header Connection "";
         proxy_set_header Host $http_host;
-        proxy_connect_timeout      450; # in seconds
-        proxy_send_timeout         450; # in seconds
-        proxy_read_timeout         450; # in seconds
+        proxy_connect_timeout      75s; # 75s is the ceiling, regardless of the setting
+        proxy_send_timeout         450s;
+        proxy_read_timeout         450s;
         proxy_cache_revalidate on;
         proxy_cache_min_uses 3;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
+++ b/roles/nginxplus/files/conf/http/lib-solr9-prod.conf
@@ -34,9 +34,9 @@ server {
         proxy_cache_methods POST;
         proxy_set_header Connection "";
         proxy_set_header Host $http_host;
-        proxy_connect_timeout      450;
-        proxy_send_timeout         450;
-        proxy_read_timeout         450;
+        proxy_connect_timeout      75s; # 75s is the ceiling, regardless of the setting
+        proxy_send_timeout         450s;
+        proxy_read_timeout         450s;
         proxy_cache_revalidate on;
         proxy_cache_min_uses 3;
         proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
see https://www.netdata.cloud/guides/nginx/nginx-upstream-timed-out/