### PR TITLE
[orangelight] Rotate the Rails production log daily

### DIFF
--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -60,6 +60,18 @@ orangelight_logrotate_rules:
       # Optional: add postrotate script if service needs notification
       # postrotate: |
       #   systemctl reload myservice || true
+  - name: "orangelight"
+    paths:
+      - "/opt/orangelight/current/log/production.log"
+    options:
+      rotate: "{{ logrotate_global_defaults.rotate }}"
+      maxsize: "{{ logrotate_global_defaults.maxsize }}"
+      create_mode: "{{ logrotate_global_defaults.create_mode }}"
+      create_owner: "deploy"
+      create_group: "deploy"
+      su_user: "{{ logrotate_global_defaults.su_user }}"
+      su_group: "{{ logrotate_global_defaults.su_group }}"
+      copytruncate: true
 rails_app_dependencies:
   - libpq-dev
   - pkg-config

--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -62,7 +62,7 @@ orangelight_logrotate_rules:
       #   systemctl reload myservice || true
   - name: "orangelight"
     paths:
-      - "/opt/orangelight/current/log/production.log"
+      - "/opt/orangelight/current/log/{{ rails_app_env }}.log"
     options:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"

--- a/group_vars/orangelight/common.yml
+++ b/group_vars/orangelight/common.yml
@@ -63,6 +63,7 @@ orangelight_logrotate_rules:
   - name: "orangelight"
     paths:
       - "/opt/orangelight/current/log/{{ rails_app_env }}.log"
+      - "/opt/orangelight/current/log/sneakers.log"
     options:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"

--- a/roles/common/templates/logrotate_rules.j2
+++ b/roles/common/templates/logrotate_rules.j2
@@ -30,8 +30,15 @@
     missingok
     notifempty
 
+{% if item.options.copytruncate is defined and item.options.copytruncate %}
+
+    # Truncate in place so processes holding the file open keep logging
+    copytruncate
+{% else %}
+
     # Standardized file creation (always create new files with consistent permissions)
     create {{ item.options.create_mode }} {{ item.options.create_owner  }} {{ item.options.create_group  }}
+{% endif %}
 
     # Use date extension for clarity  so logs will say application.log-20250623-1719158400
     dateext

--- a/roles/orangelight/defaults/main.yml
+++ b/roles/orangelight/defaults/main.yml
@@ -17,7 +17,7 @@ orangelight_logrotate_rules:
       #   systemctl reload myservice || true
   - name: "orangelight"
     paths:
-      - "/opt/orangelight/current/log/production.log"
+      - "/opt/orangelight/current/log/{{ rails_app_env | default('staging') }}.log"
     options:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"

--- a/roles/orangelight/defaults/main.yml
+++ b/roles/orangelight/defaults/main.yml
@@ -18,6 +18,7 @@ orangelight_logrotate_rules:
   - name: "orangelight"
     paths:
       - "/opt/orangelight/current/log/{{ rails_app_env | default('staging') }}.log"
+      - "/opt/orangelight/current/log/sneakers.log"
     options:
       rotate: "{{ logrotate_global_defaults.rotate }}"
       maxsize: "{{ logrotate_global_defaults.maxsize }}"

--- a/roles/orangelight/defaults/main.yml
+++ b/roles/orangelight/defaults/main.yml
@@ -15,6 +15,18 @@ orangelight_logrotate_rules:
       # Optional: add postrotate script if service needs notification
       # postrotate: |
       #   systemctl reload myservice || true
+  - name: "orangelight"
+    paths:
+      - "/opt/orangelight/current/log/production.log"
+    options:
+      rotate: "{{ logrotate_global_defaults.rotate }}"
+      maxsize: "{{ logrotate_global_defaults.maxsize }}"
+      create_mode: "{{ logrotate_global_defaults.create_mode }}"
+      create_owner: "deploy"
+      create_group: "deploy"
+      su_user: "{{ logrotate_global_defaults.su_user }}"
+      su_group: "{{ logrotate_global_defaults.su_group }}"
+      copytruncate: true
 # postgres test VM settings
 postgres_port: 5432
 postgres_version: 15

--- a/roles/orangelight/handlers/main.yml
+++ b/roles/orangelight/handlers/main.yml
@@ -5,3 +5,10 @@
     daemon_reload: true
   become: true
   when: running_on_server
+
+- name: reload_logrotate
+  ansible.builtin.command: logrotate --force /etc/logrotate.conf
+  become: true
+  register: orangelight_logrotate_reload
+  changed_when: orangelight_logrotate_reload.rc == 0
+  when: running_on_server | default(true)

--- a/roles/orangelight/molecule/default/verify.yml
+++ b/roles/orangelight/molecule/default/verify.yml
@@ -46,3 +46,16 @@
         - "'/var/log/sneakers/sneakers.log' in sneakers_logrotate_config_content.content | b64decode"
         - "'daily' in sneakers_logrotate_config_content.content | b64decode"
         - "'rotate 7' in sneakers_logrotate_config_content.content | b64decode"
+
+  - name: Check if the orangelight rails logrotate file exists
+    ansible.builtin.slurp:
+      path: /etc/logrotate.d/orangelight
+    register: orangelight_logrotate_config_content
+
+  - name: Check for orangelight rails logrotate file
+    ansible.builtin.assert:
+      that:
+        - "'/opt/orangelight/current/log/production.log' in orangelight_logrotate_config_content.content | b64decode"
+        - "'daily' in orangelight_logrotate_config_content.content | b64decode"
+        - "'rotate 7' in orangelight_logrotate_config_content.content | b64decode"
+        - "'copytruncate' in orangelight_logrotate_config_content.content | b64decode"

--- a/roles/orangelight/molecule/default/verify.yml
+++ b/roles/orangelight/molecule/default/verify.yml
@@ -56,6 +56,7 @@
     ansible.builtin.assert:
       that:
         - "'/opt/orangelight/current/log/staging.log' in orangelight_logrotate_config_content.content | b64decode"
+        - "'/opt/orangelight/current/log/sneakers.log' in orangelight_logrotate_config_content.content | b64decode"
         - "'daily' in orangelight_logrotate_config_content.content | b64decode"
         - "'rotate 7' in orangelight_logrotate_config_content.content | b64decode"
         - "'copytruncate' in orangelight_logrotate_config_content.content | b64decode"

--- a/roles/orangelight/molecule/default/verify.yml
+++ b/roles/orangelight/molecule/default/verify.yml
@@ -55,7 +55,7 @@
   - name: Check for orangelight rails logrotate file
     ansible.builtin.assert:
       that:
-        - "'/opt/orangelight/current/log/production.log' in orangelight_logrotate_config_content.content | b64decode"
+        - "'/opt/orangelight/current/log/staging.log' in orangelight_logrotate_config_content.content | b64decode"
         - "'daily' in orangelight_logrotate_config_content.content | b64decode"
         - "'rotate 7' in orangelight_logrotate_config_content.content | b64decode"
         - "'copytruncate' in orangelight_logrotate_config_content.content | b64decode"

--- a/roles/orangelight/tasks/main.yml
+++ b/roles/orangelight/tasks/main.yml
@@ -83,12 +83,7 @@
   loop: "{{ orangelight_logrotate_rules }}"
   loop_control:
     label: "{{ item.name }}"
-  register: orangelight_logrotate_files
+  notify: reload_logrotate
   when:
     - orangelight_logrotate_rules is defined
     - orangelight_logrotate_rules | length > 0
-
-- name: Orangelight | reload logrotate configuration
-  ansible.builtin.command: logrotate --force /etc/logrotate.conf
-  become: true
-  when: orangelight_logrotate_files is changed

--- a/roles/orangelight/tasks/main.yml
+++ b/roles/orangelight/tasks/main.yml
@@ -73,7 +73,7 @@
     - running_on_server
     - sneakers_service_file.changed
 
-- name: Orangelight | create logrotate configuration for sneakers
+- name: Orangelight | create logrotate configurations
   ansible.builtin.template:
     src: "../../common/templates/logrotate_rules.j2"
     dest: "/etc/logrotate.d/{{ item.name }}"
@@ -81,16 +81,14 @@
     owner: root
     group: root
   loop: "{{ orangelight_logrotate_rules }}"
-  when: 
+  loop_control:
+    label: "{{ item.name }}"
+  register: orangelight_logrotate_files
+  when:
     - orangelight_logrotate_rules is defined
     - orangelight_logrotate_rules | length > 0
-
-- name: Orangelight | check if sneakers logrotate configuration has changed
-  ansible.builtin.stat:
-    path: /etc/logrotate.d/sneakers
-  register: sneakers_logrotate_file
 
 - name: Orangelight | reload logrotate configuration
   ansible.builtin.command: logrotate --force /etc/logrotate.conf
   become: true
-  when: sneakers_logrotate_file.changed
+  when: orangelight_logrotate_files is changed


### PR DESCRIPTION
The application log at /opt/orangelight/current/log/production.log was   never rotated and could grow until it filled the disk. It now rotates   daily with the same retention as our other logs, truncating in place so   the running app keeps writing without a restart. Also fixes the reload   step, which previously never detected config changes.

related #7494 