### PR TITLE
[orangelight] Remove datadog

### DIFF
--- a/group_vars/orangelight/production.yml
+++ b/group_vars/orangelight/production.yml
@@ -27,45 +27,6 @@ postgres_port: "5432"
 rails_app_env: "production"
 passenger_max_pool_size: 30
 scsb_auth_key: "{{ vault_scsb_auth_key }}"
-datadog_api_key: "{{ vault_datadog_key }}"
-datadog_config:
-  tags: "application:orangelight, environment:production, type:webserver"
-  apm_enabled: "true"
-  log_enabled: true
-  process_config:
-    enabled: "true"
-  apm_config:
-    analyzed_spans:
-      orangelight|rack.request: 1
-    filter_tags:
-      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
-datadog_typed_checks:
-  - type: process
-    configuration:
-      init_config:
-      instances:
-        - name: orangelight
-          service: orangelight
-          search_string:
-            - nginx
-  - type: nginx
-    configuration:
-      init_config:
-      instances:
-        - nginx_status_url: http://localhost:80/nginx_status/
-      logs:
-        - type: file
-          path: /var/log/nginx/access.log
-          source: nginx
-          service: orangelight
-        - type: file
-          path: /var/log/nginx/error.log
-          source: nginx
-          service: orangelight
-        - type: file
-          path: /opt/orangelight/current/log/production.log
-          source: rails
-          service: orangelight
 # beyla
 beyla_enabled: true
 beyla_service_name: orangelight

--- a/group_vars/orangelight/qa.yml
+++ b/group_vars/orangelight/qa.yml
@@ -29,36 +29,3 @@ postgres_host: "lib-postgres-qa1.princeton.edu"
 rails_app_env: "qa"
 passenger_max_pool_size: 8
 scsb_auth_key: "{{ vault_scsb_auth_key }}"
-datadog_api_key: "{{ vault_datadog_key }}"
-datadog_config:
-  tags: "application:orangelight, environment:qa, type:webserver"
-  apm_enabled: "true"
-  log_enabled: true
-  process_config:
-    enabled: "true"
-  apm_config:
-    analyzed_spans:
-      orangelight|rack.request: 1
-    filter_tags:
-      reject: ["http.useragent:nginx/1.23.4 (health check)", "operation:heartbeat", "operation:job_fetch", "operation:scheduled_push", "operation:scheduled_poller_wait"]
-datadog_checks:
-  ruby:
-    init_config:
-    logs:
-      - type: file
-        path: /opt/orangelight/current/log/qa.log
-        service: orangelight
-        source: ruby
-  nginx:
-    init_config:
-    logs:
-      - type: file
-        path: /var/log/nginx/access.log
-        service: orangelight
-        source: nginx
-        sourcecategory: http_web_access
-      - type: file
-        path: /var/log/nginx/error.log
-        service: orangelight
-        source: nginx
-        sourcecategory: http_web_access

--- a/playbooks/orangelight.yml
+++ b/playbooks/orangelight.yml
@@ -30,8 +30,6 @@
       tags: otel
     - role: beyla
       tags: otel
-    - role: datadog
-      when: runtime_env | default('staging') == "production"
 
   post_tasks:
     - name: Production webservers | Disable ufw


### PR DESCRIPTION
We are using signoz instead

I removed the agent from the boxes with the `remove_datadog` playbook and manually deleted `/opt/datadog-agent`