### PR TITLE
[Nomad] Update to 2.0.5

### DIFF
--- a/roles/pul_nomad/defaults/main.yml
+++ b/roles/pul_nomad/defaults/main.yml
@@ -4,7 +4,7 @@ tower_github_token: 'blank'
 consul_version: '2.0.2'
 consul_installed_version: 
 nomad_installed_version: 
-nomad_version: 2.0.4
+nomad_version: 2.0.5
 nomad_podman_version: 0.6.4
 nomad_architecture_map:
   amd64: amd64


### PR DESCRIPTION
Fixes a bug where new jobs that remove resources can't be placed. Before this I wasn't unable to get rid of Redis on
figgy-infrastructure-staging.