### PR TITLE
restrict autoreboot highly available hosts

### DIFF
--- a/playbooks/utils/os_updates.yml
+++ b/playbooks/utils/os_updates.yml
@@ -104,6 +104,9 @@
       when:
         - ansible_os_family == "Debian"
         - reboot_required_file.stat.exists == true
+        - "'k8s' not in inventory_hostname"
+        - "'lib-solr' not in inventory_hostname"
+        - "'lib-zk' not in inventory_hostname"
 
     - name: tell everyone on slack you ran an ansible playbook
       community.general.slack:
@@ -121,6 +124,8 @@
         - ansible_os_family == "RedHat"
         - yum_update_status.changed
         - "'ansible' in inventory_hostname"
-        - "'k8s' not in inventory_hostname"
-        - "'libserv171' not in inventory_hostname"
-        - "'recap' not in inventory_hostname"
+        - "'k8s' in inventory_hostname"
+        - "'libserv171' in inventory_hostname"
+        - "'lib-solr' in inventory_hostname"
+        - "'lib-zk' in inventory_hostname"
+        - "'recap' in inventory_hostname"


### PR DESCRIPTION
the following hosts need to have a person determine when they can reboot. this is an improvement but needs further investigation

related #7103 